### PR TITLE
fix(domains): read host via Headers.get and add dev-host slug fallback

### DIFF
--- a/src/lib/server-fn/custom-domain-loader.ts
+++ b/src/lib/server-fn/custom-domain-loader.ts
@@ -11,19 +11,13 @@ const APP_HOSTS = new Set(["localhost", "127.0.0.1"]);
 const APP_HOST_PATTERNS = [/\.vercel\.app$/];
 
 /**
- * Extract the user-facing host from request headers, preferring
- * `x-forwarded-host` (set by Vercel/proxies) over the raw `host` header
- * (which can be an internal hostname in serverless environments).
+ * Extract the user-facing host from a Headers object, preferring
+ * `x-forwarded-host` (set by Vercel/proxies) over the raw `host` header.
+ * Accepts the native Headers instance returned by TanStack Start's
+ * getRequestHeaders() — NOT a plain object.
  */
-export const getRequestHost = (headers: Record<string, string | string[] | undefined>): string => {
-  const pick = (value: string | string[] | undefined): string | undefined => {
-    if (!value) return undefined;
-    return Array.isArray(value) ? value[0] : value.split(",")[0]?.trim();
-  };
-  return (
-    pick(headers["x-forwarded-host"]) ?? pick(headers.host) ?? pick(headers[":authority"]) ?? ""
-  );
-};
+export const getRequestHost = (headers: Headers): string =>
+  headers.get("x-forwarded-host") ?? headers.get("host") ?? headers.get(":authority") ?? "";
 
 /**
  * Returns true when the Host header belongs to the app itself
@@ -75,6 +69,38 @@ export const resolveCustomDomain = async (host: string): Promise<ResolvedDomain>
   }
 
   return domain;
+};
+
+/**
+ * Dev-friendly fallback: when the request is from an app host (localhost,
+ * Vercel preview), look up the custom domain assigned to a form by slug.
+ * Lets developers preview custom-domain forms without simulating the host.
+ */
+export const resolveDomainForSlug = async (slug: string): Promise<ResolvedDomain> => {
+  const [row] = await db
+    .select({
+      id: customDomains.id,
+      organizationId: customDomains.organizationId,
+      domain: customDomains.domain,
+      siteTitle: customDomains.siteTitle,
+      faviconUrl: customDomains.faviconUrl,
+      ogImageUrl: customDomains.ogImageUrl,
+    })
+    .from(customDomains)
+    .innerJoin(forms, eq(forms.customDomainId, customDomains.id))
+    .where(
+      and(
+        eq(forms.slug, slug),
+        eq(forms.status, "published"),
+        eq(customDomains.status, "verified"),
+      ),
+    );
+
+  if (!row) {
+    throw notFound();
+  }
+
+  return row;
 };
 
 /**

--- a/src/routes/$slug.tsx
+++ b/src/routes/$slug.tsx
@@ -13,6 +13,7 @@ import {
   getRequestHost,
   isAppHost,
   resolveCustomDomain,
+  resolveDomainForSlug,
   loadFormForCustomDomain,
 } from "@/lib/server-fn/custom-domain-loader";
 import { generateThemeCss, getGoogleFontLinkUrl } from "@/lib/theme/generate-theme-css";
@@ -33,16 +34,12 @@ const resolveSystemTheme = (): "light" | "dark" => {
 const getFormByCustomDomainSlug = createServerFn({ method: "GET" })
   .inputValidator(z.object({ slug: z.string() }))
   .handler(async ({ data }) => {
-    const headers = getRequestHeaders();
-    const host = getRequestHost(headers);
-    console.log("[$slug] host=", host, "slug=", data.slug);
+    const host = getRequestHost(getRequestHeaders());
 
-    if (isAppHost(host)) {
-      throw notFound();
-    }
+    const domain = isAppHost(host)
+      ? await resolveDomainForSlug(data.slug)
+      : await resolveCustomDomain(host);
 
-    const domain = await resolveCustomDomain(host);
-    console.log("[$slug] resolved domain=", domain.id, domain.domain);
     return loadFormForCustomDomain(domain, data.slug, "slug");
   });
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,9 +12,7 @@ import { getRequestHost, isAppHost } from "@/lib/server-fn/custom-domain-loader"
 const LandingEditor = lazy(() => import("./-components/landing-editor"));
 
 const checkHostIsApp = createServerFn({ method: "GET" }).handler(() => {
-  const headers = getRequestHeaders();
-  const host = getRequestHost(headers);
-  console.log("[index] host=", host);
+  const host = getRequestHost(getRequestHeaders());
   if (!isAppHost(host)) {
     throw notFound();
   }


### PR DESCRIPTION
Two bugs were masking the custom-domain routing:

1. getRequestHeaders() returns a native Headers instance, not a plain object. Passing it through JSON.stringify returned "{}" so logs and property access showed empty headers. Switch getRequestHost() to use headers.get("x-forwarded-host") / .get("host") against the Headers API, which actually returns the populated values.

2. The $slug handler bailed with notFound() whenever isAppHost(host) was true, which blocked local (and Vercel preview) access to forms. Add resolveDomainForSlug(slug) that joins forms \u2194 customDomains by the form's customDomainId so app hosts can preview the form as the custom domain would render it; custom-domain requests keep the stricter host-scoped resolveCustomDomain(host) path.