### PR TITLE
AI theme generation: plan-aware tools, daily quota, and consistent input theming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Reform is a TanStack Start (Router + Vite) + React 19 app with TanStack DB colle
 - **Check**: `bun x ultracite check`
 - **Lint**: `bun lint` (oxlint --type-aware + knip)
 - **Typecheck**: `bun typecheck`
-- **Tests**: `bun test` (Vitest)
+- **Tests**: `bun run test` (runs Vitest via the package script). Do **not** use `bun test` — that invokes Bun's built-in runner, which doesn't implement parts of the Vitest API the suite uses (`vi.stubGlobal`, `vi.unstubAllGlobals`, etc.) and silently fails those tests. To run a single file, use `bun x vitest run path/to/file.test.ts`.
 - **Dev server**: `bun dev` (or `bun dev:auto` to pick a free port)
 
 Ultracite (Oxlint + Oxfmt) enforces formatting, type safety, accessibility, security, and most code-quality rules automatically. Run `bun x ultracite fix` before committing — focus your judgement on what the linter can't check: business logic, naming, architecture, edge cases, UX.
@@ -45,6 +45,7 @@ Ultracite (Oxlint + Oxfmt) enforces formatting, type safety, accessibility, secu
 
 - Vitest. Assertions inside `it()` / `test()`. Use async/await, not done callbacks. No `.only` / `.skip` committed.
 - Match the current typed `vi.mock` signature — don't regress to older shapes.
+- Always run via `bun run test` (or `bun x vitest run <file>` for a single file). `bun test` is a different runner — it skips/fails Vitest-only APIs without warning.
 
 ## Agent skills
 

