### PR TITLE
fix(forms): smooth out perceived loading on step transitions

### DIFF
--- a/src/components/form-components/field-skeleton.tsx
+++ b/src/components/form-components/field-skeleton.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import type { FieldType } from "./fields/shared";
+
+const InputSkeleton = () => <Skeleton className="h-7 w-full max-w-[464px] rounded-[8px]" />;
+
+const TextareaSkeleton = () => <Skeleton className="h-24 w-full max-w-[464px] rounded-[8px]" />;
+
+const FileUploadSkeleton = () => <Skeleton className="h-20 w-full max-w-[464px] rounded-[8px]" />;
+
+const OptionListSkeleton = ({ withBadge = false }: { withBadge?: boolean }) => (
+  <div className="flex flex-col gap-2">
+    {[0, 1, 2].map((i) => (
+      <div className="flex items-center gap-2" key={i}>
+        <Skeleton className={withBadge ? "size-5 rounded" : "size-4 rounded-[4px]"} />
+        <Skeleton className="h-3 w-40 rounded-md" />
+      </div>
+    ))}
+  </div>
+);
+
+const FIELD_SKELETONS: Record<FieldType, React.ComponentType> = {
+  Input: InputSkeleton,
+  Textarea: TextareaSkeleton,
+  Email: InputSkeleton,
+  Phone: InputSkeleton,
+  Number: InputSkeleton,
+  Link: InputSkeleton,
+  Date: InputSkeleton,
+  Time: InputSkeleton,
+  FileUpload: FileUploadSkeleton,
+  Checkbox: OptionListSkeleton,
+  MultiChoice: () => <OptionListSkeleton withBadge />,
+  MultiSelect: InputSkeleton,
+  Ranking: () => <OptionListSkeleton withBadge />,
+};
+
+export const FieldSkeleton = ({ fieldType }: { fieldType: FieldType }) => {
+  const Component = FIELD_SKELETONS[fieldType];
+  return Component ? <Component /> : <InputSkeleton />;
+};

--- a/src/components/form-components/fields/shared.tsx
+++ b/src/components/form-components/fields/shared.tsx
@@ -25,6 +25,12 @@ export const extractErrorMessage = (error: unknown): string => {
   return "Invalid value";
 };
 
