### PR TITLE
refactor(page-break): drop deprecated className prop read

### DIFF
--- a/src/components/ui/page-break-node.tsx
+++ b/src/components/ui/page-break-node.tsx
@@ -91,7 +91,7 @@ export const PageBreakElement = (props: PlateElementProps) => {
   };
 
   return (
-    <PlateElement {...props} className={cn("clear-both", props.className)}>
+    <PlateElement {...props} className="clear-both">
       <div
         contentEditable={false}
         role="presentation"


### PR DESCRIPTION
## Summary
- Removes the deprecated `props.className` read inside `PageBreakElement`. Plate.js has deprecated `PlateElementProps.className` in favor of `attributes.className`, which is already passed through via `{...props}`.
- One-line change; clears a TS6385 (`@deprecated`) warning.

## Test plan
- [ ] Visual smoke test on the form editor: page break still renders the dashed-line divider with the page label and "Thank you" page toggle.
- [ ] Verify no new TS6385 warnings on `page-break-node.tsx`.