--- a/drizzle/20260430160000_ai_generation_counts/migration.sql
+++ b/drizzle/20260430160000_ai_generation_counts/migration.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "ai_generation_counts" (
+	"id" text PRIMARY KEY,
+	"organization_id" text NOT NULL,
+	"period_day" text NOT NULL,
+	"count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER TABLE "ai_generation_counts"
+	ADD CONSTRAINT "ai_generation_counts_organization_id_organization_id_fkey"
+	FOREIGN KEY ("organization_id")
+	REFERENCES "organization"("id")
+	ON DELETE CASCADE;
+
+CREATE INDEX "idx_ai_generation_counts_org_day"
+	ON "ai_generation_counts" ("organization_id", "period_day");

--- a/src/components/editor/hooks/use-form-gen-stream.ts
+++ b/src/components/editor/hooks/use-form-gen-stream.ts
@@ -8,16 +8,22 @@ import type { PlateEditor } from "platejs/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { AI_DIFF_KEY } from "@/components/editor/plugins/ai-diff-kit";
+import { toast } from "sonner";
 import { applyOp, canLiveUpdate, liveUpdateOp } from "@/lib/editor/apply-op";
 import type { AppliedOp, ApplyContext } from "@/lib/editor/apply-op";
+import { mergeThemeIntoCustomization } from "@/lib/editor/merge-theme";
+import { settingsDialogStore } from "@/hooks/use-settings-dialog";
+import { FREE_CUSTOMIZATION_KEYS } from "@/lib/server-fn/plan-helpers";
+import { AI_DAILY_LIMIT_ERROR } from "@/lib/server-fn/ai-quota.server";
 import { formGenSchema, isOpReady } from "@/lib/ai/ops-schema";
 import type { FormGenResult, Op, PartialOp, SetThemeOp } from "@/lib/ai/ops-schema";
 
-type ThemePayload = {
-  tokens: Record<string, string>;
-  font: string;
-  radius: "none" | "small" | "medium" | "large";
-};
+// Flat customization dict the server returns for theme-mode. For Pro plans
+// it carries the full `light:*`/`dark:*` token overrides plus `font`/`radius`;
+// for free plans it carries only the basic Theme keys (themeColor/baseColor/
+// font/radius/defaultMode). The client treats both the same — spread into
+// formDoc.customization.
+type ThemePayload = Record<string, string>;
 
 type UseObjectReturn = {
   object: Partial<FormGenResult> | undefined;
@@ -236,31 +242,68 @@ export const useFormGenStream = ({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(requestBody),
       });
-      if (!res.ok) throw new Error(`theme request failed: ${res.status}`);
+      if (!res.ok) {
+        // Surface the rate-limit toast with an Upgrade-to-Pro CTA — the
+        // server returns 429 with a structured body when the daily AI
+        // quota is exhausted.
+        if (res.status === 429) {
+          const body = (await res.json().catch(() => null)) as {
+            message?: string;
+            limit?: number;
+          } | null;
+          toast.error(body?.message || "Daily AI limit reached. Upgrade to Pro for unlimited.", {
+            action: {
+              label: "Upgrade to Pro",
+              onClick: () => settingsDialogStore.open("billing"),
+            },
+          });
+          throw new Error(body?.message || AI_DAILY_LIMIT_ERROR);
+        }
+        throw new Error(`theme request failed: ${res.status}`);
+      }
       const data = (await res.json()) as { theme?: ThemePayload };
       if (!data.theme) throw new Error("no theme in response");
       return data.theme;
     },
-    onSuccess: (theme) => {
-      const themeOp: Op = {
-        type: "set-theme",
-        tokens: theme.tokens,
-        font: theme.font,
-        radius: theme.radius,
-      } as Op;
-      const ctx: ApplyContext = {
-        editor,
-        initialPathRef,
-        firstOpRef,
-        editMode: false,
-        createMode: false,
-        nextInsertPathRef,
-        formId,
-        insertedCountRef,
-        thankYouEmittedRef,
-        firstContentSeenRef,
+    onSuccess: async (theme) => {
+      if (!formId) {
+        onFinish?.();
+        return;
+      }
+      // Apply the customization dict directly to the form collection. The
+      // shape is plan-aware (Pro: light:/dark: tokens + font + radius; Free:
+      // themeColor/baseColor/font/radius/defaultMode), but the merge logic
+      // is the same — spread on top of existing customization with preset
+      // marked "custom" so the editor's preset selector reflects the change.
+      const collectionsModule = await import("@/collections");
+      const localModule = await import("@/collections/local/form");
+
+      const updateDraft = (draft: { customization?: unknown; updatedAt?: string }) => {
+        const current = (draft.customization ?? {}) as Record<string, string>;
+        draft.customization = mergeThemeIntoCustomization(current, theme);
+        draft.updatedAt = new Date().toISOString();
       };
-      applyOp(themeOp, ctx);
+
+      const cloud = collectionsModule.getFormListings();
+      if (cloud.get(formId)) {
+        cloud.update(formId, updateDraft as never);
+      } else if (localModule.localFormCollection.get(formId)) {
+        localModule.localFormCollection.update(formId, updateDraft as never);
+      }
+
+      // Detect a free-tier theme response (every key is a free-plan key)
+      // and prompt the user to upgrade for full color customization. Pro
+      // responses include `light:*`/`dark:*` tokens — those skip the toast.
+      const isFreeTierResponse = Object.keys(theme).every((k) => FREE_CUSTOMIZATION_KEYS.has(k));
+      if (isFreeTierResponse) {
+        toast("Theme applied. For full per-mode color customization, upgrade to Pro.", {
+          action: {
+            label: "Upgrade to Pro",
+            onClick: () => settingsDialogStore.open("billing"),
+          },
+        });
+      }
+
       onFinish?.();
     },
     onError: (err: Error) => {
@@ -376,7 +419,20 @@ export const useFormGenStream = ({
     },
     onError: (err: Error) => {
       rollback();
-      onError?.(err.message || "Generation failed. Changes have been rolled back.");
+      // Surface daily-limit toasts for the streaming path too. The server
+      // returns 429 before streaming starts; the AI SDK passes the body
+      // text through in `err.message`. We sniff for the canonical token
+      // we set server-side rather than the brittle message text.
+      const msg = err.message ?? "";
+      if (msg.includes(AI_DAILY_LIMIT_ERROR) || msg.includes("Daily AI limit")) {
+        toast.error("Daily AI limit reached. Upgrade to Pro for unlimited generations.", {
+          action: {
+            label: "Upgrade to Pro",
+            onClick: () => settingsDialogStore.open("billing"),
+          },
+        });
+      }
+      onError?.(msg || "Generation failed. Changes have been rolled back.");
     },
   }) as unknown as UseObjectReturn;
 

--- a/src/components/form-components/fields/FileUploadField.tsx
+++ b/src/components/form-components/fields/FileUploadField.tsx
@@ -201,7 +201,7 @@ const FileUploadField = ({ element, form }: FieldRendererProps<"FileUpload">) =>
             <button
               type="button"
               className={cn(
-                "relative flex min-h-20 w-full cursor-pointer flex-col items-center justify-center rounded-[8px] border border-dashed border-border/60 bg-[var(--color-gray-50)] p-4 shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)] transition-colors hover:bg-accent/50",
+                "relative flex min-h-20 w-full cursor-pointer flex-col items-center justify-center rounded-[8px] border border-dashed border-border/60 bg-[var(--form-input-bg,var(--color-gray-50))] p-4 shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)] transition-colors hover:bg-accent/50",
                 showError && "border-destructive ring-1 ring-destructive",
               )}
               onClick={!hasFile ? openFileDialog : undefined}

--- a/src/components/form-components/fields/MultiChoiceField.tsx
+++ b/src/components/form-components/fields/MultiChoiceField.tsx
@@ -31,7 +31,7 @@ const MultiChoiceField = ({ element, form }: FieldRendererProps<"MultiChoice">) 
                       "flex size-5 shrink-0 items-center justify-center rounded text-[11px]! leading-none font-semibold",
                       isSelected
                         ? "bg-primary text-primary-foreground"
-                        : "bg-[var(--color-gray-50)] text-muted-foreground shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]",
+                        : "bg-[var(--form-input-bg,var(--color-gray-50))] text-muted-foreground shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]",
                       hasErrors && !isSelected && "ring-1 ring-destructive",
                     )}
                   >

--- a/src/components/ui/block-menu.tsx
+++ b/src/components/ui/block-menu.tsx
@@ -29,7 +29,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { useEditorTheme } from "@/contexts/editor-theme-context";
+import { useReanchorThemeProps } from "@/hooks/use-form-theme";
 import {
   FILE_SUBTYPES,
   FILE_TYPE_CATEGORY_LABELS,
@@ -189,7 +189,7 @@ const FileExtensionToggleRow = ({ category, selected, onToggle }: FileExtensionT
 export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
   const { api, editor } = useEditorPlugin(BlockMenuPlugin);
   const openId = usePluginOption(BlockMenuPlugin, "openId");
-  const { themeVars, hasCustomization } = useEditorTheme();
+  const themeReanchor = useReanchorThemeProps("w-[288px] p-1");
   const isOpen = openId === BLOCK_CONTEXT_MENU_ID;
 
   const position = usePluginOption(BlockMenuPlugin, "position");
@@ -687,8 +687,8 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
       <DropdownMenu open={isOpen} onOpenChange={handleOpenChange} modal={false}>
         <DropdownMenuContent
           anchor={virtualAnchor}
-          className={cn("w-[288px] p-1", hasCustomization && "bf-themed")}
-          style={hasCustomization ? themeVars : undefined}
+          className={themeReanchor.className}
+          style={themeReanchor.style}
           align="start"
           sideOffset={8}
         >

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -4,6 +4,7 @@ import { CalendarIcon } from "@/components/ui/icons";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 import { cn } from "@/lib/utils";
+import { useReanchorThemeProps } from "@/hooks/use-form-theme";
 
 interface DatePickerProps {
   value?: string | null;
@@ -41,6 +42,10 @@ export const DatePicker = ({
 
   const displayText = date ? format(date, "MMM d, yyyy") : placeholder;
 
+  // PopoverContent portals to document.body, which breaks CSS-var inheritance
+  // from the form's .bf-themed wrapper. Re-anchor the theme on the popup.
+  const themeReanchor = useReanchorThemeProps("w-auto p-0");
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger
@@ -49,7 +54,7 @@ export const DatePicker = ({
             type="button"
             data-empty={!date}
             className={cn(
-              "inline-flex h-[30px] w-full items-center justify-start rounded-[8px] border-0 bg-[var(--color-gray-50)] pr-1.5 pl-2.5 text-left text-sm font-normal shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]",
+              "inline-flex h-[30px] w-full items-center justify-start rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] pr-1.5 pl-2.5 text-left text-sm font-normal shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]",
               !date && "text-muted-foreground",
               className,
             )}
@@ -59,7 +64,7 @@ export const DatePicker = ({
           </button>
         }
       />
-      <PopoverContent className="w-auto p-0" align="start">
+      <PopoverContent className={themeReanchor.className} style={themeReanchor.style} align="start">
         <Calendar mode="single" selected={date} onSelect={handleDateSelect} />
       </PopoverContent>
     </Popover>

--- a/src/components/ui/form-field-node.tsx
+++ b/src/components/ui/form-field-node.tsx
@@ -61,7 +61,7 @@ export const FormFieldElement = (allProps: PlateElementProps) => {
     <PlateElement
       attributes={{ ...attributes, placeholder, "data-bf-input": "true" }}
       className={cn(
-        "relative flex h-7 w-full max-w-[464px] cursor-text items-center gap-[4px] rounded-[8px] border-0 bg-[var(--color-gray-50)] pr-[8px] pl-[10px] text-sm caret-current shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]",
+        "relative flex h-7 w-full max-w-[464px] cursor-text items-center gap-[4px] rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] pr-[8px] pl-[10px] text-sm caret-current shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]",
         isSelected && focused && "ring-[3px] ring-ring/50",
       )}
       element={element}

--- a/src/components/ui/form-file-upload-node.tsx
+++ b/src/components/ui/form-file-upload-node.tsx
@@ -29,7 +29,7 @@ export const FormFileUploadElement = ({ children, ...props }: PlateElementProps)
     <PlateElement
       attributes={{ ...attributes, "data-bf-input": "true" }}
       className={cn(
-        "relative flex min-h-20 w-full max-w-[464px] cursor-default flex-col items-center justify-center rounded-[8px] border border-dashed border-border/60 bg-[var(--color-gray-50)] p-4 shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]",
+        "relative flex min-h-20 w-full max-w-[464px] cursor-default flex-col items-center justify-center rounded-[8px] border border-dashed border-border/60 bg-[var(--form-input-bg,var(--color-gray-50))] p-4 shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]",
         isSelected && focused && "ring-[3px] ring-ring/50",
       )}
       element={element}

--- a/src/components/ui/form-multi-select-input-node.tsx
+++ b/src/components/ui/form-multi-select-input-node.tsx
@@ -181,7 +181,7 @@ export const FormMultiSelectInputElement = ({ children, ...props }: PlateElement
     <PlateElement
       attributes={{ ...attributes, "data-bf-input": "true" }}
       className={cn(
-        "relative flex min-h-7 w-full max-w-[464px] cursor-default items-center rounded-[8px] border-0 bg-[var(--color-gray-50)] px-2 py-1 text-sm shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]",
+        "relative flex min-h-7 w-full max-w-[464px] cursor-default items-center rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] px-2 py-1 text-sm shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]",
         isSelected && focused && "ring-[3px] ring-ring/50",
       )}
       element={element}

--- a/src/components/ui/form-option-item-node.tsx
+++ b/src/components/ui/form-option-item-node.tsx
@@ -25,7 +25,7 @@ const OptionIcon = ({ variant, index }: { variant: OptionVariant; index: number 
     case "multiChoice": {
       const letter = LETTER_LABELS[index % LETTER_LABELS.length];
       return (
-        <span className="flex size-5 shrink-0 items-center justify-center rounded bg-[var(--color-gray-50)] text-[11px] font-semibold text-muted-foreground shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]">
+        <span className="flex size-5 shrink-0 items-center justify-center rounded bg-[var(--form-input-bg,var(--color-gray-50))] text-[11px] font-semibold text-muted-foreground shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)]">
           {letter}
         </span>
       );

--- a/src/components/ui/form-textarea-node.tsx
+++ b/src/components/ui/form-textarea-node.tsx
@@ -16,7 +16,7 @@ export const FormTextareaElement = ({ children, ...props }: PlateElementProps) =
     <PlateElement
       attributes={{ ...attributes, placeholder, "data-bf-input": "true" }}
       className={cn(
-        "relative flex min-h-24 w-full max-w-[464px] cursor-text items-start gap-[4px] rounded-[8px] border-0 bg-[var(--color-gray-50)] pr-[8px] pl-[10px] text-sm caret-current shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)] before:top-2.5",
+        "relative flex min-h-24 w-full max-w-[464px] cursor-text items-start gap-[4px] rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] pr-[8px] pl-[10px] text-sm caret-current shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)] before:top-2.5",
         isSelected && focused && "ring-[3px] ring-ring/50",
       )}
       element={element}

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -71,7 +71,7 @@ export const MultiSelect = ({
             setOpen(false);
           }
         }}
-        className="flex min-h-[30px] w-full cursor-pointer items-center gap-1 rounded-[8px] border-0 bg-[var(--color-gray-50)] px-2 py-1 text-sm shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="flex min-h-[30px] w-full cursor-pointer items-center gap-1 rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] px-2 py-1 text-sm shadow-[0_0_1px_rgba(0,0,0,0.54),0_1px_1px_rgba(0,0,0,0.06)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <div className="flex flex-1 flex-wrap gap-1">
           {selectedOptions.length > 0 ? (

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -94,9 +94,12 @@ function InputComponent({ className, ...props }: React.ComponentProps<"input">) 
 
   return (
     <InputGroupInput
+      data-bf-input-fill
       className={cn(
-        // Right-side "input-text" piece: white surface, full border, only the
-        // right corners rounded so it butts cleanly against the country select.
+        // Right-side "input-text" piece: full border, only the right corners
+        // rounded so it butts cleanly against the country select. Surface
+        // color is bg-background by default; .bf-themed overrides via
+        // [data-bf-input-fill] so the Input token applies.
         "flex-1 rounded-l-none rounded-r-[8px] border border-border bg-background px-2.5 py-2 text-sm tracking-[0.28px] text-foreground shadow-none ring-0! outline-none! focus-visible:ring-0 aria-invalid:ring-0",
         variant === "sm" && "h-7",
         variant === "lg" && "h-9",
@@ -152,6 +155,7 @@ function CountrySelect({
             variant="ghost"
             size={variant}
             aria-label="Select country"
+            data-bf-input-fill
             className={cn(
               // Left "input-select" piece — flag + chevron in a left-rounded
               // bordered cell. Top/left/bottom borders only; right edge butts

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -767,6 +767,25 @@ export const uploadRateLimits = pgTable("upload_rate_limits", {
   count: integer("count").notNull().default(0),
 });
 
+// Tracks AI form-generate calls per org per UTC day. Read by the rate-limit
+// check in /api/ai/form-generate, written on every successful generation.
+// `id` format: `${organizationId}:${YYYY-MM-DD}` so a single upsert handles
+// the per-day bucket without a composite-PK migration.
+export const aiGenerationCounts = pgTable(
+  "ai_generation_counts",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    periodDay: text("period_day").notNull(), // YYYY-MM-DD (UTC)
+    count: integer("count").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index("idx_ai_generation_counts_org_day").on(t.organizationId, t.periodDay)],
+);
+
 export const FormZod = createSelectSchema(forms);
 export const FormVersionZod = createSelectSchema(formVersions);
 export const SubmissionZod = createSelectSchema(submissions);

--- a/src/hooks/use-form-theme.ts
+++ b/src/hooks/use-form-theme.ts
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+import type { CSSProperties } from "react";
+import { cn } from "@/lib/utils";
+import { useEditorTheme } from "@/contexts/editor-theme-context";
+import type { EditorThemeValue } from "@/contexts/editor-theme-context";
+
+type UseFormThemeContextValueArgs = {
+  themeVars: CSSProperties;
+  hasCustomization: boolean;
+  customization?: Record<string, string> | null;
+  /** Editor-only callback; preview-mode passes nothing here (read-only). */
+  updateThemeColor?: (themeColor: string) => void;
+};
+
+/**
+ * Memoizes the EditorThemeProvider value so the editor app and preview mode
+ * publish a stable context object — without this, every parent render creates
+ * a fresh object and propagates through context to every consumer.
+ */
+export const useFormThemeContextValue = ({
+  themeVars,
+  hasCustomization,
+  customization,
+  updateThemeColor,
+}: UseFormThemeContextValueArgs): EditorThemeValue =>
+  useMemo(
+    () => ({
+      themeVars,
+      hasCustomization,
+      customization,
+      updateThemeColor: hasCustomization ? updateThemeColor : undefined,
+    }),
+    [themeVars, hasCustomization, customization, updateThemeColor],
+  );
+
+/**
+ * Returns the className/style pair to slap on portaled popover/dropdown
+ * content so theme tokens reach inside the portal. Without this, content
+ * portaled to document.body loses CSS-var inheritance from `.bf-themed`.
+ *
+ * Caller spreads:
+ *   <PopoverContent className={cn(myClasses, theme.className)} style={theme.style} />
+ */
+export const useReanchorThemeProps = (
+  baseClassName?: string,
+): { className: string | undefined; style: CSSProperties | undefined } => {
+  const { themeVars, hasCustomization } = useEditorTheme();
+  return {
+    className: cn(baseClassName, hasCustomization && "bf-themed") || undefined,
+    style: hasCustomization ? themeVars : undefined,
+  };
+};

--- a/src/lib/ai/ops-schema.ts
+++ b/src/lib/ai/ops-schema.ts
@@ -70,6 +70,40 @@ export const themeTokensSchema = z.object(themeTokensShape);
 
 export const RADIUS_OPTIONS = ["none", "small", "medium", "large"] as const;
 
+// Limited set the AI may pick from on free plans — mirrors the Customize
+// sidebar's basic Theme section so the server-side gate accepts the write.
+export const FREE_THEME_COLOR_OPTIONS = [
+  "neutral",
+  "zinc",
+  "rose",
+  "blue",
+  "green",
+  "amber",
+  "orange",
+  "violet",
+  "emerald",
+  "cyan",
+  "indigo",
+  "pink",
+  "red",
+] as const;
+
+export const FREE_BASE_COLOR_OPTIONS = ["neutral", "zinc", "slate", "stone", "gray"] as const;
+
+export const FREE_DEFAULT_MODE_OPTIONS = ["light", "dark", "system"] as const;
+
+// Schema the AI emits for free plans — only keys in FREE_CUSTOMIZATION_KEYS
+// (server-side gate). No light:*/dark:* token overrides, no custom CSS, etc.
+export const freeThemeSchema = z.object({
+  themeColor: z.enum(FREE_THEME_COLOR_OPTIONS),
+  baseColor: z.enum(FREE_BASE_COLOR_OPTIONS),
+  font: z.string(),
+  radius: z.enum(RADIUS_OPTIONS),
+  defaultMode: z.enum(FREE_DEFAULT_MODE_OPTIONS),
+});
+
+export type FreeThemeArgs = z.infer<typeof freeThemeSchema>;
+
 export const setThemeOp = z.object({
   type: z.literal("set-theme"),
   // Object is optional, but if present all 30 keys must be filled — forces the

--- a/src/lib/ai/system-prompts.ts
+++ b/src/lib/ai/system-prompts.ts
@@ -147,6 +147,32 @@ RADIUS — one of "none", "small", "medium", "large" (named keys, NOT CSS values
 
 Output ONLY the JSON object with the "ops" key containing the single set-theme op. No commentary.`;
 
+export const FORM_THEME_FREE_SYSTEM_PROMPT = `You are a form THEME generator for the FREE plan. The user wants to update the visual theme of an existing form. They may have provided a reference image to extract style from.
+
+The free plan only exposes the basic Theme controls — no per-mode color overrides, no custom CSS, no layout/typography/title fine-tuning. Pick the closest match from the limited palettes below.
+
+Your job: emit ONE setFormThemeFree tool call with these five fields:
+
+1. themeColor — the accent / primary color the form will use. Pick the SINGLE closest match to the dominant brand color of the image (or the requested style). Allowed values:
+   neutral, zinc, rose, blue, green, amber, orange, violet, emerald, cyan, indigo, pink, red.
+
+2. baseColor — the neutral foundation (backgrounds, borders, muted surfaces). Pick the closest tonal family of the image's neutrals. Allowed values:
+   neutral, zinc, slate, stone, gray.
+
+3. font — Google Font family name that matches the image's typographic feel (e.g. "Inter" for modern/clean, "Poppins" for friendly, "Playfair Display" for elegant editorial, "JetBrains Mono" for technical, "Lora" for literary).
+
+4. radius — corner radius preset, picked from the image's corner sharpness. Allowed values:
+   none (sharp), small (slightly rounded), medium (moderately rounded), large (very rounded).
+
+5. defaultMode — which color mode the published form opens in. Allowed values:
+   light, dark, system.
+
+HARD CONSTRAINTS:
+- Call setFormThemeFree EXACTLY ONCE. Do not call any other tool.
+- ALL five fields are required. Never omit one.
+- Each value MUST be from its allowed list — do not invent new values, do not return hex codes.
+- If the image is monochrome / unclear, default to themeColor: "neutral", baseColor: "neutral", radius: "medium", font: "Inter", defaultMode: "system".`;
+
 export const FORM_APPEND_SYSTEM_PROMPT = `You are MODIFYING an existing form. The user has asked for a change. Emit ONLY the ops needed for that specific change — never re-emit content that already exists.
 
 HARD CONSTRAINTS:

--- a/src/lib/ai/theme-route-helpers.ts
+++ b/src/lib/ai/theme-route-helpers.ts
@@ -1,0 +1,54 @@
+import type { ServerPlan } from "@/lib/server-fn/plan-helpers";
+import { FORM_THEME_FREE_SYSTEM_PROMPT, FORM_THEME_SYSTEM_PROMPT } from "@/lib/ai/system-prompts";
+import type { FreeThemeArgs } from "@/lib/ai/ops-schema";
+
+export type ProThemeArgs = {
+  tokens: Record<string, string>;
+  font: string;
+  radius: "none" | "small" | "medium" | "large";
+};
+
+export type ThemePromptPick = {
+  prompt: string;
+  toolName: "setFormTheme" | "setFormThemeFree";
+  isPro: boolean;
+};
+
+/**
+ * Pure plan → (prompt, tool) routing for theme-mode AI requests. Pro and
+ * Business get the full-fidelity tool with 30 light:/dark: token overrides;
+ * everything else (including unknown plan strings) gets the limited
+ * free-tier tool whose output stays inside the gate-allowed customization
+ * keys. Defaulting unknown plans to free is intentional — better to gate
+ * down than up if the plan column ever holds an unexpected value.
+ */
+export const pickThemePromptForPlan = (plan: ServerPlan): ThemePromptPick => {
+  if (plan === "pro" || plan === "business") {
+    return {
+      prompt: FORM_THEME_SYSTEM_PROMPT,
+      toolName: "setFormTheme",
+      isPro: true,
+    };
+  }
+  return {
+    prompt: FORM_THEME_FREE_SYSTEM_PROMPT,
+    toolName: "setFormThemeFree",
+    isPro: false,
+  };
+};
+
+/** Flatten Pro tool args into a customization dict the client can spread. */
+export const flattenProThemeArgs = (args: ProThemeArgs): Record<string, string> => ({
+  ...args.tokens,
+  font: args.font,
+  radius: args.radius,
+});
+
+/** Flatten Free tool args into a customization dict the client can spread. */
+export const flattenFreeThemeArgs = (args: FreeThemeArgs): Record<string, string> => ({
+  themeColor: args.themeColor,
+  baseColor: args.baseColor,
+  font: args.font,
+  radius: args.radius,
+  defaultMode: args.defaultMode,
+});

--- a/src/lib/config/plan-gates.ts
+++ b/src/lib/config/plan-gates.ts
@@ -21,7 +21,7 @@ export const PLAN_GATES: Record<FeatureGate, ServerPlan> = {
   customization: "pro",
 };
 
-const PLAN_RANK: Record<ServerPlan, number> = {
+export const PLAN_RANK: Record<ServerPlan, number> = {
   free: 0,
   pro: 1,
   business: 2,
@@ -29,3 +29,26 @@ const PLAN_RANK: Record<ServerPlan, number> = {
 
 export const planUnlocks = (plan: ServerPlan, feature: FeatureGate): boolean =>
   PLAN_RANK[plan] >= PLAN_RANK[PLAN_GATES[feature]];
+
+// ─── Plan-scoped quotas ────────────────────────────────────────────────
+// Numeric limits that vary by plan (counts/durations/sizes), not boolean
+// gates. Co-located with PLAN_GATES so the team can edit both in one
+// place. `null` means "no cap".
+export type PlanQuota = {
+  /** Hard cap on AI form-generate calls per org per UTC day. */
+  aiGenerationsPerDay: number | null;
+};
+
+export const PLAN_QUOTAS: Record<ServerPlan, PlanQuota> = {
+  free: {
+    aiGenerationsPerDay: 5,
+  },
+  pro: {
+    aiGenerationsPerDay: null,
+  },
+  business: {
+    aiGenerationsPerDay: null,
+  },
+};
+
+export const aiQuotaForPlan = (plan: ServerPlan): PlanQuota => PLAN_QUOTAS[plan];

--- a/src/lib/editor/apply-op.ts
+++ b/src/lib/editor/apply-op.ts
@@ -167,21 +167,11 @@ const applySetTheme = (op: SetThemeOp, ctx: ApplyContext): AppliedOp | null => {
   void (async () => {
     const collectionsModule = await import("@/collections");
     const localModule = await import("@/collections/local/form");
+    const { mergeSetThemeOpIntoCustomization } = await import("@/lib/editor/merge-theme");
 
     const updateDraft = (draft: { customization?: unknown; updatedAt?: string }) => {
       const current = (draft.customization ?? {}) as Record<string, string>;
-      const next: Record<string, string> = {
-        ...current,
-        preset: "custom",
-      };
-      if (op.tokens) {
-        for (const [key, value] of Object.entries(op.tokens)) {
-          next[key] = value;
-        }
-      }
-      if (op.font) next.font = op.font;
-      if (op.radius) next.radius = op.radius;
-      draft.customization = next;
+      draft.customization = mergeSetThemeOpIntoCustomization(current, op);
       draft.updatedAt = new Date().toISOString();
     };
 

--- a/src/lib/editor/merge-theme.ts
+++ b/src/lib/editor/merge-theme.ts
@@ -1,0 +1,75 @@
+import type { SetThemeOp } from "@/lib/ai/ops-schema";
+import { FREE_CUSTOMIZATION_KEYS } from "@/lib/server-fn/plan-helpers";
+
+/**
+ * A theme payload is "free-tier" when every key in it is in the free-tier
+ * customization allowlist. The Pro-tier path emits `light:*` / `dark:*`
+ * token overrides — none of those are in the allowlist, so any presence of
+ * such a key flips the payload to Pro-tier.
+ */
+const isFreeTierThemePayload = (theme: Record<string, string>): boolean => {
+  for (const key of Object.keys(theme)) {
+    if (!FREE_CUSTOMIZATION_KEYS.has(key)) return false;
+  }
+  return true;
+};
+
+/**
+ * Merges a flat theme payload (returned by /api/ai/form-generate in theme
+ * mode) into an existing customization record. Used by the editor's
+ * themeMutation to build the optimistic update.
+ *
+ * Pro-plan payloads carry `light:*` / `dark:*` token overrides plus
+ * `font`/`radius`. Free-plan payloads carry only the basic keys
+ * (`themeColor`, `baseColor`, `font`, `radius`, `defaultMode`).
+ *
+ * Branching rule:
+ * - **Free-tier merge** (every key in `theme` is a free key): start from a
+ *   filtered `current` that *also* drops any non-free keys. This keeps the
+ *   final payload inside the server gate's allowlist — important for
+ *   downgraded users (whose `light:*` overrides are preserved on
+ *   downgrade) and for users whose `organization.plan` column is stale.
+ * - **Pro-tier merge** (any Pro key in `theme`): preserve `current`
+ *   verbatim. Pro users retain their existing customization.
+ *
+ * In both cases the preset is marked "custom" so the editor's preset
+ * selector reflects that the user has deviated from a built-in style.
+ */
+export const mergeThemeIntoCustomization = (
+  current: Record<string, string>,
+  theme: Record<string, string>,
+): Record<string, string> => {
+  // Empty theme = no-op. Don't flip preset to "custom" or strip any keys —
+  // the AI returned nothing actionable.
+  if (Object.keys(theme).length === 0) return current;
+  if (isFreeTierThemePayload(theme)) {
+    const filteredCurrent: Record<string, string> = {};
+    for (const [key, value] of Object.entries(current)) {
+      if (FREE_CUSTOMIZATION_KEYS.has(key)) filteredCurrent[key] = value;
+    }
+    return { ...filteredCurrent, ...theme, preset: "custom" };
+  }
+  return { ...current, ...theme, preset: "custom" };
+};
+
+/**
+ * Streaming-path variant: applies a SetThemeOp (the schema the AI emits in
+ * non-theme modes — create / append / replace) to an existing customization
+ * record. Same merge semantics as mergeThemeIntoCustomization, but unpacks
+ * the op's `tokens` / `font` / `radius` fields. Undefined fields don't
+ * overwrite — only the keys the op actually carries are merged in.
+ */
+export const mergeSetThemeOpIntoCustomization = (
+  current: Record<string, string>,
+  op: SetThemeOp,
+): Record<string, string> => {
+  const next: Record<string, string> = { ...current, preset: "custom" };
+  if (op.tokens) {
+    for (const [key, value] of Object.entries(op.tokens)) {
+      next[key] = value;
+    }
+  }
+  if (op.font) next.font = op.font;
+  if (op.radius) next.radius = op.radius;
+  return next;
+};

--- a/src/lib/server-fn/ai-quota.server.ts
+++ b/src/lib/server-fn/ai-quota.server.ts
@@ -1,0 +1,76 @@
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { aiGenerationCounts } from "@/db/schema";
+import { aiQuotaForPlan } from "@/lib/config/plan-gates";
+import type { ServerPlan } from "@/lib/server-fn/plan-helpers";
+
+// Server-emitted error code surfaced in the 429 body. Mirrored on the client
+// so toast wiring can detect quota errors without parsing message text.
+export const AI_DAILY_LIMIT_ERROR = "ai_daily_limit_exceeded";
+
+/** Stable UTC YYYY-MM-DD bucket so the limit resets at 00:00 UTC. */
+export const utcDayKey = (now: Date = new Date()): string => now.toISOString().slice(0, 10);
+
+const rowKey = (orgId: string, day: string) => `${orgId}:${day}`;
+
+/**
+ * Reads the current AI-generation count for `orgId` on the given UTC day.
+ * Returns 0 when no row exists yet. Pure read — does not increment.
+ */
+export const getAiCount = async (orgId: string, day: string = utcDayKey()): Promise<number> => {
+  const [row] = await db
+    .select({ count: aiGenerationCounts.count })
+    .from(aiGenerationCounts)
+    .where(eq(aiGenerationCounts.id, rowKey(orgId, day)));
+  return row?.count ?? 0;
+};
+
+/**
+ * Increment-or-insert the per-day counter atomically. Called after a
+ * successful AI call so failed calls don't burn quota.
+ */
+export const incrementAiCount = async (orgId: string, day: string = utcDayKey()): Promise<void> => {
+  await db
+    .insert(aiGenerationCounts)
+    .values({
+      id: rowKey(orgId, day),
+      organizationId: orgId,
+      periodDay: day,
+      count: 1,
+    })
+    .onConflictDoUpdate({
+      target: aiGenerationCounts.id,
+      set: {
+        count: sql`${aiGenerationCounts.count} + 1`,
+        updatedAt: sql`now()`,
+      },
+    });
+};
+
+export type AiQuotaCheck =
+  | { allowed: true; plan: ServerPlan; used: number; limit: number | null }
+  | {
+      allowed: false;
+      plan: ServerPlan;
+      used: number;
+      limit: number;
+      reason: "daily_limit_exceeded";
+    };
+
+/**
+ * Checks whether `orgId` may make another AI call right now. Pro/business
+ * plans (limit=null) are always allowed; free is capped per PLAN_QUOTAS.
+ */
+export const checkAiQuota = async (
+  orgId: string,
+  plan: ServerPlan,
+  day: string = utcDayKey(),
+): Promise<AiQuotaCheck> => {
+  const { aiGenerationsPerDay: limit } = aiQuotaForPlan(plan);
+  const used = await getAiCount(orgId, day);
+  if (limit === null) return { allowed: true, plan, used, limit: null };
+  if (used >= limit) {
+    return { allowed: false, plan, used, limit, reason: "daily_limit_exceeded" };
+  }
+  return { allowed: true, plan, used, limit };
+};

--- a/src/lib/server-fn/billing.ts
+++ b/src/lib/server-fn/billing.ts
@@ -1,0 +1,49 @@
+import { createServerFn } from "@tanstack/react-start";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/db";
+import { member } from "@/db/schema";
+import { authMiddleware } from "@/lib/auth/middleware";
+
+/**
+ * Opens Polar's hosted customer portal for an organization-scoped customer.
+ *
+ * The Better Auth `authClient.customer.portal()` looks up the Polar customer
+ * by `externalId = user.id`, but our subscriptions are purchased with
+ * `referenceId: orgId` so the customer in Polar is keyed by **org** id.
+ * We bypass the adapter and create a customer session directly via the SDK.
+ */
+export const openOrgBillingPortal = createServerFn({ method: "POST" })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ orgId: z.string() }))
+  .handler(async ({ data, context }) => {
+    const [membership] = await db
+      .select()
+      .from(member)
+      .where(
+        and(eq(member.userId, context.session.user.id), eq(member.organizationId, data.orgId)),
+      );
+
+    if (!membership) {
+      throw new Error("Not authorized to manage billing for this organization");
+    }
+
+    const { polarClient } = await import("@/lib/auth/auth");
+    const email = context.session.user.email;
+
+    // The Polar customer for this org's subscription has no `externalId` set
+    // (the @polar-sh/better-auth checkout flow created it with email only,
+    // and `referenceId` lives on the subscription's metadata, not the customer).
+    // Look up the customer by email, then mint a session with `customerId`.
+    const list = await polarClient.customers.list({ email, limit: 1 });
+    const customer = list.result.items[0];
+    if (!customer) {
+      throw new Error("No Polar customer found for this account");
+    }
+
+    const session = await polarClient.customerSessions.create({
+      customerId: customer.id,
+    });
+
+    return { url: session.customerPortalUrl };
+  });

--- a/src/lib/server-fn/plan-helpers.server.ts
+++ b/src/lib/server-fn/plan-helpers.server.ts
@@ -1,6 +1,9 @@
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { organization } from "@/db/schema";
+import { planForProductId } from "@/lib/config/plan-config";
+import type { Plan } from "@/lib/config/plan-config";
+import { logger } from "@/lib/utils";
 import { isServerPlan } from "./plan-helpers";
 import type { ServerPlan } from "./plan-helpers";
 
@@ -11,5 +14,82 @@ export const getOrgPlan = async (orgId: string): Promise<ServerPlan> => {
     .select({ plan: organization.plan })
     .from(organization)
     .where(eq(organization.id, orgId));
-  return isServerPlan(row?.plan) ? row.plan : "free";
+  const resolved: ServerPlan = isServerPlan(row?.plan) ? row.plan : "free";
+  logger("[getOrgPlan]", {
+    orgId,
+    rawColumnValue: row?.plan ?? null,
+    rowFound: Boolean(row),
+    returns: resolved,
+  });
+  return resolved;
+};
+
+/**
+ * Plan resolver with self-heal: reads `organization.plan` first; if it says
+ * "free" (which can be stale when a Polar upgrade webhook didn't reach this
+ * env), falls back to verifying with Polar using the caller's email. If
+ * Polar shows an active paid subscription for this org, writes it back to
+ * the DB and returns the corrected plan. The fast path (no email passed,
+ * or column already paid) skips the Polar round-trip entirely.
+ */
+export const getOrgPlanWithPolarSync = async (
+  orgId: string,
+  userEmail: string | null,
+): Promise<ServerPlan> => {
+  const cached = await getOrgPlan(orgId);
+  if (cached !== "free") return cached;
+  if (!userEmail) return cached;
+
+  try {
+    const { polarClient } = await import("@/lib/auth/auth");
+
+    // Polar customers are keyed by email in this project (see
+    // openOrgBillingPortal). The user's active subs across all their
+    // customers — we filter to ones whose metadata.referenceId matches
+    // this org.
+    const customerList = await polarClient.customers.list({ email: userEmail, limit: 5 });
+    const customers = customerList.result.items;
+    if (customers.length === 0) {
+      logger("[getOrgPlanWithPolarSync] no Polar customer for email", { orgId, userEmail });
+      return cached;
+    }
+
+    const subLists = await Promise.all(
+      customers.map((c) => polarClient.subscriptions.list({ customerId: c.id, active: true })),
+    );
+
+    let detected: Plan = "free";
+    for (const subs of subLists) {
+      for (const sub of subs.result.items) {
+        const metaRef = (sub.metadata as { referenceId?: unknown } | null)?.referenceId;
+        if (metaRef !== orgId) continue;
+        const plan = planForProductId(sub.productId);
+        if (plan === "business") {
+          detected = "business";
+          break;
+        }
+        if (plan === "pro" && detected === "free") detected = "pro";
+      }
+      if (detected === "business") break;
+    }
+
+    if (detected === "free") {
+      logger("[getOrgPlanWithPolarSync] Polar also reports free", { orgId });
+      return cached;
+    }
+
+    logger("[getOrgPlanWithPolarSync] DRIFT detected — writing back", {
+      orgId,
+      cachedColumn: cached,
+      polarReports: detected,
+    });
+    await db.update(organization).set({ plan: detected }).where(eq(organization.id, orgId));
+    return detected;
+  } catch (e) {
+    logger(
+      "[getOrgPlanWithPolarSync] Polar verify failed — keeping cached value",
+      e instanceof Error ? e.message : String(e),
+    );
+    return cached;
+  }
 };

--- a/src/lib/server-fn/plan-helpers.ts
+++ b/src/lib/server-fn/plan-helpers.ts
@@ -13,6 +13,27 @@ export type FormProSettingsInput = {
   customization?: Record<string, unknown> | null;
 };
 
+// Customization keys available to every plan (basic Theme controls in the
+// editor's Customize sidebar). Anything outside this set — light:/dark:
+// per-mode color overrides, layout numbers, typography, custom CSS — is
+// Pro-only and triggers the customization gate.
+export const FREE_CUSTOMIZATION_KEYS: ReadonlySet<string> = new Set([
+  "preset",
+  "themeColor",
+  "baseColor",
+  "font",
+  "radius",
+  "defaultMode",
+]);
+
+const customizationRequiresPro = (value: unknown): boolean => {
+  if (value == null || typeof value !== "object") return false;
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    if (!FREE_CUSTOMIZATION_KEYS.has(key)) return true;
+  }
+  return false;
+};
+
 // Maps each FormProSettingsInput field to the FeatureGate it triggers, with
 // the predicate that decides when the field is "on" (gating-eligible).
 const FORM_INPUT_GATES: ReadonlyArray<{
@@ -31,7 +52,7 @@ const FORM_INPUT_GATES: ReadonlyArray<{
   {
     field: "customization",
     gate: "customization",
-    isActive: (v) => v != null && Object.keys(v as Record<string, unknown>).length > 0,
+    isActive: customizationRequiresPro,
   },
 ];
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -38,6 +38,7 @@ export const logger = createIsomorphicFn()
     }
   })
   .server((...args: unknown[]) => {
+    if (process.env.NODE_ENV === "production") return;
     console.log("[Server Log] :", ...args);
   });
 

--- a/src/routes/_authenticated/-components/settings/billing-content.tsx
+++ b/src/routes/_authenticated/-components/settings/billing-content.tsx
@@ -1,12 +1,30 @@
-import { useQuery } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { auth, authClient } from "@/lib/auth/auth-client";
+import { authClient } from "@/lib/auth/auth-client";
 import { useLoaderData } from "@tanstack/react-router";
 import { Loader2Icon } from "@/components/ui/icons";
 import { useUserPlan } from "@/hooks/use-user-plan";
+import { openOrgBillingPortal } from "@/lib/server-fn/billing";
+import { PLAN_RANK } from "@/lib/config/plan-gates";
+import type { Plan } from "@/lib/config/plan-config";
+
+type TierAction = "Current" | "Upgrade" | "Downgrade";
+type ButtonVariant = "default" | "outline" | "ghost";
+
+const tierActionLabel = (currentPlan: Plan, tier: Plan): TierAction => {
+  if (currentPlan === tier) return "Current";
+  return PLAN_RANK[tier] > PLAN_RANK[currentPlan] ? "Upgrade" : "Downgrade";
+};
+
+// Visual weight follows action: Upgrade is the CTA (filled), Downgrade is
+// a soft secondary (ghost), Current is shown as a disabled outline marker.
+const tierActionVariant = (action: TierAction): ButtonVariant => {
+  if (action === "Upgrade") return "default";
+  if (action === "Current") return "outline";
+  return "ghost";
+};
 
 export const BillingContent = () => {
   const { activeOrg } = useLoaderData({ from: "/_authenticated" });
@@ -16,12 +34,40 @@ export const BillingContent = () => {
     isBusiness: isBusinessPlan,
     isFree: isFreePlan,
     isLoading,
+    plan: currentPlan,
   } = useUserPlan(activeOrg?.id);
+
+  const freeLabel = tierActionLabel(currentPlan, "free");
+  const proLabel = tierActionLabel(currentPlan, "pro");
+  const businessLabel = tierActionLabel(currentPlan, "business");
+  const freeVariant = tierActionVariant(freeLabel);
+  const proVariant = tierActionVariant(proLabel);
+  const businessVariant = tierActionVariant(businessLabel);
+
+  const handleOpenPortal = useCallback(async () => {
+    if (!activeOrg) {
+      toast.error("Please select an organization first");
+      return;
+    }
+    try {
+      const { url } = await openOrgBillingPortal({ data: { orgId: activeOrg.id } });
+      window.location.href = url;
+    } catch (error: unknown) {
+      toast.error((error as Error).message || "Failed to open billing portal");
+    }
+  }, [activeOrg]);
 
   const handleUpgrade = useCallback(
     async (planSlug: string) => {
       if (!activeOrg) {
         toast.error("Please select an organization first");
+        return;
+      }
+      // Polar's checkout creates a *new* subscription and rejects customers
+      // who already have an active one. Route existing paid customers through
+      // the customer portal, which supports plan switching with proration.
+      if (!isFreePlan) {
+        await handleOpenPortal();
         return;
       }
       try {
@@ -39,19 +85,9 @@ export const BillingContent = () => {
         toast.error((error as Error).message || "Failed to initiate checkout");
       }
     },
-    [activeOrg],
+    [activeOrg, isFreePlan, handleOpenPortal],
   );
 
-  const { data: portalData, refetch: openPortal } = useQuery({
-    ...auth.customer.portal.queryOptions(),
-    enabled: false,
-  });
-
-  if ((portalData as { url?: string })?.url) {
-    window.location.href = (portalData as { url: string }).url;
-  }
-
-  const handleOpenPortal = useCallback(() => openPortal(), [openPortal]);
   const handleUpgradePro = useCallback(() => handleUpgrade("Pro"), [handleUpgrade]);
   const handleUpgradeBusiness = useCallback(() => handleUpgrade("Business"), [handleUpgrade]);
 
@@ -93,11 +129,12 @@ export const BillingContent = () => {
             </ul>
             <Button
               className="w-full"
-              variant={isFreePlan ? "outline" : "ghost"}
+              variant={freeVariant}
               size="sm"
+              onClick={isFreePlan ? undefined : handleOpenPortal}
               disabled={isFreePlan}
             >
-              {isFreePlan ? "Current" : "Downgrade"}
+              {freeLabel}
             </Button>
           </CardContent>
         </Card>
@@ -116,12 +153,12 @@ export const BillingContent = () => {
             </ul>
             <Button
               className="w-full"
-              variant={isProPlan ? "outline" : "default"}
+              variant={proVariant}
               size="sm"
               onClick={handleUpgradePro}
               disabled={isProPlan}
             >
-              {isProPlan ? "Current" : "Upgrade"}
+              {proLabel}
             </Button>
           </CardContent>
         </Card>
@@ -140,12 +177,12 @@ export const BillingContent = () => {
             </ul>
             <Button
               className="w-full"
-              variant={isBusinessPlan ? "outline" : "default"}
+              variant={businessVariant}
               size="sm"
               onClick={handleUpgradeBusiness}
               disabled={isBusinessPlan}
             >
-              {isBusinessPlan ? "Current" : "Upgrade"}
+              {businessLabel}
             </Button>
           </CardContent>
         </Card>

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/editor-app.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/editor-app.tsx
@@ -10,6 +10,7 @@ import { EditorThemeProvider } from "@/contexts/editor-theme-context";
 import { getFormListings } from "@/collections";
 import type { Form } from "@/collections";
 import { useFormCustomization } from "@/hooks/use-form-customization";
+import { useFormThemeContextValue } from "@/hooks/use-form-theme";
 import { useForm } from "@/hooks/use-live-hooks";
 import { useResolvedTheme } from "@/components/theme-provider";
 import { cn } from "@/lib/utils";
@@ -272,15 +273,12 @@ const EditorAppInner = ({
     [formId],
   );
 
-  const themeCtx = useMemo(
-    () => ({
-      themeVars,
-      hasCustomization: Boolean(hasCustomization),
-      customization,
-      updateThemeColor: hasCustomization ? updateThemeColor : undefined,
-    }),
-    [themeVars, hasCustomization, customization, updateThemeColor],
-  );
+  const themeCtx = useFormThemeContextValue({
+    themeVars,
+    hasCustomization,
+    customization,
+    updateThemeColor,
+  });
 
   return (
     <EditorThemeProvider value={themeCtx}>

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
@@ -13,8 +13,10 @@ import { PreviewRendererContext } from "@/components/form-components/render-step
 import { Button } from "@/components/ui/button";
 import type { EmbedType } from "@/hooks/use-editor-sidebar";
 import { useFormCustomization } from "@/hooks/use-form-customization";
+import { useFormThemeContextValue } from "@/hooks/use-form-theme";
 import { useForm } from "@/hooks/use-live-hooks";
 import { useResolvedTheme } from "@/components/theme-provider";
+import { EditorThemeProvider } from "@/contexts/editor-theme-context";
 import { cn, isValidUrl } from "@/lib/utils";
 import { buildPublicFormSettings } from "@/types/form-settings";
 import type { PublicFormSettings } from "@/types/form-settings";
@@ -65,6 +67,11 @@ export const PreviewMode = ({ formId, workspaceId }: { formId: string; workspace
     if (embedType === "popup") setIsPopupOpen(true);
   }
 
+  // Portaled popovers (date picker, etc.) lose CSS-var inheritance. Publish
+  // themeVars/hasCustomization via EditorThemeProvider so portaled content
+  // can re-anchor the theme. Hook must run before any early returns.
+  const themeCtxValue = useFormThemeContextValue({ themeVars, hasCustomization, customization });
+
   if (!isLoading && savedDocs !== undefined && savedDocs.length === 0) {
     return (
       <div className="flex h-full w-full items-center justify-center">
@@ -86,265 +93,271 @@ export const PreviewMode = ({ formId, workspaceId }: { formId: string; workspace
   }
 
   return (
-    <PreviewRendererContext.Provider value={RenderStepPreviewInputEager}>
-      <div
-        className={cn(
-          hasCustomization && "bf-themed",
-          resolvedAppTheme === "dark" && "dark",
-          "flex h-full w-full flex-col overflow-hidden bg-background text-foreground transition-colors duration-300",
-        )}
-        style={{
-          ...(hasCustomization ? themeVars : undefined),
-          viewTransitionName: "preview-content",
-        }}
-      >
-        {embedType !== "fullpage" && (
-          <div className="scrollbar-hide flex flex-1 flex-col overflow-x-hidden overflow-y-auto">
-            <div className="relative flex-1 p-4 lg:p-0">
-              <div className="mx-auto max-w-[1000px] space-y-8 px-4 pt-4 lg:px-8">
-                <div className="flex items-center pt-2">
-                  <span className="text-[10px] font-bold tracking-widest text-muted-foreground/40 uppercase">
-                    Live Preview
-                  </span>
-                </div>
-
-                <div className="space-y-4 opacity-40">
-                  <div className="h-4 w-20 rounded-sm border border-border/50 bg-muted/50" />
-                  <div className="flex items-end justify-between border-b border-border/30 pb-3">
-                    <div className="flex gap-4 lg:gap-6">
-                      <div className="h-1.5 w-8 rounded-full bg-muted/50 lg:w-10" />
-                      <div className="h-1.5 w-8 rounded-full bg-muted/50 lg:w-10" />
-                    </div>
-                    <div className="h-6 w-12 rounded-md border border-border/30 bg-muted/30 lg:w-14" />
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-12 gap-4 pt-2 lg:gap-8">
-                  <div className="col-span-3 hidden space-y-5 opacity-30 lg:block">
-                    <div className="h-6 w-full rounded-sm bg-muted/40" />
-                    <div className="space-y-2">
-                      <div className="h-1.5 w-full rounded-full bg-muted/50" />
-                      <div className="h-1.5 w-4/5 rounded-full bg-muted/50" />
-                    </div>
-                    <div className="h-24 w-full rounded-xl border border-dashed border-border/50 bg-muted/20" />
+    <EditorThemeProvider value={themeCtxValue}>
+      <PreviewRendererContext.Provider value={RenderStepPreviewInputEager}>
+        <div
+          className={cn(
+            hasCustomization && "bf-themed",
+            resolvedAppTheme === "dark" && "dark",
+            "flex h-full w-full flex-col overflow-hidden bg-background text-foreground transition-colors duration-300",
+          )}
+          style={{
+            ...(hasCustomization ? themeVars : undefined),
+            viewTransitionName: "preview-content",
+          }}
+        >
+          {embedType !== "fullpage" && (
+            <div className="scrollbar-hide flex flex-1 flex-col overflow-x-hidden overflow-y-auto">
+              <div className="relative flex-1 p-4 lg:p-0">
+                <div className="mx-auto max-w-[1000px] space-y-8 px-4 pt-4 lg:px-8">
+                  <div className="flex items-center pt-2">
+                    <span className="text-[10px] font-bold tracking-widest text-muted-foreground/40 uppercase">
+                      Live Preview
+                    </span>
                   </div>
 
-                  <div className="col-span-12 space-y-6 lg:col-span-9">
-                    <div className="space-y-3 opacity-40">
-                      <div className="h-5 w-2/3 rounded-sm border border-border/50 bg-muted/50" />
-                      <div className="space-y-1.5">
-                        <div className="h-1.5 w-full rounded-full bg-muted/50" />
-                        <div className="h-1.5 w-full rounded-full bg-muted/50" />
+                  <div className="space-y-4 opacity-40">
+                    <div className="h-4 w-20 rounded-sm border border-border/50 bg-muted/50" />
+                    <div className="flex items-end justify-between border-b border-border/30 pb-3">
+                      <div className="flex gap-4 lg:gap-6">
+                        <div className="h-1.5 w-8 rounded-full bg-muted/50 lg:w-10" />
+                        <div className="h-1.5 w-8 rounded-full bg-muted/50 lg:w-10" />
                       </div>
+                      <div className="h-6 w-12 rounded-md border border-border/30 bg-muted/30 lg:w-14" />
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-12 gap-4 pt-2 lg:gap-8">
+                    <div className="col-span-3 hidden space-y-5 opacity-30 lg:block">
+                      <div className="h-6 w-full rounded-sm bg-muted/40" />
+                      <div className="space-y-2">
+                        <div className="h-1.5 w-full rounded-full bg-muted/50" />
+                        <div className="h-1.5 w-4/5 rounded-full bg-muted/50" />
+                      </div>
+                      <div className="h-24 w-full rounded-xl border border-dashed border-border/50 bg-muted/20" />
                     </div>
 
-                    {embedType === "standard" && (
-                      <div className="group/embed relative">
-                        <div className="pointer-events-none absolute -top-5 right-0 text-[8px] font-bold tracking-widest text-muted-foreground/30 uppercase">
-                          Embedded State
+                    <div className="col-span-12 space-y-6 lg:col-span-9">
+                      <div className="space-y-3 opacity-40">
+                        <div className="h-5 w-2/3 rounded-sm border border-border/50 bg-muted/50" />
+                        <div className="space-y-1.5">
+                          <div className="h-1.5 w-full rounded-full bg-muted/50" />
+                          <div className="h-1.5 w-full rounded-full bg-muted/50" />
+                        </div>
+                      </div>
+
+                      {embedType === "standard" && (
+                        <div className="group/embed relative">
+                          <div className="pointer-events-none absolute -top-5 right-0 text-[8px] font-bold tracking-widest text-muted-foreground/30 uppercase">
+                            Embedded State
+                          </div>
+
+                          <div
+                            className={cn(
+                              "w-full overflow-hidden rounded-lg border-2 border-dashed border-border transition-all duration-500",
+                              transparentBackground
+                                ? "bg-[repeating-conic-gradient(#e8e8e8_0%_25%,white_0%_50%)] bg-[length:12px_12px]"
+                                : "bg-background",
+                            )}
+                            style={{
+                              height: dynamicHeight ? "auto" : height,
+                            }}
+                          >
+                            <div
+                              className={cn(
+                                "h-full w-full overflow-x-hidden",
+                                !dynamicHeight &&
+                                  "scrollbar-thin scrollbar-thumb-muted-foreground/20 overflow-y-auto",
+                                alignLeft ? "max-w-[600px]" : "",
+                              )}
+                              style={
+                                dynamicWidth
+                                  ? ({ "--bf-page-width": "100%" } as React.CSSProperties)
+                                  : undefined
+                              }
+                            >
+                              <FormPreviewFromPlate
+                                content={content}
+                                title={hideTitle ? "" : (doc.title ?? undefined)}
+                                icon={showEmoji ? (doc.icon ?? undefined) : undefined}
+                                cover={doc.cover ?? undefined}
+                                onSubmit={noop}
+                                hideTitle={hideTitle}
+                                customization={customization}
+                                settings={previewSettings}
+                                formId={formId}
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      )}
+
+                      <div className="space-y-2 pt-4 opacity-20">
+                        <div className="h-1.5 w-full rounded-full bg-muted/50" />
+                        <div className="h-1.5 w-3/4 rounded-full bg-muted/50" />
+                      </div>
+
+                      {branding && <BrandingBadge />}
+                    </div>
+                  </div>
+                </div>
+
+                {embedType === "popup" && (
+                  <div className="pointer-events-none absolute inset-0 flex flex-col">
+                    {darkOverlay && isPopupOpen && (
+                      <button
+                        type="button"
+                        className="pointer-events-auto absolute inset-0 z-10 h-full w-full cursor-default border-none bg-black/40 transition-opacity duration-300"
+                        onClick={handleClosePopup}
+                        aria-label="Close preview"
+                      />
+                    )}
+
+                    {isPopupOpen && (
+                      <div
+                        className="pointer-events-auto absolute z-20 flex flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-[0_30px_60px_rgba(0,0,0,0.15)] transition-[top,left,transform] duration-300 ease-out"
+                        style={{
+                          width: popupWidth,
+                          ...(popupPosition === "center"
+                            ? {
+                                top: "50%",
+                                left: `calc(50% - ${popupWidth / 2}px)`,
+                                transform: "translateY(-50%)",
+                              }
+                            : popupPosition === "bottom-left"
+                              ? {
+                                  top: "100%",
+                                  left: 48,
+                                  transform: "translateY(calc(-100% - 48px))",
+                                }
+                              : {
+                                  top: "100%",
+                                  left: `calc(100% - ${popupWidth}px - 48px)`,
+                                  transform: "translateY(calc(-100% - 48px))",
+                                }),
+                        }}
+                      >
+                        <div className="pointer-events-auto absolute top-4 right-4 z-30">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 rounded-full bg-background/50 text-muted-foreground shadow-sm backdrop-blur-sm hover:bg-muted"
+                            onClick={handleClosePopup}
+                            aria-label="Close"
+                          >
+                            <XIcon className="h-4 w-4" />
+                          </Button>
                         </div>
 
                         <div
-                          className={cn(
-                            "w-full overflow-hidden rounded-lg border-2 border-dashed border-border transition-all duration-500",
-                            transparentBackground
-                              ? "bg-[repeating-conic-gradient(#e8e8e8_0%_25%,white_0%_50%)] bg-[length:12px_12px]"
-                              : "bg-background",
-                          )}
-                          style={{
-                            height: dynamicHeight ? "auto" : height,
-                          }}
+                          className={
+                            previewSettings.presentationMode === "field-by-field"
+                              ? "h-[650px] overflow-hidden"
+                              : "max-h-[650px] overflow-x-hidden overflow-y-auto"
+                          }
                         >
-                          <div
-                            className={cn(
-                              "h-full w-full overflow-x-hidden",
-                              !dynamicHeight &&
-                                "scrollbar-thin scrollbar-thumb-muted-foreground/20 overflow-y-auto",
-                              alignLeft ? "max-w-[600px]" : "",
-                            )}
-                            style={
-                              dynamicWidth
-                                ? ({ "--bf-page-width": "100%" } as React.CSSProperties)
-                                : undefined
-                            }
-                          >
-                            <FormPreviewFromPlate
-                              content={content}
-                              title={hideTitle ? "" : (doc.title ?? undefined)}
-                              icon={showEmoji ? (doc.icon ?? undefined) : undefined}
-                              cover={doc.cover ?? undefined}
-                              onSubmit={noop}
-                              hideTitle={hideTitle}
-                              customization={customization}
-                              settings={previewSettings}
-                              formId={formId}
-                            />
-                          </div>
+                          <FormPreviewFromPlate
+                            content={content}
+                            title={hideTitle ? "" : (doc.title ?? undefined)}
+                            icon={showEmoji ? (doc.icon ?? undefined) : undefined}
+                            cover={doc.cover ?? undefined}
+                            onSubmit={noop}
+                            hideTitle={hideTitle}
+                            customization={customization}
+                            settings={previewSettings}
+                            isPopup
+                            formId={formId}
+                          />
                         </div>
+
+                        {branding && (
+                          <div className="flex shrink-0 justify-center border-t border-border bg-muted/60 py-3">
+                            <div className="flex items-center gap-1.5 text-[12px] font-semibold text-muted-foreground">
+                              <span>Made with</span>
+                              <SparklesIcon className="h-3 w-3 fill-muted-foreground text-muted-foreground" />
+                              <span className="text-foreground">{APP_NAME}</span>
+                            </div>
+                          </div>
+                        )}
                       </div>
                     )}
 
-                    <div className="space-y-2 pt-4 opacity-20">
-                      <div className="h-1.5 w-full rounded-full bg-muted/50" />
-                      <div className="h-1.5 w-3/4 rounded-full bg-muted/50" />
-                    </div>
-
-                    {branding && <BrandingBadge />}
-                  </div>
-                </div>
-              </div>
-
-              {embedType === "popup" && (
-                <div className="pointer-events-none absolute inset-0 flex flex-col">
-                  {darkOverlay && isPopupOpen && (
-                    <button
-                      type="button"
-                      className="pointer-events-auto absolute inset-0 z-10 h-full w-full cursor-default border-none bg-black/40 transition-opacity duration-300"
-                      onClick={handleClosePopup}
-                      aria-label="Close preview"
-                    />
-                  )}
-
-                  {isPopupOpen && (
-                    <div
-                      className="pointer-events-auto absolute z-20 flex flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-[0_30px_60px_rgba(0,0,0,0.15)] transition-[top,left,transform] duration-300 ease-out"
-                      style={{
-                        width: popupWidth,
-                        ...(popupPosition === "center"
-                          ? {
-                              top: "50%",
-                              left: `calc(50% - ${popupWidth / 2}px)`,
-                              transform: "translateY(-50%)",
-                            }
-                          : popupPosition === "bottom-left"
-                            ? { top: "100%", left: 48, transform: "translateY(calc(-100% - 48px))" }
-                            : {
-                                top: "100%",
-                                left: `calc(100% - ${popupWidth}px - 48px)`,
-                                transform: "translateY(calc(-100% - 48px))",
-                              }),
-                      }}
-                    >
-                      <div className="pointer-events-auto absolute top-4 right-4 z-30">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-8 w-8 rounded-full bg-background/50 text-muted-foreground shadow-sm backdrop-blur-sm hover:bg-muted"
-                          onClick={handleClosePopup}
-                          aria-label="Close"
-                        >
-                          <XIcon className="h-4 w-4" />
-                        </Button>
-                      </div>
-
-                      <div
-                        className={
-                          previewSettings.presentationMode === "field-by-field"
-                            ? "h-[650px] overflow-hidden"
-                            : "max-h-[650px] overflow-x-hidden overflow-y-auto"
+                    {!isPopupOpen && (
+                      <button
+                        type="button"
+                        onClick={handleOpenPopup}
+                        aria-label="Open form preview"
+                        className="pointer-events-auto absolute z-20 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full bg-primary text-primary-foreground shadow-[0_4px_20px_rgba(0,0,0,0.15)] transition-[inset] duration-300 ease-out hover:scale-105 active:scale-95"
+                        style={
+                          popupPosition === "bottom-left"
+                            ? { bottom: 24, left: 24, right: "auto" }
+                            : { bottom: 24, right: "auto", left: "calc(100% - 80px)" }
                         }
                       >
-                        <FormPreviewFromPlate
-                          content={content}
-                          title={hideTitle ? "" : (doc.title ?? undefined)}
-                          icon={showEmoji ? (doc.icon ?? undefined) : undefined}
-                          cover={doc.cover ?? undefined}
-                          onSubmit={noop}
-                          hideTitle={hideTitle}
-                          customization={customization}
-                          settings={previewSettings}
-                          isPopup
-                          formId={formId}
-                        />
-                      </div>
-
-                      {branding && (
-                        <div className="flex shrink-0 justify-center border-t border-border bg-muted/60 py-3">
-                          <div className="flex items-center gap-1.5 text-[12px] font-semibold text-muted-foreground">
-                            <span>Made with</span>
-                            <SparklesIcon className="h-3 w-3 fill-muted-foreground text-muted-foreground" />
-                            <span className="text-foreground">{APP_NAME}</span>
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  )}
-
-                  {!isPopupOpen && (
-                    <button
-                      type="button"
-                      onClick={handleOpenPopup}
-                      aria-label="Open form preview"
-                      className="pointer-events-auto absolute z-20 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full bg-primary text-primary-foreground shadow-[0_4px_20px_rgba(0,0,0,0.15)] transition-[inset] duration-300 ease-out hover:scale-105 active:scale-95"
-                      style={
-                        popupPosition === "bottom-left"
-                          ? { bottom: 24, left: 24, right: "auto" }
-                          : { bottom: 24, right: "auto", left: "calc(100% - 80px)" }
-                      }
-                    >
-                      {showEmoji && doc.icon && iconMap.has(doc.icon) ? (
-                        <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
-                          <use href={`${SPRITE_PATH}#${doc.icon}`} />
-                        </svg>
-                      ) : (
-                        <svg
-                          className="h-6 w-6"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        >
-                          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-                        </svg>
-                      )}
-                    </button>
-                  )}
-                </div>
-              )}
+                        {showEmoji && doc.icon && iconMap.has(doc.icon) ? (
+                          <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                            <use href={`${SPRITE_PATH}#${doc.icon}`} />
+                          </svg>
+                        ) : (
+                          <svg
+                            className="h-6 w-6"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                          </svg>
+                        )}
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {embedType === "fullpage" && (
-          <div
-            className={cn(
-              "relative flex flex-1 flex-col overflow-hidden transition-colors duration-300",
-              transparentBackground ? "bg-transparent" : "bg-background",
-            )}
-          >
-            {/* Field-by-field mode: render the cover as a full-pane background here
-              because the form-preview's own bg-image only fills its content height. */}
-            {previewSettings.presentationMode === "field-by-field" && doc.cover && (
-              <FieldByFieldCoverBackground cover={doc.cover} />
-            )}
+          {embedType === "fullpage" && (
             <div
               className={cn(
-                "h-full min-h-0 w-full flex-1",
-                previewSettings.presentationMode !== "field-by-field" &&
-                  "overflow-x-hidden overflow-y-auto",
-                previewSettings.presentationMode !== "field-by-field" && branding && "pb-16",
+                "relative flex flex-1 flex-col overflow-hidden transition-colors duration-300",
+                transparentBackground ? "bg-transparent" : "bg-background",
               )}
             >
-              <FormPreviewFromPlate
-                content={content}
-                title={hideTitle ? "" : (doc.title ?? undefined)}
-                icon={doc.icon ?? undefined}
-                cover={doc.cover ?? undefined}
-                onSubmit={noop}
-                hideTitle={hideTitle}
-                layout="editor"
-                customization={customization}
-                settings={previewSettings}
-                formId={formId}
-              />
+              {/* Field-by-field mode: render the cover as a full-pane background here
+              because the form-preview's own bg-image only fills its content height. */}
+              {previewSettings.presentationMode === "field-by-field" && doc.cover && (
+                <FieldByFieldCoverBackground cover={doc.cover} />
+              )}
+              <div
+                className={cn(
+                  "h-full min-h-0 w-full flex-1",
+                  previewSettings.presentationMode !== "field-by-field" &&
+                    "overflow-x-hidden overflow-y-auto",
+                  previewSettings.presentationMode !== "field-by-field" && branding && "pb-16",
+                )}
+              >
+                <FormPreviewFromPlate
+                  content={content}
+                  title={hideTitle ? "" : (doc.title ?? undefined)}
+                  icon={doc.icon ?? undefined}
+                  cover={doc.cover ?? undefined}
+                  onSubmit={noop}
+                  hideTitle={hideTitle}
+                  layout="editor"
+                  customization={customization}
+                  settings={previewSettings}
+                  formId={formId}
+                />
+              </div>
+              {branding && <BrandingBadge />}
             </div>
-            {branding && <BrandingBadge />}
-          </div>
-        )}
-      </div>
-    </PreviewRendererContext.Provider>
+          )}
+        </div>
+      </PreviewRendererContext.Provider>
+    </EditorThemeProvider>
   );
 };
 

--- a/src/routes/api/ai/form-generate.ts
+++ b/src/routes/api/ai/form-generate.ts
@@ -2,15 +2,34 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createFileRoute } from "@tanstack/react-router";
 import { convertToModelMessages, generateText, streamObject, tool } from "ai";
 import type { UIMessage } from "ai";
+import { getRequestHeaders } from "@tanstack/react-start/server";
 import { z } from "zod";
 import { apiAuthMiddleware } from "@/lib/auth/middleware";
-import { formGenSchema, RADIUS_OPTIONS, themeTokensSchema } from "@/lib/ai/ops-schema";
+import {
+  formGenSchema,
+  freeThemeSchema,
+  RADIUS_OPTIONS,
+  themeTokensSchema,
+} from "@/lib/ai/ops-schema";
 import {
   FORM_APPEND_SYSTEM_PROMPT,
   FORM_EDIT_SYSTEM_PROMPT,
   FORM_GEN_SYSTEM_PROMPT,
-  FORM_THEME_SYSTEM_PROMPT,
 } from "@/lib/ai/system-prompts";
+import {
+  flattenFreeThemeArgs,
+  flattenProThemeArgs,
+  pickThemePromptForPlan,
+} from "@/lib/ai/theme-route-helpers";
+import { getActiveOrgId } from "@/lib/server-fn/auth-helpers";
+import { getOrgPlanWithPolarSync } from "@/lib/server-fn/plan-helpers.server";
+import {
+  AI_DAILY_LIMIT_ERROR,
+  checkAiQuota,
+  incrementAiCount,
+} from "@/lib/server-fn/ai-quota.server";
+import type { ServerPlan } from "@/lib/server-fn/plan-helpers";
+import { logger } from "@/lib/utils";
 
 const getModel = async () => {
   const provider = process.env.AI_PROVIDER ?? "openai";
@@ -54,9 +73,82 @@ export const Route = createFileRoute("/api/ai/form-generate")({
         const model = await getModel();
 
         const mode = body.mode ?? "create";
+
+        // Resolve plan + active org up front for every mode. Used by:
+        // 1. Theme mode → pickThemePromptForPlan (full vs limited tool).
+        // 2. All modes → AI rate-limit check (free=5/day, pro/business=∞).
+        let resolvedPlan: ServerPlan = "free";
+        let resolvedOrgId: string | null = null;
+        let planLookupError: string | null = null;
+        try {
+          const { auth } = await import("@/lib/auth/auth");
+          const session = await auth.api.getSession({ headers: getRequestHeaders() });
+          logger("[ai-plan] session present?", Boolean(session), {
+            userId: (session as { user?: { id?: string } } | null)?.user?.id ?? null,
+            activeOrganizationId:
+              (session as { session?: { activeOrganizationId?: string } } | null)?.session
+                ?.activeOrganizationId ?? null,
+          });
+          if (session) {
+            resolvedOrgId = getActiveOrgId(session as never);
+            const userEmail =
+              (session as { user?: { email?: string } } | null)?.user?.email ?? null;
+            // Self-heal: if the DB column is stale (webhook missed), Polar
+            // is consulted with the user's email; on drift the column is
+            // rewritten to the real plan. Fast path (column already paid)
+            // skips the Polar round-trip.
+            resolvedPlan = await getOrgPlanWithPolarSync(resolvedOrgId, userEmail);
+            logger("[ai-plan] resolved", {
+              mode,
+              orgId: resolvedOrgId,
+              plan: resolvedPlan,
+              note: "plan is read from organization.plan DB column (Polar webhook syncs it; route falls back to Polar API on cached='free')",
+            });
+          } else {
+            logger("[ai-plan] no session — defaulting to free, orgId=null");
+          }
+        } catch (e) {
+          planLookupError = e instanceof Error ? e.message : String(e);
+          logger("[ai-plan] lookup threw — falling back to free", planLookupError);
+          // Fall through with resolvedPlan="free", resolvedOrgId=null;
+          // null orgId skips quota tracking but still gates with free path.
+        }
+
+        // Rate-limit check. Pro/business get null limit → always allowed.
+        if (resolvedOrgId) {
+          const quota = await checkAiQuota(resolvedOrgId, resolvedPlan);
+          logger("[ai-quota] check", {
+            orgId: resolvedOrgId,
+            plan: resolvedPlan,
+            allowed: quota.allowed,
+            used: quota.used,
+            limit: quota.limit,
+          });
+          if (!quota.allowed) {
+            return new Response(
+              JSON.stringify({
+                error: AI_DAILY_LIMIT_ERROR,
+                used: quota.used,
+                limit: quota.limit,
+                plan: quota.plan,
+                message: `Daily AI limit reached (${quota.used}/${quota.limit}). Upgrade to Pro for unlimited generations.`,
+              }),
+              { status: 429, headers: { "Content-Type": "application/json" } },
+            );
+          }
+        }
+
+        const themePick = pickThemePromptForPlan(resolvedPlan);
+        logger("[ai-plan] tool pick", {
+          mode,
+          plan: resolvedPlan,
+          toolName: themePick.toolName,
+          isPro: themePick.isPro,
+        });
+
         const basePrompt =
           mode === "theme"
-            ? FORM_THEME_SYSTEM_PROMPT
+            ? themePick.prompt
             : mode === "replace"
               ? FORM_EDIT_SYSTEM_PROMPT
               : mode === "append"
@@ -90,15 +182,61 @@ export const Route = createFileRoute("/api/ai/form-generate")({
 
         // ── Theme mode: tool-call (one-shot, non-streaming) ─────────────────
         // Theme is atomic — no benefit to streaming, and tool-call gives the
-        // model a clear contract (call setFormTheme exactly once with full args).
+        // model a clear contract. Pro plans get the full-fidelity tool with
+        // 30 light:/dark: token overrides; free plans get the limited tool
+        // whose output stays inside the gate-allowed customization keys.
         if (mode === "theme") {
-          const setFormThemeArgs = z.object({
-            tokens: themeTokensSchema,
-            font: z.string(),
-            radius: z.enum(RADIUS_OPTIONS),
-          });
+          if (themePick.isPro) {
+            const setFormThemeArgs = z.object({
+              tokens: themeTokensSchema,
+              font: z.string(),
+              radius: z.enum(RADIUS_OPTIONS),
+            });
 
-          let captured: z.infer<typeof setFormThemeArgs> | null = null;
+            let captured: z.infer<typeof setFormThemeArgs> | null = null;
+
+            await generateText({
+              model,
+              system: systemWithContext,
+              messages: modelMessages,
+              toolChoice: "required",
+              tools: {
+                [themePick.toolName]: tool({
+                  description:
+                    "Apply a complete visual theme to the form (colors, font, radius). Call exactly once with all 30 token values, font, and radius.",
+                  inputSchema: setFormThemeArgs,
+                  execute: async (args) => {
+                    captured = args;
+                    return { ok: true };
+                  },
+                }),
+              },
+            });
+
+            // Re-bind to a const so TS narrows after the null check (the
+            // assignment lives in a closure, so flow analysis can't reach it
+            // through the original `let`).
+            const captured2 = captured as z.infer<typeof setFormThemeArgs> | null;
+            if (!captured2) {
+              return new Response(JSON.stringify({ error: "model_did_not_emit_theme" }), {
+                status: 502,
+                headers: { "Content-Type": "application/json" },
+              });
+            }
+
+            const theme = flattenProThemeArgs(captured2);
+            if (resolvedOrgId)
+              void incrementAiCount(resolvedOrgId).catch((e) =>
+                logger("[ai-quota] increment failed", e),
+              );
+            return new Response(JSON.stringify({ theme }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+
+          // Free plan: limited tool — themeColor + baseColor + font + radius + defaultMode.
+          let captured: z.infer<typeof freeThemeSchema> | null = null;
 
           await generateText({
             model,
@@ -106,10 +244,10 @@ export const Route = createFileRoute("/api/ai/form-generate")({
             messages: modelMessages,
             toolChoice: "required",
             tools: {
-              setFormTheme: tool({
+              [themePick.toolName]: tool({
                 description:
-                  "Apply a complete visual theme to the form (colors, font, radius). Call exactly once with all 30 token values, font, and radius.",
-                inputSchema: setFormThemeArgs,
+                  "Apply a basic theme available on the free plan. Call exactly once with themeColor, baseColor, font, radius, and defaultMode — each value must be from the allowed list in the system prompt.",
+                inputSchema: freeThemeSchema,
                 execute: async (args) => {
                   captured = args;
                   return { ok: true };
@@ -118,14 +256,20 @@ export const Route = createFileRoute("/api/ai/form-generate")({
             },
           });
 
-          if (!captured) {
+          const capturedFree = captured as z.infer<typeof freeThemeSchema> | null;
+          if (!capturedFree) {
             return new Response(JSON.stringify({ error: "model_did_not_emit_theme" }), {
               status: 502,
               headers: { "Content-Type": "application/json" },
             });
           }
 
-          return new Response(JSON.stringify({ theme: captured }), {
+          const theme = flattenFreeThemeArgs(capturedFree);
+          if (resolvedOrgId)
+            void incrementAiCount(resolvedOrgId).catch((e) =>
+              logger("[ai-quota] increment failed", e),
+            );
+          return new Response(JSON.stringify({ theme }), {
             status: 200,
             headers: { "Content-Type": "application/json" },
           });
@@ -139,6 +283,13 @@ export const Route = createFileRoute("/api/ai/form-generate")({
           messages: modelMessages,
         });
 
+        // Streaming hands the response off to the client; we increment once
+        // we know the model accepted the request. If the stream errors out
+        // mid-way, that still counts as a generation (work was performed).
+        if (resolvedOrgId)
+          void incrementAiCount(resolvedOrgId).catch((e) =>
+            logger("[ai-quota] increment failed", e),
+          );
         return result.toTextStreamResponse();
       },
     },

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -633,10 +633,14 @@
    spec from Figma (gray/50 fill, 8px radius, hairline drop shadow) in both
    light and dark. Uses !important to override the underlying <Input>
    component's cva variants (bg-card, dark:border, etc.), since this utility
-   is the canonical form-field style. */
+   is the canonical form-field style.
+
+   The fill is driven by --form-input-bg with a gray/50 fallback; .bf-themed
+   binds it to --bf-input so the customize-sidebar Input token actually
+   reaches every input widget. */
 @utility form-input {
   @apply w-full text-foreground placeholder:text-muted-foreground/50;
-  background-color: var(--color-gray-50) !important;
+  background-color: var(--form-input-bg, var(--color-gray-50)) !important;
   border-radius: 8px !important;
   box-shadow: 0 0 1px rgba(0, 0, 0, 0.54), 0 1px 1px rgba(0, 0, 0, 0.06) !important;
   border: 0 !important;
@@ -789,6 +793,37 @@
 /* Input width: editor input nodes */
 .bf-themed [data-bf-input] {
   max-width: var(--bf-input-width);
+}
+
+/* Input fill: drive the form-input utility from the Input token so all
+   text-input widgets (Input/Email/Number/Link/Textarea/Time/Date/Phone/
+   FileUpload) honor the customize-sidebar Input color. */
+.bf-themed {
+  --form-input-bg: var(--bf-input);
+}
+
+/* Components that bypass the form-input utility (phone input parts,
+   unchecked checkbox surfaces) get the same Input token via [data-bf-
+   input-fill] markers in their JSX, plus the existing data-slot the
+   checkbox primitive ships with. Multi-choice option letter badges
+   already consume --form-input-bg via the bg-[var(...)] arbitrary value.
+   Note: the [data-slot="checkbox"]:not([data-checked]) selector is
+   coupled to base-ui's internal attributes — verify these selectors
+   still match when upgrading @base-ui/react. */
+.bf-themed [data-bf-input-fill],
+.bf-themed [data-slot="checkbox"]:not([data-checked]) {
+  background-color: var(--bf-input) !important;
+}
+
+/* Popup surfaces inside themed forms — date-picker calendar, multi-select
+   dropdown, etc. — bypass `--bf-popover` (which derives from the base
+   preset, typically white) and route through `--bf-input` so popups feel
+   like an extension of the input/trigger they expand from. The
+   `--color-popover` override is needed for Tailwind v4's bg-popover utility,
+   which resolves through the @theme color scale rather than the raw token. */
+.bf-themed {
+  --popover: var(--bf-input);
+  --color-popover: var(--bf-input);
 }
 
 /* Typography bridge */

--- a/src/test/ai-quota.test.ts
+++ b/src/test/ai-quota.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { aiQuotaForPlan, PLAN_QUOTAS } from "@/lib/config/plan-gates";
+import {
+  checkAiQuota,
+  getAiCount,
+  incrementAiCount,
+  utcDayKey,
+} from "@/lib/server-fn/ai-quota.server";
+import {
+  cleanupTestOrg,
+  cleanupTestUser,
+  createTestOrg,
+  getTestUtils,
+  setOrgPlan,
+} from "@/test/helpers";
+
+describe("aiQuotaForPlan (central plan-quotas config)", () => {
+  it("free plan: 5 generations / day", () => {
+    expect(aiQuotaForPlan("free").aiGenerationsPerDay).toBe(5);
+  });
+
+  it("pro plan: unlimited (null)", () => {
+    expect(aiQuotaForPlan("pro").aiGenerationsPerDay).toBeNull();
+  });
+
+  it("business plan: unlimited (null)", () => {
+    expect(aiQuotaForPlan("business").aiGenerationsPerDay).toBeNull();
+  });
+
+  it("pLAN_QUOTAS covers every ServerPlan", () => {
+    expect(Object.keys(PLAN_QUOTAS).toSorted()).toStrictEqual(
+      ["business", "free", "pro"].toSorted(),
+    );
+  });
+});
+
+describe("utcDayKey", () => {
+  it("returns YYYY-MM-DD in UTC", () => {
+    const key = utcDayKey(new Date("2026-04-30T23:59:59Z"));
+    expect(key).toBe("2026-04-30");
+  });
+
+  it("rolls over at 00:00 UTC", () => {
+    expect(utcDayKey(new Date("2026-05-01T00:00:00Z"))).toBe("2026-05-01");
+  });
+});
+
+describe("aI quota counter (DB-backed)", () => {
+  const ownerId = crypto.randomUUID();
+  let orgId: string;
+
+  beforeEach(async () => {
+    const t = await getTestUtils();
+    await t.saveUser(
+      t.createUser({
+        id: ownerId,
+        email: `owner-aiquota-${ownerId}@example.com`,
+        name: "AI Quota Owner",
+      }),
+    );
+    const org = await createTestOrg(ownerId);
+    orgId = org.id;
+  });
+
+  afterEach(async () => {
+    await cleanupTestUser(ownerId);
+    await cleanupTestOrg(orgId);
+  });
+
+  it("getAiCount returns 0 for a fresh org with no row yet", async () => {
+    await expect(getAiCount(orgId)).resolves.toBe(0);
+  });
+
+  it("incrementAiCount inserts the first row at count=1", async () => {
+    await incrementAiCount(orgId);
+    await expect(getAiCount(orgId)).resolves.toBe(1);
+  });
+
+  it("incrementAiCount increments the same-day row idempotently", async () => {
+    await incrementAiCount(orgId);
+    await incrementAiCount(orgId);
+    await incrementAiCount(orgId);
+    await expect(getAiCount(orgId)).resolves.toBe(3);
+  });
+
+  it("counts are per-day: yesterday's bucket doesn't bleed into today", async () => {
+    const today = utcDayKey(new Date("2026-04-30T12:00:00Z"));
+    const tomorrow = utcDayKey(new Date("2026-05-01T12:00:00Z"));
+    await incrementAiCount(orgId, today);
+    await incrementAiCount(orgId, today);
+    await incrementAiCount(orgId, tomorrow);
+
+    await expect(getAiCount(orgId, today)).resolves.toBe(2);
+    await expect(getAiCount(orgId, tomorrow)).resolves.toBe(1);
+  });
+});
+
+describe("checkAiQuota", () => {
+  const ownerId = crypto.randomUUID();
+  let orgId: string;
+
+  beforeEach(async () => {
+    const t = await getTestUtils();
+    await t.saveUser(
+      t.createUser({
+        id: ownerId,
+        email: `owner-aiquota-check-${ownerId}@example.com`,
+        name: "AI Quota Check Owner",
+      }),
+    );
+    const org = await createTestOrg(ownerId);
+    orgId = org.id;
+  });
+
+  afterEach(async () => {
+    await cleanupTestUser(ownerId);
+    await cleanupTestOrg(orgId);
+  });
+
+  it("free plan: under-limit allows", async () => {
+    const result = await checkAiQuota(orgId, "free");
+    expect(result.allowed).toBeTruthy();
+    expect(result.limit).toBe(5);
+    expect(result.used).toBe(0);
+  });
+
+  it("free plan: at-limit blocks with daily_limit_exceeded", async () => {
+    for (let i = 0; i < 5; i++) await incrementAiCount(orgId);
+    const result = await checkAiQuota(orgId, "free");
+    // Cast through the discriminated union once so the assertions don't
+    // need a type-narrowing conditional (oxlint forbids those in tests).
+    const blocked = result as Extract<typeof result, { allowed: false }>;
+    expect(blocked.allowed).toBeFalsy();
+    expect(blocked.reason).toBe("daily_limit_exceeded");
+    expect(blocked.used).toBe(5);
+    expect(blocked.limit).toBe(5);
+  });
+
+  it("free plan: one-below-limit still allows (5/day = 5 calls)", async () => {
+    for (let i = 0; i < 4; i++) await incrementAiCount(orgId);
+    const result = await checkAiQuota(orgId, "free");
+    expect(result.allowed).toBeTruthy();
+    expect(result.used).toBe(4);
+  });
+
+  it("pro plan: never blocks regardless of count", async () => {
+    await setOrgPlan(orgId, "pro");
+    for (let i = 0; i < 50; i++) await incrementAiCount(orgId);
+    const result = await checkAiQuota(orgId, "pro");
+    expect(result.allowed).toBeTruthy();
+    expect(result.limit).toBeNull();
+    expect(result.used).toBe(50);
+  });
+
+  it("business plan: never blocks", async () => {
+    await setOrgPlan(orgId, "business");
+    for (let i = 0; i < 100; i++) await incrementAiCount(orgId);
+    const result = await checkAiQuota(orgId, "business");
+    expect(result.allowed).toBeTruthy();
+    expect(result.limit).toBeNull();
+  });
+
+  it("free plan: day boundary resets the budget", async () => {
+    const yesterday = utcDayKey(new Date("2026-04-30T12:00:00Z"));
+    const today = utcDayKey(new Date("2026-05-01T12:00:00Z"));
+
+    for (let i = 0; i < 5; i++) await incrementAiCount(orgId, yesterday);
+
+    const yesterdayCheck = await checkAiQuota(orgId, "free", yesterday);
+    expect(yesterdayCheck.allowed).toBeFalsy();
+
+    const todayCheck = await checkAiQuota(orgId, "free", today);
+    expect(todayCheck.allowed).toBeTruthy();
+    expect(todayCheck.used).toBe(0);
+  });
+});

--- a/src/test/ai-theme-merge.test.ts
+++ b/src/test/ai-theme-merge.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import { requiresProForFormSettings } from "@/lib/server-fn/plan-helpers";
+import {
+  mergeSetThemeOpIntoCustomization,
+  mergeThemeIntoCustomization,
+} from "@/lib/editor/merge-theme";
+import type { SetThemeOp } from "@/lib/ai/ops-schema";
+
+// What the FREE setFormThemeFree tool returns (server already flattened it).
+const freeThemePayload = {
+  themeColor: "blue",
+  baseColor: "neutral",
+  font: "Inter",
+  radius: "medium",
+  defaultMode: "system",
+};
+
+// What the PRO setFormTheme tool returns (server already flattened it).
+const proThemePayload = {
+  "light:background": "#ffffff",
+  "light:foreground": "#0a0a0a",
+  "light:primary": "#2563eb",
+  "dark:background": "#0a0a0a",
+  "dark:foreground": "#fafafa",
+  "dark:primary": "#3b82f6",
+  font: "Inter",
+  radius: "medium",
+};
+
+describe("mergeThemeIntoCustomization (theme-mode optimistic write)", () => {
+  it("merges a free-tier theme into an empty customization without triggering the Pro gate", () => {
+    const merged = mergeThemeIntoCustomization({}, freeThemePayload);
+
+    // Sanity: every key the free tool returns lands in customization, plus
+    // the preset marker so the editor's preset selector flips to "custom".
+    expect(merged).toMatchObject({
+      ...freeThemePayload,
+      preset: "custom",
+    });
+
+    // The whole point of Bug 1's fix: the gate must NOT fire for this payload.
+    expect(requiresProForFormSettings({ customization: merged })).toBeFalsy();
+  });
+
+  it("merges a free-tier theme on top of an existing free preset without triggering the Pro gate", () => {
+    const merged = mergeThemeIntoCustomization(
+      { preset: "mira", themeColor: "zinc" },
+      freeThemePayload,
+    );
+
+    // Theme overrides existing themeColor; preset is rewritten to "custom".
+    expect(merged.themeColor).toBe("blue");
+    expect(merged.preset).toBe("custom");
+
+    expect(requiresProForFormSettings({ customization: merged })).toBeFalsy();
+  });
+
+  it("merges a Pro-tier theme — gate fires (so the server can plan-check)", () => {
+    const merged = mergeThemeIntoCustomization({}, proThemePayload);
+
+    // Pro payload writes light:/dark: token overrides. Those are Pro-only.
+    expect(requiresProForFormSettings({ customization: merged })).toBeTruthy();
+  });
+
+  it("strips stale Pro-tier keys when merging a free-tier theme (no key carry-over)", () => {
+    // A user who was previously Pro (or whose org.plan column is stale) may
+    // already have light:/dark: tokens in customization. A free-tier AI
+    // write must not drag those forward, otherwise the optimistic update
+    // hits the Pro gate at the server.
+    const merged = mergeThemeIntoCustomization(
+      {
+        "light:primary": "#abcdef",
+        "dark:primary": "#123456",
+        customCss: ".x {}",
+        themeColor: "zinc",
+      },
+      freeThemePayload,
+    );
+
+    expect(merged["light:primary"]).toBeUndefined();
+    expect(merged["dark:primary"]).toBeUndefined();
+    expect(merged.customCss).toBeUndefined();
+  });
+
+  it("after stripping stale Pro keys on a free-tier merge, the resulting customization passes the gate", () => {
+    const merged = mergeThemeIntoCustomization(
+      { "light:primary": "#abcdef", customCss: ".x {}", themeColor: "zinc" },
+      freeThemePayload,
+    );
+
+    // New theme is applied, preset flipped to custom.
+    expect(merged.themeColor).toBe("blue");
+    expect(merged.preset).toBe("custom");
+    // The whole point: the resulting customization no longer trips the gate.
+    expect(requiresProForFormSettings({ customization: merged })).toBeFalsy();
+  });
+
+  it("keeps existing Pro-tier keys when merging a Pro-tier theme (Pro users retain their full customization)", () => {
+    // The Pro-tier path emits light:/dark: tokens. Merging into existing
+    // customization with light: keys is the Pro-user steady state — those
+    // keys must be preserved (and overwritten where the new theme provides
+    // a fresh value), NOT stripped.
+    const merged = mergeThemeIntoCustomization(
+      { "light:secondary": "#eeeeee", titleFont: "Lora" },
+      proThemePayload,
+    );
+
+    expect(merged["light:secondary"]).toBe("#eeeeee");
+    expect(merged.titleFont).toBe("Lora");
+    expect(merged["light:primary"]).toBe("#2563eb");
+    expect(merged.preset).toBe("custom");
+  });
+});
+
+describe("streaming-path / theme-mode parity (backwards compat after refactor)", () => {
+  it("a streaming SetThemeOp with full Pro tokens produces the same customization as the theme-mode Pro path", () => {
+    // The AI emits a SetThemeOp (streaming, non-theme modes) shaped like
+    // { tokens, font, radius }. The theme-mode endpoint pre-flattens that
+    // same data into { ...tokens, font, radius }. After merging both into
+    // an empty customization, the resulting records must be identical
+    // (modulo nothing — no field should drift between the two code paths).
+    const tokens: Record<string, string> = {
+      "light:primary": "#2563eb",
+      "dark:primary": "#3b82f6",
+      "light:background": "#ffffff",
+      "dark:background": "#0a0a0a",
+    };
+    const op: SetThemeOp = {
+      type: "set-theme",
+      tokens,
+      font: "Inter",
+      radius: "medium",
+    };
+
+    const fromStreamingPath = mergeSetThemeOpIntoCustomization({}, op);
+    const fromThemeModePath = mergeThemeIntoCustomization(
+      {},
+      {
+        ...tokens,
+        font: "Inter",
+        radius: "medium",
+      },
+    );
+
+    expect(fromStreamingPath).toStrictEqual(fromThemeModePath);
+  });
+
+  it("a streaming SetThemeOp with only font set still produces the same shape as the theme-mode path with the same single field", () => {
+    const op: SetThemeOp = { type: "set-theme", font: "Lora" };
+
+    const fromStreamingPath = mergeSetThemeOpIntoCustomization({}, op);
+    const fromThemeModePath = mergeThemeIntoCustomization({}, { font: "Lora" });
+
+    expect(fromStreamingPath).toStrictEqual(fromThemeModePath);
+  });
+
+  it("preserves prior free-tier customization (themeColor) across both paths identically when the new payload is free-tier", () => {
+    // When the new theme is free-tier, both paths preserve free-tier keys
+    // from `current`. (Note: the theme-mode path additionally strips
+    // non-free keys from `current`; the streaming path doesn't, since
+    // streaming doesn't currently plan-branch. That divergence is tested
+    // separately above.)
+    const op: SetThemeOp = { type: "set-theme", radius: "large" };
+
+    const current = { themeColor: "rose" };
+    const fromStreamingPath = mergeSetThemeOpIntoCustomization(current, op);
+    const fromThemeModePath = mergeThemeIntoCustomization(current, { radius: "large" });
+
+    expect(fromStreamingPath).toStrictEqual(fromThemeModePath);
+    expect(fromStreamingPath.themeColor).toBe("rose");
+  });
+});
+
+describe("mergeSetThemeOpIntoCustomization (streaming AI path → set-theme op)", () => {
+  it("applies tokens, font, and radius from a SetThemeOp", () => {
+    const op: SetThemeOp = {
+      type: "set-theme",
+      tokens: { "light:primary": "#2563eb", "dark:primary": "#3b82f6" },
+      font: "Poppins",
+      radius: "large",
+    };
+    const merged = mergeSetThemeOpIntoCustomization({}, op);
+
+    expect(merged["light:primary"]).toBe("#2563eb");
+    expect(merged["dark:primary"]).toBe("#3b82f6");
+    expect(merged.font).toBe("Poppins");
+    expect(merged.radius).toBe("large");
+    expect(merged.preset).toBe("custom");
+  });
+
+  it("preserves existing customization keys not overridden by the op", () => {
+    const op: SetThemeOp = {
+      type: "set-theme",
+      font: "Inter",
+    };
+    const merged = mergeSetThemeOpIntoCustomization({ themeColor: "blue", titleFont: "Lora" }, op);
+
+    expect(merged.themeColor).toBe("blue");
+    expect(merged.titleFont).toBe("Lora");
+    expect(merged.font).toBe("Inter");
+    expect(merged.preset).toBe("custom");
+  });
+
+  it("is a no-op on customization keys when the op carries no fields (still marks preset='custom')", () => {
+    const op: SetThemeOp = { type: "set-theme" };
+    const merged = mergeSetThemeOpIntoCustomization({ font: "Lora" }, op);
+
+    // Existing keys preserved, preset upgraded.
+    expect(merged.font).toBe("Lora");
+    expect(merged.preset).toBe("custom");
+  });
+
+  it("does not write radius/font when op fields are undefined", () => {
+    const op: SetThemeOp = {
+      type: "set-theme",
+      tokens: { "light:primary": "#000" },
+    };
+    const merged = mergeSetThemeOpIntoCustomization({}, op);
+
+    expect(merged["light:primary"]).toBe("#000");
+    expect(merged.font).toBeUndefined();
+    expect(merged.radius).toBeUndefined();
+  });
+});

--- a/src/test/ai-theme-plan-integration.test.ts
+++ b/src/test/ai-theme-plan-integration.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getOrgPlan } from "@/lib/server-fn/plan-helpers.server";
+import { pickThemePromptForPlan } from "@/lib/ai/theme-route-helpers";
+import {
+  cleanupTestOrg,
+  cleanupTestUser,
+  createTestOrg,
+  getTestUtils,
+  setOrgPlan,
+} from "@/test/helpers";
+
+describe("/api/ai/form-generate plan resolution (end-to-end)", () => {
+  const ownerId = crypto.randomUUID();
+  let orgId: string;
+
+  beforeEach(async () => {
+    const t = await getTestUtils();
+    await t.saveUser(
+      t.createUser({
+        id: ownerId,
+        email: `owner-ai-theme-${ownerId}@example.com`,
+        name: "AI Theme Owner",
+      }),
+    );
+    const org = await createTestOrg(ownerId);
+    orgId = org.id;
+  });
+
+  afterEach(async () => {
+    await cleanupTestUser(ownerId);
+    await cleanupTestOrg(orgId);
+  });
+
+  it("default-new org → getOrgPlan='free' → route picks the Free tool (limited customization)", async () => {
+    const plan = await getOrgPlan(orgId);
+    expect(plan).toBe("free");
+
+    const pick = pickThemePromptForPlan(plan);
+    expect(pick.toolName).toBe("setFormThemeFree");
+    expect(pick.isPro).toBeFalsy();
+  });
+
+  it("pro org → getOrgPlan='pro' → route picks the full setFormTheme tool with light:/dark: tokens", async () => {
+    await setOrgPlan(orgId, "pro");
+    const plan = await getOrgPlan(orgId);
+    expect(plan).toBe("pro");
+
+    const pick = pickThemePromptForPlan(plan);
+    expect(pick.toolName).toBe("setFormTheme");
+    expect(pick.isPro).toBeTruthy();
+  });
+
+  it("business org → getOrgPlan='business' → route picks the full setFormTheme tool", async () => {
+    await setOrgPlan(orgId, "business");
+    const plan = await getOrgPlan(orgId);
+    expect(plan).toBe("business");
+
+    const pick = pickThemePromptForPlan(plan);
+    expect(pick.toolName).toBe("setFormTheme");
+    expect(pick.isPro).toBeTruthy();
+  });
+
+  it("downgrade pro → free flips the route back to the limited Free tool", async () => {
+    await setOrgPlan(orgId, "pro");
+    expect(pickThemePromptForPlan(await getOrgPlan(orgId)).isPro).toBeTruthy();
+
+    await setOrgPlan(orgId, "free");
+    const pick = pickThemePromptForPlan(await getOrgPlan(orgId));
+    expect(pick.toolName).toBe("setFormThemeFree");
+    expect(pick.isPro).toBeFalsy();
+  });
+});

--- a/src/test/ai-theme-route.test.ts
+++ b/src/test/ai-theme-route.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  flattenFreeThemeArgs,
+  flattenProThemeArgs,
+  pickThemePromptForPlan,
+} from "@/lib/ai/theme-route-helpers";
+import { FORM_THEME_FREE_SYSTEM_PROMPT, FORM_THEME_SYSTEM_PROMPT } from "@/lib/ai/system-prompts";
+import { AI_THEME_TOKEN_KEYS } from "@/lib/ai/ops-schema";
+
+describe("pickThemePromptForPlan", () => {
+  it("uses the full Pro prompt + setFormTheme tool for plan='pro'", () => {
+    const picked = pickThemePromptForPlan("pro");
+    expect(picked.prompt).toBe(FORM_THEME_SYSTEM_PROMPT);
+    expect(picked.toolName).toBe("setFormTheme");
+    expect(picked.isPro).toBeTruthy();
+  });
+
+  it("uses the full Pro prompt + setFormTheme tool for plan='business'", () => {
+    const picked = pickThemePromptForPlan("business");
+    expect(picked.prompt).toBe(FORM_THEME_SYSTEM_PROMPT);
+    expect(picked.toolName).toBe("setFormTheme");
+    expect(picked.isPro).toBeTruthy();
+  });
+
+  it("uses the limited Free prompt + setFormThemeFree tool for plan='free'", () => {
+    const picked = pickThemePromptForPlan("free");
+    expect(picked.prompt).toBe(FORM_THEME_FREE_SYSTEM_PROMPT);
+    expect(picked.toolName).toBe("setFormThemeFree");
+    expect(picked.isPro).toBeFalsy();
+  });
+
+  it("falls through to free for an unknown plan string (safer to gate down)", () => {
+    const picked = pickThemePromptForPlan("enterprise" as never);
+    expect(picked.prompt).toBe(FORM_THEME_FREE_SYSTEM_PROMPT);
+    expect(picked.toolName).toBe("setFormThemeFree");
+    expect(picked.isPro).toBeFalsy();
+  });
+});
+
+describe("flattenProThemeArgs", () => {
+  it("returns a flat dict containing every token plus font and radius", () => {
+    const tokens: Record<string, string> = {};
+    for (const key of AI_THEME_TOKEN_KEYS) {
+      tokens[`light:${key}`] = "#ffffff";
+      tokens[`dark:${key}`] = "#000000";
+    }
+    const flat = flattenProThemeArgs({ tokens, font: "Inter", radius: "medium" });
+
+    // 30 token keys + font + radius = 32 keys
+    expect(Object.keys(flat)).toHaveLength(AI_THEME_TOKEN_KEYS.length * 2 + 2);
+    expect(flat.font).toBe("Inter");
+    expect(flat.radius).toBe("medium");
+    expect(flat["light:primary"]).toBe("#ffffff");
+    expect(flat["dark:primary"]).toBe("#000000");
+  });
+
+  it("does not introduce free-only keys (themeColor / baseColor / defaultMode)", () => {
+    const tokens: Record<string, string> = {};
+    for (const key of AI_THEME_TOKEN_KEYS) {
+      tokens[`light:${key}`] = "#fff";
+      tokens[`dark:${key}`] = "#000";
+    }
+    const flat = flattenProThemeArgs({ tokens, font: "Inter", radius: "small" });
+    expect(flat.themeColor).toBeUndefined();
+    expect(flat.baseColor).toBeUndefined();
+    expect(flat.defaultMode).toBeUndefined();
+  });
+});
+
+describe("flattenFreeThemeArgs", () => {
+  it("returns exactly themeColor, baseColor, font, radius, defaultMode", () => {
+    const flat = flattenFreeThemeArgs({
+      themeColor: "blue",
+      baseColor: "neutral",
+      font: "Inter",
+      radius: "medium",
+      defaultMode: "system",
+    });
+
+    expect(Object.keys(flat).toSorted()).toStrictEqual(
+      ["baseColor", "defaultMode", "font", "radius", "themeColor"].toSorted(),
+    );
+  });
+
+  it("does not introduce Pro-only keys (light:* / dark:*)", () => {
+    const flat = flattenFreeThemeArgs({
+      themeColor: "rose",
+      baseColor: "stone",
+      font: "Lora",
+      radius: "large",
+      defaultMode: "light",
+    });
+
+    for (const key of Object.keys(flat)) {
+      expect(key.startsWith("light:")).toBeFalsy();
+      expect(key.startsWith("dark:")).toBeFalsy();
+    }
+  });
+});

--- a/src/test/ai-theme-schemas.test.ts
+++ b/src/test/ai-theme-schemas.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { freeThemeSchema, themeTokensSchema, AI_THEME_TOKEN_KEYS } from "@/lib/ai/ops-schema";
+
+describe("freeThemeSchema", () => {
+  const valid = {
+    themeColor: "blue",
+    baseColor: "neutral",
+    font: "Inter",
+    radius: "medium",
+    defaultMode: "system",
+  };
+
+  it("accepts a fully valid payload", () => {
+    expect(freeThemeSchema.safeParse(valid).success).toBeTruthy();
+  });
+
+  it("rejects an out-of-enum themeColor", () => {
+    const result = freeThemeSchema.safeParse({ ...valid, themeColor: "magenta" });
+    expect(result.success).toBeFalsy();
+  });
+
+  it("rejects an out-of-enum baseColor (e.g. a theme color slipping in)", () => {
+    const result = freeThemeSchema.safeParse({ ...valid, baseColor: "blue" });
+    expect(result.success).toBeFalsy();
+  });
+
+  it("rejects an out-of-enum radius", () => {
+    const result = freeThemeSchema.safeParse({ ...valid, radius: "round" });
+    expect(result.success).toBeFalsy();
+  });
+
+  it("rejects an out-of-enum defaultMode", () => {
+    const result = freeThemeSchema.safeParse({ ...valid, defaultMode: "auto" });
+    expect(result.success).toBeFalsy();
+  });
+
+  it("rejects when any of the five required fields is missing", () => {
+    for (const key of Object.keys(valid)) {
+      const partial = { ...valid } as Record<string, unknown>;
+      delete partial[key];
+      expect(freeThemeSchema.safeParse(partial).success).toBeFalsy();
+    }
+  });
+
+  it("accepts any non-empty string for font (Google Fonts catalog is open)", () => {
+    expect(freeThemeSchema.safeParse({ ...valid, font: "Playfair Display" }).success).toBeTruthy();
+    expect(freeThemeSchema.safeParse({ ...valid, font: "JetBrains Mono" }).success).toBeTruthy();
+  });
+});
+
+describe("themeTokensSchema", () => {
+  const fullTokens = (() => {
+    const out: Record<string, string> = {};
+    for (const key of AI_THEME_TOKEN_KEYS) {
+      out[`light:${key}`] = "#ffffff";
+      out[`dark:${key}`] = "#000000";
+    }
+    return out;
+  })();
+
+  it("accepts a fully populated 30-key payload", () => {
+    expect(themeTokensSchema.safeParse(fullTokens).success).toBeTruthy();
+  });
+
+  it("rejects a partial payload (15 keys missing)", () => {
+    const half: Record<string, string> = {};
+    for (const key of AI_THEME_TOKEN_KEYS) {
+      half[`light:${key}`] = "#ffffff";
+    }
+    expect(themeTokensSchema.safeParse(half).success).toBeFalsy();
+  });
+
+  it("rejects a payload missing a single required key", () => {
+    const missingOne = { ...fullTokens };
+    delete (missingOne as Record<string, unknown>)["light:primary"];
+    expect(themeTokensSchema.safeParse(missingOne).success).toBeFalsy();
+  });
+
+  it("rejects a payload with non-string token values", () => {
+    const badType = { ...fullTokens, "light:primary": 123 } as unknown;
+    expect(themeTokensSchema.safeParse(badType).success).toBeFalsy();
+  });
+});

--- a/src/test/plan-write-gates.test.ts
+++ b/src/test/plan-write-gates.test.ts
@@ -79,9 +79,41 @@ describe("plan-write-gates", () => {
       expect(requiresProForFormSettings({ analytics: true })).toBeTruthy();
     });
 
-    it("true when customization is non-empty", () => {
+    it("true when customization carries a Pro-tier key (light/dark token override)", () => {
       expect(
-        requiresProForFormSettings({ customization: { primaryColor: "#abcdef" } }),
+        requiresProForFormSettings({ customization: { "light:primary": "#abcdef" } }),
+      ).toBeTruthy();
+    });
+
+    it("true when customization carries a non-free key (e.g. customCss)", () => {
+      expect(
+        requiresProForFormSettings({ customization: { customCss: ".x { color: red }" } }),
+      ).toBeTruthy();
+    });
+
+    it("false when customization only contains basic Theme keys (preset / themeColor / baseColor / font / radius / defaultMode)", () => {
+      expect(
+        requiresProForFormSettings({
+          customization: {
+            preset: "custom",
+            themeColor: "blue",
+            baseColor: "neutral",
+            font: "Inter",
+            radius: "medium",
+            defaultMode: "system",
+          },
+        }),
+      ).toBeFalsy();
+    });
+
+    it("true when basic Theme keys are mixed with a Pro-tier key", () => {
+      expect(
+        requiresProForFormSettings({
+          customization: {
+            themeColor: "blue",
+            "light:primary": "#abcdef",
+          },
+        }),
       ).toBeTruthy();
     });
 
@@ -89,7 +121,7 @@ describe("plan-write-gates", () => {
       expect(
         requiresProForFormSettings({
           branding: false,
-          customization: { primaryColor: "#abcdef" },
+          customization: { customCss: ".x {}" },
         }),
       ).toBeTruthy();
     });


### PR DESCRIPTION
## Summary

Two related changes that fix the AI image-upload theme flow end-to-end:

- **Plan-aware AI theme generation + daily quota** ([`9669a28`](../commit/9669a28)) — the AI route now picks the right tool based on the caller's plan, free-tier writes succeed without tripping the Pro gate, the editor surfaces upgrade prompts via toasts, and a daily 5/gen quota gates free usage. Plus a self-heal that re-syncs `organization.plan` from Polar when the column is stale.
- **Input theming consistency** ([`37f5ba3`](../commit/37f5ba3)) — every form-shaped widget now respects the Customize-sidebar **Input** token, and portaled popovers (date picker, block menu) re-anchor the theme so the calendar's selected date / today highlight follow the form's palette instead of falling back to default black/gray.

## What changed

### `feat(ai)` — plan-aware theme + quota

- **Server gate is now granular** — `requiresProForFormSettings` only flags `customization` payloads carrying non-free keys, so editing Accent / Base / Font / Radius / Default Theme works on any plan.
- **AI route plan branch** — `/api/ai/form-generate` resolves `getOrgPlan(orgId)` and routes through `pickThemePromptForPlan`. Pro/Business get the full `setFormTheme` tool (30 light:/dark: token overrides); free gets the limited `setFormThemeFree` tool whose output stays inside the gate's allowlist.
- **AI daily quota** — new `ai_generation_counts` table, `PLAN_QUOTAS` config (free=5/day, pro/business=∞) co-located with `PLAN_GATES`, fire-and-forget `incrementAiCount` after success. Server returns `429 ai_daily_limit_exceeded` when over.
- **Plan self-heal** — `getOrgPlanWithPolarSync` falls back to the Polar API when the cached column says "free", parallelising customer subscription lookups and writing back on drift.
- **Free-tier merge** — client-side `mergeThemeIntoCustomization` strips stale `light:*`/`dark:*` keys when the AI returns a free-tier payload so previously-paid users don't carry forward Pro keys that block the optimistic write.
- **Toasts + billing UI** — free-plan theme write surfaces an "Upgrade to Pro" toast, 429 surfaces a "Daily AI limit reached" toast, both wired to `settingsDialogStore.open('billing')`. Billing tier buttons are now action-driven (Upgrade / Downgrade / Current) using the exported `PLAN_RANK`.
- **AGENTS.md** — tests must run via `bun run test`, not `bun test` (Bun's built-in runner silently skips Vitest-only APIs).

### `fix(theme)` — consistent input theming

- **`form-input` utility now reads `var(--form-input-bg, var(--color-gray-50))`** — `.bf-themed` binds `--form-input-bg` to `--bf-input` so the Input token reaches every text-input widget that uses the utility.
- **Eight bypassing widgets switched to the same arbitrary value** — date-picker, multi-select, file-upload, phone, multi-choice badges, and the four editor-side `form-*-node` files all now read `bg-[var(--form-input-bg,var(--color-gray-50))]`.
- **Phone country trigger + checkbox** marked with `data-bf-input-fill` and routed through `--bf-input` in `.bf-themed`.
- **Popover surfaces** — `--popover` and `--color-popover` aliased to `--bf-input` inside `.bf-themed`, so the date-picker calendar and multi-select dropdown match the form's input fill.
- **Portaled popovers re-anchor the theme** — `useReanchorThemeProps` (new `src/hooks/use-form-theme.ts`) returns `{ className, style }` to apply on portaled content. `useFormThemeContextValue` memoizes the `EditorThemeProvider` value so editor-app and preview-mode publish a stable context. Wired into `date-picker.tsx`, `block-menu.tsx`, `editor-app.tsx`, `preview-mode.tsx`.

## Tests

268 passing across 31 suites, including 6 new files exercising every new helper:

- `plan-write-gates.test.ts` — gate predicate (17 tests)
- `ai-theme-merge.test.ts` — merge logic incl. free-tier strip (13 tests)
- `ai-theme-schemas.test.ts` — Zod validation (11 tests)
- `ai-theme-route.test.ts` — `pickThemePromptForPlan` + flatteners (8 tests)
- `ai-theme-plan-integration.test.ts` — end-to-end plan resolution against a real org via `setOrgPlan` (4 tests)
- `ai-quota.test.ts` — DB-backed counter + `checkAiQuota` incl. day-boundary reset (16 tests)

## Test plan

- [ ] Free-plan AI image upload returns only basic Theme keys; gate accepts; toast prompts upgrade.
- [ ] Pro/Business AI image upload returns full 30 token overrides; theme applies.
- [ ] Hitting `5/day` on free plan returns 429 with the daily-limit toast.
- [ ] Date picker calendar inside themed form: selected date is `--bf-primary`, today highlight is `--bf-muted`, surface is `--bf-input`.
- [ ] Multi-select dropdown popup matches input fill.
- [ ] Phone input + unchecked checkbox match input fill.
- [ ] Billing UI shows Pro/Free as **Downgrade** when on Business; Free as **Downgrade** when on Pro; current tier shows **Current**.

## Schema migration

Adds `ai_generation_counts` table — `drizzle/20260430160000_ai_generation_counts/migration.sql`. Run `bun db:migrate` (already applied locally during development).