+export const getFieldLabelProps = (element: PlateFormField) => ({
+  label: "label" in element ? (element.label ?? "") : "",
+  required: "required" in element ? !!element.required : false,
+  labelType: "labelType" in element ? element.labelType : undefined,
+});
+
 export const getAriaLabelFallback = (element: PlateFormField): string | undefined => {
   const label = "label" in element ? element.label : undefined;
   if (label) return undefined;

--- a/src/components/form-components/render-step-preview-input-eager.tsx
+++ b/src/components/form-components/render-step-preview-input-eager.tsx
@@ -1,0 +1,55 @@
+import type { AppForm } from "@/hooks/use-form-builder";
+import type { PlateFormField } from "@/lib/editor/transform-plate-to-form";
+
+import CheckboxField from "./fields/CheckboxField";
+import DateField from "./fields/DateField";
+import EmailField from "./fields/EmailField";
+import FileUploadField from "./fields/FileUploadField";
+import InputField from "./fields/InputField";
+import LinkField from "./fields/LinkField";
+import MultiChoiceField from "./fields/MultiChoiceField";
+import MultiSelectField from "./fields/MultiSelectField";
+import NumberField from "./fields/NumberField";
+import PhoneField from "./fields/PhoneField";
+import RankingField from "./fields/RankingField";
+import type { FieldType } from "./fields/shared";
+import TextareaField from "./fields/TextareaField";
+import TimeField from "./fields/TimeField";
+import { PreviewInputShell } from "./render-step-preview-input";
+
+// Static-import twin of `RenderStepPreviewInput` for the form-builder preview.
+// The lazy/Suspense variant flashes empty when stepping into a chunk that
+// hasn't loaded yet; in the editor preview the auth bundle already contains
+// every field, so chunk-splitting buys us nothing and costs perceived speed.
+const FIELD_RENDERERS: Record<FieldType, React.ComponentType<{ element: never; form: AppForm }>> = {
+  Input: InputField,
+  Textarea: TextareaField,
+  Email: EmailField,
+  Phone: PhoneField,
+  Number: NumberField,
+  Link: LinkField,
+  Date: DateField,
+  Time: TimeField,
+  FileUpload: FileUploadField,
+  Checkbox: CheckboxField,
+  MultiChoice: MultiChoiceField,
+  MultiSelect: MultiSelectField,
+  Ranking: RankingField,
+} as const;
+
+export const RenderStepPreviewInputEager = ({
+  element,
+  form,
+}: {
+  element: PlateFormField;
+  form: AppForm;
+}) => {
+  if (element.fieldType === "Button") return null;
+  const Component = FIELD_RENDERERS[element.fieldType as FieldType];
+  if (!Component) return null;
+  return (
+    <PreviewInputShell element={element}>
+      <Component element={element as never} form={form} />
+    </PreviewInputShell>
+  );
+};

--- a/src/components/form-components/render-step-preview-input.tsx
+++ b/src/components/form-components/render-step-preview-input.tsx
@@ -1,9 +1,18 @@
-import { lazy, Suspense } from "react";
+import { createContext, lazy, Suspense } from "react";
 
 import type { AppForm } from "@/hooks/use-form-builder";
 import type { PlateFormField } from "@/lib/editor/transform-plate-to-form";
-import { FieldLabelText } from "./fields/shared";
+import { FieldSkeleton } from "./field-skeleton";
+import { FieldLabelText, getFieldLabelProps } from "./fields/shared";
 import type { FieldType } from "./fields/shared";
+
+// Editor preview supplies an eager (static-import) renderer here to avoid the
+// lazy-chunk flash when stepping between pages. Live form leaves it null and
+// keeps code-splitting.
+export const PreviewRendererContext = createContext<React.ComponentType<{
+  element: PlateFormField;
+  form: AppForm;
+}> | null>(null);
 
 // One chunk per field type. A form that only uses Input + Textarea pulls only
 // those two chunks — PhoneInput, DatePicker, MultiSelect, useFileUpload, etc.
@@ -32,6 +41,27 @@ interface RenderStepPreviewInputProps {
   form: AppForm;
 }
 
+export const PreviewInputShell = ({
+  element,
+  children,
+}: {
+  element: PlateFormField;
+  children: React.ReactNode;
+}) => {
+  const { label, required, labelType } = getFieldLabelProps(element);
+  return (
+    <div data-bf-input="true" data-bf-standalone={label ? undefined : "true"}>
+      <FieldLabelText
+        text={label}
+        labelType={labelType}
+        htmlFor={element.name}
+        required={required}
+      />
+      {children}
+    </div>
+  );
+};
+
 // Just the field input (lazy-loaded) with no label/wrapper. Used by the RSC
 // flow where the server-rendered composite already provides the surrounding
 // `<div data-bf-input>` + label.
@@ -40,7 +70,7 @@ export const RenderFieldComponent = ({ element, form }: RenderStepPreviewInputPr
   const Component = FIELD_RENDERERS[element.fieldType as FieldType];
   if (!Component) return null;
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<FieldSkeleton fieldType={element.fieldType as FieldType} />}>
       <Component element={element as never} form={form} />
     </Suspense>
   );
@@ -50,22 +80,11 @@ export const RenderStepPreviewInput = ({ element, form }: RenderStepPreviewInput
   if (element.fieldType === "Button") return null;
   const Component = FIELD_RENDERERS[element.fieldType as FieldType];
   if (!Component) return null;
-
-  const label = "label" in element ? (element.label ?? "") : "";
-  const required = "required" in element ? !!element.required : false;
-  const labelType = "labelType" in element ? element.labelType : undefined;
-
   return (
-    <div data-bf-input="true" data-bf-standalone={label ? undefined : "true"}>
-      <FieldLabelText
-        text={label}
-        labelType={labelType}
-        htmlFor={element.name}
-        required={required}
-      />
-      <Suspense fallback={null}>
+    <PreviewInputShell element={element}>
+      <Suspense fallback={<FieldSkeleton fieldType={element.fieldType as FieldType} />}>
         <Component element={element as never} form={form} />
       </Suspense>
-    </div>
+    </PreviewInputShell>
   );
 };

