### PR TITLE
refactor(form-file-upload): drop deprecated className prop

### DIFF
--- a/src/components/ui/form-file-upload-node.tsx
+++ b/src/components/ui/form-file-upload-node.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/lib/form-schema/file-upload-types";
 import { cn } from "@/lib/utils";
 
-export const FormFileUploadElement = ({ className, children, ...props }: PlateElementProps) => {
+export const FormFileUploadElement = ({ children, ...props }: PlateElementProps) => {
   const { attributes, element, ...rest } = props;
   const { focused, isSelected, required } = useFormInputNode(element);
 
@@ -31,7 +31,6 @@ export const FormFileUploadElement = ({ className, children, ...props }: PlateEl
       className={cn(
         "relative  flex min-h-20 w-full max-w-[464px] flex-col items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-border/60 bg-card p-4 cursor-default shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]",
         isSelected && focused && "ring-ring/50 ring-[3px]",
-        className,
       )}
       element={element}
       {...rest}


### PR DESCRIPTION
## Summary
- Drop the deprecated `className` destructure from `PlateElementProps` in `FormFileUploadElement`
- Remove its merge into the inner `<PlateElement>`'s `cn(...)` call
- Matches the precedent set in `form-button-node.tsx` and `form-label-node.tsx`

`PlateElementProps.className` is deprecated in favor of `attributes.className`. `<PlateElement>`'s own `className` prop is fine because it uses `StyledPlateElementProps` which omits `DeprecatedNodeProps`.

## Test plan
- [ ] Type-check passes (TS6385 warning gone for this file)
- [ ] File upload form element still renders with selection ring when focused