### PR TITLE
refactor(form-option-item): drop deprecated className prop

### DIFF
--- a/src/components/ui/form-option-item-node.tsx
+++ b/src/components/ui/form-option-item-node.tsx
@@ -54,7 +54,7 @@ const OptionIcon = ({ variant, index }: { variant: OptionVariant; index: number 
   }
 };
 
-export const FormOptionItemElement = ({ className, children, ...props }: PlateElementProps) => {
+export const FormOptionItemElement = ({ children, ...props }: PlateElementProps) => {
   const { attributes, element, ...rest } = props;
   const variant = (element.variant as OptionVariant) || "checkbox";
   const elementId = (element as { id?: string }).id;
@@ -148,7 +148,6 @@ export const FormOptionItemElement = ({ className, children, ...props }: PlateEl
       className={cn(
         "relative my-0.5 w-full max-w-[464px] cursor-text caret-current rounded-md before:left-[30px] before:top-[14px] before:-translate-y-1/2 before:text-sm",
         colorStyle && cn(colorStyle.bg, colorStyle.text),
-        className,
       )}
       element={element}
       {...rest}


### PR DESCRIPTION
## Summary
- Removes the deprecated `className` field destructured from `PlateElementProps` in `FormOptionItemElement`.
- Drops the now-unused `className` reference from the inner `<PlateElement className={cn(...)}>` merge.

The Plate.js `PlateElementProps.className` is deprecated in favor of `attributes.className`. `<PlateElement>`'s own `className` prop already uses `StyledPlateElementProps`, which omits `DeprecatedNodeProps`, so any caller-supplied class still flows through correctly. This silences a TS6385 (`@deprecated`) warning with no runtime change.

Same pattern as the precedent fix in `src/components/ui/form-button-node.tsx`.

## Test plan
- [ ] No runtime change expected — type-only deprecation cleanup
- [ ] Verify no `@deprecated` warning remains on `form-option-item-node.tsx`