--- a/src/components/form-components/step-form.tsx
+++ b/src/components/form-components/step-form.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeftIcon, ChevronRightIcon } from "@/components/ui/icons";
-import { useMemo, useRef } from "react";
+import { useContext, useMemo, useRef } from "react";
 import { useFocusFirstField } from "@/hooks/use-focus-first-field";
 import { useMountEffect } from "@/hooks/use-mount-effect";
 import { Button } from "@/components/ui/button";
@@ -10,7 +10,7 @@ import { fireQuestionProgress } from "@/lib/analytics/track-client";
 import { getFieldsFromSegments } from "@/lib/editor/transform-plate-for-preview";
 import type { FieldSegment, PreviewSegment } from "@/lib/editor/transform-plate-for-preview";
 import { StaticContentBlock } from "./static-content-block";
-import { RenderStepPreviewInput } from "./render-step-preview-input";
+import { PreviewRendererContext, RenderStepPreviewInput } from "./render-step-preview-input";
 
 interface StepFormProps {
   stepIndex: number;
@@ -31,6 +31,7 @@ export const StepForm = ({
 }: StepFormProps) => {
   const { currentStep, totalSteps, goToPrevStep, isSubmitting, tracking } = useStepForm();
   const { t } = useTranslation();
+  const Renderer = useContext(PreviewRendererContext) ?? RenderStepPreviewInput;
   const fields = useMemo(() => getFieldsFromSegments(segments), [segments]);
   const hasAuthoredButton = useMemo(
     () => segments.some((seg) => seg.type === "field" && seg.field.fieldType === "Button"),
@@ -164,7 +165,7 @@ export const StepForm = ({
 
             return (
               <div key={field.id} className="w-full" data-bf-input>
-                <RenderStepPreviewInput element={field} form={form} />
+                <Renderer element={field} form={form} />
               </div>
             );
           }

--- a/src/components/ui/link-node-static.tsx
+++ b/src/components/ui/link-node-static.tsx
@@ -8,7 +8,7 @@ export const LinkElementStatic = (props: SlateElementProps<TLinkElement>) => (
   <SlateElement
     {...props}
     as="a"
-    className="text-primary underline decoration-primary underline-offset-4"
+    className="text-blue-600 underline decoration-blue-600 underline-offset-4 dark:text-blue-400 dark:decoration-blue-400"
     attributes={{
       ...props.attributes,
       ...getLinkAttributes(props.editor, props.element),

--- a/src/components/ui/link-node.tsx
+++ b/src/components/ui/link-node.tsx
@@ -16,7 +16,7 @@ export const LinkElement = (props: PlateElementProps<TLinkElement>) => {
       {...props}
       as="a"
       className={cn(
-        "text-primary underline decoration-primary underline-offset-4",
+        "text-blue-600 underline decoration-blue-600 underline-offset-4 dark:text-blue-400 dark:decoration-blue-400",
         suggestionData?.type === "remove" && "bg-red-100 text-red-700",
         suggestionData?.type === "insert" && "bg-emerald-100 text-emerald-700",
       )}

--- a/src/lib/server-fn/public-form-view-rsc.impl.tsx
+++ b/src/lib/server-fn/public-form-view-rsc.impl.tsx
@@ -8,6 +8,7 @@ import { EditorStatic } from "@/components/ui/editor-static";
 import { DEFAULT_ICON } from "@/lib/config/app-config";
 import { CUSTOMIZATION_AUTO_DEFAULTS } from "@/lib/theme/customization-defaults";
 import { cn, DEFAULT_ICON_NAME, isValidUrl } from "@/lib/utils";
+import { getFieldLabelProps } from "@/components/form-components/fields/shared";
 import { transformPlateForPreview } from "@/lib/editor/transform-plate-for-preview";
 import type {
   FieldSegment,
@@ -180,9 +181,7 @@ export const renderStepComponent = async (segments: PreviewSegment[]) => {
             if (field.fieldType === "Button") {
               return <Field key={item.key} fieldId={field.id} field={field} />;
             }
-            const label = "label" in field ? (field.label ?? "") : "";
-            const required = "required" in field ? !!field.required : false;
-            const labelType = "labelType" in field ? field.labelType : undefined;
+            const { label, required, labelType } = getFieldLabelProps(field);
             return (
               <div
                 key={item.key}

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
@@ -8,6 +8,8 @@ import {
   FormPreviewFromPlate,
   isHexColor,
 } from "@/components/form-components/form-preview-from-plate";
+import { RenderStepPreviewInputEager } from "@/components/form-components/render-step-preview-input-eager";
+import { PreviewRendererContext } from "@/components/form-components/render-step-preview-input";
 import { Button } from "@/components/ui/button";
 import type { EmbedType } from "@/hooks/use-editor-sidebar";
 import { useFormCustomization } from "@/hooks/use-form-customization";
@@ -83,262 +85,265 @@ export const PreviewMode = ({ formId, workspaceId }: { formId: string; workspace
   }
 
   return (
-    <div
-      className={cn(
-        hasCustomization && "bf-themed",
-        resolvedAppTheme === "dark" && "dark",
-        "w-full h-full flex flex-col transition-colors duration-300 bg-background text-foreground overflow-hidden",
-      )}
-      style={{
-        ...(hasCustomization ? themeVars : undefined),
-        viewTransitionName: "preview-content",
-      }}
-    >
-      {embedType !== "fullpage" && (
-        <div className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col scrollbar-hide">
-          <div className="flex-1 relative p-4 lg:p-0">
-            <div className="max-w-[1000px] mx-auto pt-4 px-4 lg:px-8 space-y-8">
-              <div className="flex items-center pt-2">
-                <span className="text-muted-foreground/40 font-bold text-[10px] uppercase tracking-widest">
-                  Live Preview
-                </span>
-              </div>
-
-              <div className="space-y-4 opacity-40">
-                <div className="w-20 h-4 bg-muted/50 border border-border/50 rounded-sm" />
-                <div className="flex justify-between items-end border-b border-border/30 pb-3">
-                  <div className="flex gap-4 lg:gap-6">
-                    <div className="w-8 lg:w-10 h-1.5 bg-muted/50 rounded-full" />
-                    <div className="w-8 lg:w-10 h-1.5 bg-muted/50 rounded-full" />
-                  </div>
-                  <div className="w-12 lg:w-14 h-6 bg-muted/30 border border-border/30 rounded-md" />
-                </div>
-              </div>
-
-              <div className="grid grid-cols-12 gap-4 lg:gap-8 pt-2">
-                <div className="hidden lg:block col-span-3 space-y-5 opacity-30">
-                  <div className="w-full h-6 bg-muted/40 rounded-sm" />
-                  <div className="space-y-2">
-                    <div className="w-full h-1.5 bg-muted/50 rounded-full" />
-                    <div className="w-4/5 h-1.5 bg-muted/50 rounded-full" />
-                  </div>
-                  <div className="w-full h-24 bg-muted/20 border border-dashed border-border/50 rounded-xl" />
+    <PreviewRendererContext.Provider value={RenderStepPreviewInputEager}>
+      <div
+        className={cn(
+          hasCustomization && "bf-themed",
+          resolvedAppTheme === "dark" && "dark",
+          "w-full h-full flex flex-col transition-colors duration-300 bg-background text-foreground overflow-hidden",
+        )}
+        style={{
+          ...(hasCustomization ? themeVars : undefined),
+          viewTransitionName: "preview-content",
+        }}
+      >
+        {embedType !== "fullpage" && (
+          <div className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col scrollbar-hide">
+            <div className="flex-1 relative p-4 lg:p-0">
+              <div className="max-w-[1000px] mx-auto pt-4 px-4 lg:px-8 space-y-8">
+                <div className="flex items-center pt-2">
+                  <span className="text-muted-foreground/40 font-bold text-[10px] uppercase tracking-widest">
+                    Live Preview
+                  </span>
                 </div>
 
-                <div className="col-span-12 lg:col-span-9 space-y-6">
-                  <div className="space-y-3 opacity-40">
-                    <div className="w-2/3 h-5 bg-muted/50 border border-border/50 rounded-sm" />
-                    <div className="space-y-1.5">
-                      <div className="w-full h-1.5 bg-muted/50 rounded-full" />
-                      <div className="w-full h-1.5 bg-muted/50 rounded-full" />
+                <div className="space-y-4 opacity-40">
+                  <div className="w-20 h-4 bg-muted/50 border border-border/50 rounded-sm" />
+                  <div className="flex justify-between items-end border-b border-border/30 pb-3">
+                    <div className="flex gap-4 lg:gap-6">
+                      <div className="w-8 lg:w-10 h-1.5 bg-muted/50 rounded-full" />
+                      <div className="w-8 lg:w-10 h-1.5 bg-muted/50 rounded-full" />
                     </div>
+                    <div className="w-12 lg:w-14 h-6 bg-muted/30 border border-border/30 rounded-md" />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-12 gap-4 lg:gap-8 pt-2">
+                  <div className="hidden lg:block col-span-3 space-y-5 opacity-30">
+                    <div className="w-full h-6 bg-muted/40 rounded-sm" />
+                    <div className="space-y-2">
+                      <div className="w-full h-1.5 bg-muted/50 rounded-full" />
+                      <div className="w-4/5 h-1.5 bg-muted/50 rounded-full" />
+                    </div>
+                    <div className="w-full h-24 bg-muted/20 border border-dashed border-border/50 rounded-xl" />
                   </div>
 
-                  {embedType === "standard" && (
-                    <div className="relative group/embed">
-                      <div className="absolute -top-5 right-0 text-[8px] font-bold text-muted-foreground/30 uppercase tracking-widest pointer-events-none">
-                        Embedded State
+                  <div className="col-span-12 lg:col-span-9 space-y-6">
+                    <div className="space-y-3 opacity-40">
+                      <div className="w-2/3 h-5 bg-muted/50 border border-border/50 rounded-sm" />
+                      <div className="space-y-1.5">
+                        <div className="w-full h-1.5 bg-muted/50 rounded-full" />
+                        <div className="w-full h-1.5 bg-muted/50 rounded-full" />
+                      </div>
+                    </div>
+
+                    {embedType === "standard" && (
+                      <div className="relative group/embed">
+                        <div className="absolute -top-5 right-0 text-[8px] font-bold text-muted-foreground/30 uppercase tracking-widest pointer-events-none">
+                          Embedded State
+                        </div>
+
+                        <div
+                          className={cn(
+                            "w-full transition-all duration-500 border-2 border-dashed border-border rounded-lg overflow-hidden",
+                            transparentBackground
+                              ? "bg-[repeating-conic-gradient(#e8e8e8_0%_25%,white_0%_50%)] bg-[length:12px_12px]"
+                              : "bg-background",
+                          )}
+                          style={{
+                            height: dynamicHeight ? "auto" : height,
+                          }}
+                        >
+                          <div
+                            className={cn(
+                              "w-full h-full overflow-x-hidden",
+                              !dynamicHeight &&
+                                "overflow-y-auto scrollbar-thin scrollbar-thumb-muted-foreground/20",
+                              alignLeft ? "max-w-[600px]" : "",
+                            )}
+                            style={
+                              dynamicWidth
+                                ? ({ "--bf-page-width": "100%" } as React.CSSProperties)
+                                : undefined
+                            }
+                          >
+                            <FormPreviewFromPlate
+                              content={content}
+                              title={hideTitle ? "" : (doc.title ?? undefined)}
+                              icon={showEmoji ? (doc.icon ?? undefined) : undefined}
+                              cover={doc.cover ?? undefined}
+                              onSubmit={noop}
+                              hideTitle={hideTitle}
+                              customization={customization}
+                              settings={previewSettings}
+                              formId={formId}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="space-y-2 pt-4 opacity-20">
+                      <div className="w-full h-1.5 bg-muted/50 rounded-full" />
+                      <div className="w-3/4 h-1.5 bg-muted/50 rounded-full" />
+                    </div>
+
+                    {branding && <BrandingBadge />}
+                  </div>
+                </div>
+              </div>
+
+              {embedType === "popup" && (
+                <div className="absolute inset-0 flex flex-col pointer-events-none">
+                  {darkOverlay && isPopupOpen && (
+                    <button
+                      type="button"
+                      className="absolute inset-0 bg-black/40 z-10 transition-opacity duration-300 pointer-events-auto w-full h-full border-none cursor-default"
+                      onClick={handleClosePopup}
+                      aria-label="Close preview"
+                    />
+                  )}
+
+                  {isPopupOpen && (
+                    <div
+                      className="absolute bg-background rounded-2xl shadow-[0_30px_60px_rgba(0,0,0,0.15)] border border-border overflow-hidden flex flex-col z-20 pointer-events-auto transition-[top,left,transform] duration-300 ease-out"
+                      style={{
+                        width: popupWidth,
+                        ...(popupPosition === "center"
+                          ? {
+                              top: "50%",
+                              left: `calc(50% - ${popupWidth / 2}px)`,
+                              transform: "translateY(-50%)",
+                            }
+                          : popupPosition === "bottom-left"
+                            ? { top: "100%", left: 48, transform: "translateY(calc(-100% - 48px))" }
+                            : {
+                                top: "100%",
+                                left: `calc(100% - ${popupWidth}px - 48px)`,
+                                transform: "translateY(calc(-100% - 48px))",
+                              }),
+                      }}
+                    >
+                      <div className="absolute top-4 right-4 z-30 pointer-events-auto">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 hover:bg-muted text-muted-foreground bg-background/50 backdrop-blur-sm rounded-full shadow-sm"
+                          onClick={handleClosePopup}
+                          aria-label="Close"
+                        >
+                          <XIcon className="h-4 w-4" />
+                        </Button>
                       </div>
 
                       <div
-                        className={cn(
-                          "w-full transition-all duration-500 border-2 border-dashed border-border rounded-lg overflow-hidden",
-                          transparentBackground
-                            ? "bg-[repeating-conic-gradient(#e8e8e8_0%_25%,white_0%_50%)] bg-[length:12px_12px]"
-                            : "bg-background",
-                        )}
-                        style={{
-                          height: dynamicHeight ? "auto" : height,
-                        }}
+                        className={
+                          previewSettings.presentationMode === "field-by-field"
+                            ? "overflow-hidden h-[650px]"
+                            : "overflow-y-auto overflow-x-hidden max-h-[650px]"
+                        }
                       >
-                        <div
-                          className={cn(
-                            "w-full h-full overflow-x-hidden",
-                            !dynamicHeight &&
-                              "overflow-y-auto scrollbar-thin scrollbar-thumb-muted-foreground/20",
-                            alignLeft ? "max-w-[600px]" : "",
-                          )}
-                          style={
-                            dynamicWidth
-                              ? ({ "--bf-page-width": "100%" } as React.CSSProperties)
-                              : undefined
-                          }
-                        >
-                          <FormPreviewFromPlate
-                            content={content}
-                            title={hideTitle ? "" : (doc.title ?? undefined)}
-                            icon={showEmoji ? (doc.icon ?? undefined) : undefined}
-                            cover={doc.cover ?? undefined}
-                            onSubmit={noop}
-                            hideTitle={hideTitle}
-                            customization={customization}
-                            settings={previewSettings}
-                            formId={formId}
-                          />
-                        </div>
+                        <FormPreviewFromPlate
+                          content={content}
+                          title={hideTitle ? "" : (doc.title ?? undefined)}
+                          icon={showEmoji ? (doc.icon ?? undefined) : undefined}
+                          cover={doc.cover ?? undefined}
+                          onSubmit={noop}
+                          hideTitle={hideTitle}
+                          customization={customization}
+                          settings={previewSettings}
+                          isPopup
+                          formId={formId}
+                        />
                       </div>
+
+                      {branding && (
+                        <div className="py-3 flex justify-center bg-muted/60 border-t border-border shrink-0">
+                          <div className="flex items-center gap-1.5 text-[12px] font-semibold text-muted-foreground">
+                            <span>Made with</span>
+                            <SparklesIcon className="h-3 w-3 fill-muted-foreground text-muted-foreground" />
+                            <span className="text-foreground">{APP_NAME}</span>
+                          </div>
+                        </div>
+                      )}
                     </div>
                   )}
 
-                  <div className="space-y-2 pt-4 opacity-20">
-                    <div className="w-full h-1.5 bg-muted/50 rounded-full" />
-                    <div className="w-3/4 h-1.5 bg-muted/50 rounded-full" />
-                  </div>
-
-                  {branding && <BrandingBadge />}
-                </div>
-              </div>
-            </div>
-
-            {embedType === "popup" && (
-              <div className="absolute inset-0 flex flex-col pointer-events-none">
-                {darkOverlay && isPopupOpen && (
-                  <button
-                    type="button"
-                    className="absolute inset-0 bg-black/40 z-10 transition-opacity duration-300 pointer-events-auto w-full h-full border-none cursor-default"
-                    onClick={handleClosePopup}
-                    aria-label="Close preview"
-                  />
-                )}
-
-                {isPopupOpen && (
-                  <div
-                    className="absolute bg-background rounded-2xl shadow-[0_30px_60px_rgba(0,0,0,0.15)] border border-border overflow-hidden flex flex-col z-20 pointer-events-auto transition-[top,left,transform] duration-300 ease-out"
-                    style={{
-                      width: popupWidth,
-                      ...(popupPosition === "center"
-                        ? {
-                            top: "50%",
-                            left: `calc(50% - ${popupWidth / 2}px)`,
-                            transform: "translateY(-50%)",
-                          }
-                        : popupPosition === "bottom-left"
-                          ? { top: "100%", left: 48, transform: "translateY(calc(-100% - 48px))" }
-                          : {
-                              top: "100%",
-                              left: `calc(100% - ${popupWidth}px - 48px)`,
-                              transform: "translateY(calc(-100% - 48px))",
-                            }),
-                    }}
-                  >
-                    <div className="absolute top-4 right-4 z-30 pointer-events-auto">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 hover:bg-muted text-muted-foreground bg-background/50 backdrop-blur-sm rounded-full shadow-sm"
-                        onClick={handleClosePopup}
-                        aria-label="Close"
-                      >
-                        <XIcon className="h-4 w-4" />
-                      </Button>
-                    </div>
-
-                    <div
-                      className={
-                        previewSettings.presentationMode === "field-by-field"
-                          ? "overflow-hidden h-[650px]"
-                          : "overflow-y-auto overflow-x-hidden max-h-[650px]"
+                  {!isPopupOpen && (
+                    <button
+                      type="button"
+                      onClick={handleOpenPopup}
+                      aria-label="Open form preview"
+                      className="absolute z-20 pointer-events-auto w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-[0_4px_20px_rgba(0,0,0,0.15)] flex items-center justify-center hover:scale-105 active:scale-95 transition-[inset] duration-300 ease-out cursor-pointer"
+                      style={
+                        popupPosition === "bottom-left"
+                          ? { bottom: 24, left: 24, right: "auto" }
+                          : { bottom: 24, right: "auto", left: "calc(100% - 80px)" }
                       }
                     >
-                      <FormPreviewFromPlate
-                        content={content}
-                        title={hideTitle ? "" : (doc.title ?? undefined)}
-                        icon={showEmoji ? (doc.icon ?? undefined) : undefined}
-                        cover={doc.cover ?? undefined}
-                        onSubmit={noop}
-                        hideTitle={hideTitle}
-                        customization={customization}
-                        settings={previewSettings}
-                        isPopup
-                        formId={formId}
-                      />
-                    </div>
-
-                    {branding && (
-                      <div className="py-3 flex justify-center bg-muted/60 border-t border-border shrink-0">
-                        <div className="flex items-center gap-1.5 text-[12px] font-semibold text-muted-foreground">
-                          <span>Made with</span>
-                          <SparklesIcon className="h-3 w-3 fill-muted-foreground text-muted-foreground" />
-                          <span className="text-foreground">{APP_NAME}</span>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {!isPopupOpen && (
-                  <button
-                    type="button"
-                    onClick={handleOpenPopup}
-                    aria-label="Open form preview"
-                    className="absolute z-20 pointer-events-auto w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-[0_4px_20px_rgba(0,0,0,0.15)] flex items-center justify-center hover:scale-105 active:scale-95 transition-[inset] duration-300 ease-out cursor-pointer"
-                    style={
-                      popupPosition === "bottom-left"
-                        ? { bottom: 24, left: 24, right: "auto" }
-                        : { bottom: 24, right: "auto", left: "calc(100% - 80px)" }
-                    }
-                  >
-                    {showEmoji && doc.icon && iconMap.has(doc.icon) ? (
-                      <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
-                        <use href={`${SPRITE_PATH}#${doc.icon}`} />
-                      </svg>
-                    ) : (
-                      <svg
-                        className="w-6 h-6"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-                      </svg>
-                    )}
-                  </button>
-                )}
-              </div>
-            )}
+                      {showEmoji && doc.icon && iconMap.has(doc.icon) ? (
+                        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+                          <use href={`${SPRITE_PATH}#${doc.icon}`} />
+                        </svg>
+                      ) : (
+                        <svg
+                          className="w-6 h-6"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                        </svg>
+                      )}
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        )}
 
-      {embedType === "fullpage" && (
-        <div
-          className={cn(
-            "relative flex-1 flex flex-col transition-colors duration-300 overflow-hidden",
-            transparentBackground ? "bg-transparent" : "bg-background",
-          )}
-        >
-          {/* Field-by-field mode: render the cover as a full-pane background here
-              because the form-preview's own bg-image only fills its content height. */}
-          {previewSettings.presentationMode === "field-by-field" && doc.cover && (
-            <FieldByFieldCoverBackground cover={doc.cover} />
-          )}
+        {embedType === "fullpage" && (
           <div
             className={cn(
-              "flex-1 w-full h-full min-h-0",
-              previewSettings.presentationMode !== "field-by-field" &&
-                "overflow-y-auto overflow-x-hidden",
+              "relative flex-1 flex flex-col transition-colors duration-300 overflow-hidden",
+              transparentBackground ? "bg-transparent" : "bg-background",
             )}
           >
-            <FormPreviewFromPlate
-              content={content}
-              title={hideTitle ? "" : (doc.title ?? undefined)}
-              icon={doc.icon ?? undefined}
-              cover={doc.cover ?? undefined}
-              onSubmit={noop}
-              hideTitle={hideTitle}
-              layout="editor"
-              customization={customization}
-              settings={previewSettings}
-              formId={formId}
-            />
+            {/* Field-by-field mode: render the cover as a full-pane background here
+              because the form-preview's own bg-image only fills its content height. */}
+            {previewSettings.presentationMode === "field-by-field" && doc.cover && (
+              <FieldByFieldCoverBackground cover={doc.cover} />
+            )}
+            <div
+              className={cn(
+                "flex-1 w-full h-full min-h-0",
+                previewSettings.presentationMode !== "field-by-field" &&
+                  "overflow-y-auto overflow-x-hidden",
+                previewSettings.presentationMode !== "field-by-field" && branding && "pb-16",
+              )}
+            >
+              <FormPreviewFromPlate
+                content={content}
+                title={hideTitle ? "" : (doc.title ?? undefined)}
+                icon={doc.icon ?? undefined}
+                cover={doc.cover ?? undefined}
+                onSubmit={noop}
+                hideTitle={hideTitle}
+                layout="editor"
+                customization={customization}
+                settings={previewSettings}
+                formId={formId}
+              />
+            </div>
+            {branding && <BrandingBadge />}
           </div>
-          {branding && <BrandingBadge />}
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </PreviewRendererContext.Provider>
   );
 };
 


### PR DESCRIPTION
Two parts, same root cause — each field type is `lazy()`-imported with a `<Suspense fallback={null}>`, so stepping into a page whose chunk wasn't cached briefly rendered nothing.

**Editor preview** (form-builder): the auth bundle already contains every field component, so chunk-splitting costs perceived speed without saving bytes. Forks the renderer via `PreviewRendererContext` — preview-mode supplies a static-import twin (`RenderStepPreviewInputEager`); live form keeps the lazy/Suspense version. Bundle isolation: the eager file is reachable only from the form-builder route, never from `public-form-page`.

**Live form**: replaces the empty Suspense fallback with a shape-matching `FieldSkeleton` per field type (single-line for Input/Email/Phone/Number/ Link/Date/Time/MultiSelect, taller block for Textarea/FileUpload, option rows for Checkbox/MultiChoice/Ranking). Eliminates the visual jump when a chunk arrives.

Also: pad the fullpage preview's scroll container with `pb-16` when the branding badge is on, so the submit button clears the absolute footer.

Dedupes the field-label-extraction idiom (label/required/labelType) into `getFieldLabelProps`, and dedupes the input wrapper (`<div data-bf-input>` + `FieldLabelText`) into `PreviewInputShell` shared by both renderers.