### PR TITLE
refactor(login): use top-level z.email per Zod v4

### DIFF
--- a/src/routes/login/email.tsx
+++ b/src/routes/login/email.tsx
@@ -12,7 +12,7 @@ import { guestMiddleware } from "@/lib/auth/middleware";
 import { Logo } from "@/components/ui/logo";
 
 const emailSchema = z.object({
-  email: z.string().email("Please enter a valid email address"),
+  email: z.email({ error: "Please enter a valid email address" }),
 });
 
 const SAFE_REDIRECT_PATTERN = /^\/[a-zA-Z0-9\-_/$.~]+$/;


### PR DESCRIPTION
## Summary
- Replace deprecated `z.string().email(...)` with `z.email({ error: ... })` in the login email schema.
- Silences the TS6385 deprecation warning and matches the precedent already merged in `src/lib/form-schema/generate-preview-schema.ts`.

## Test plan
- [x] Behavior-equivalent rename per Zod v4 migration; validator still produces "Please enter a valid email address" for invalid input.
- [x] No tests cover this file directly; pre-existing unrelated test failures (DATABASE_URL not set, auth-workspace hoisting) not addressed here.