### PR TITLE
refactor(form-textarea): drop deprecated className prop

### DIFF
--- a/src/components/ui/form-textarea-node.tsx
+++ b/src/components/ui/form-textarea-node.tsx
@@ -8,7 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useFormInputNode } from "@/hooks/use-form-input-node";
 import { cn } from "@/lib/utils";
 
-export const FormTextareaElement = ({ className, children, ...props }: PlateElementProps) => {
+export const FormTextareaElement = ({ children, ...props }: PlateElementProps) => {
   const { attributes, element, ...rest } = props;
   const placeholder = element.placeholder as string | undefined;
   const { focused, isSelected, required } = useFormInputNode(element);
@@ -19,7 +19,6 @@ export const FormTextareaElement = ({ className, children, ...props }: PlateElem
       className={cn(
         "relative flex min-h-24 w-full max-w-[464px] items-start rounded-[var(--radius-lg)] border-0 bg-card pl-[10px] pr-[8px] text-sm shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)] cursor-text caret-current before:top-2.5",
         isSelected && focused && "ring-ring/50 ring-[3px]",
-        className,
       )}
       element={element}
       {...rest}


### PR DESCRIPTION
## Summary
- Removes the deprecated `className` destructure from `FormTextareaElement`'s `PlateElementProps` and the corresponding trailing `cn()` argument.
- `PlateElementProps.className` is deprecated in favor of `attributes.className`. `<PlateElement>`'s own `className` prop still accepts the merged classes via `StyledPlateElementProps`, which omits `DeprecatedNodeProps`.
- Mirrors the precedent already merged in `src/components/ui/form-button-node.tsx`.

## Test plan
- [ ] Type-only deprecation cleanup; no behavior change.
- [ ] Confirm no TS6385 warning remains for this file.