### PR TITLE
fix(theme): match neutral input bg to Figma gray/50

### DIFF
--- a/src/lib/theme/theme-presets.ts
+++ b/src/lib/theme/theme-presets.ts
@@ -31,7 +31,7 @@ export const BASE_COLORS: Record<string, BaseColorTokens> = {
     accent: "#ededed",
     "accent-foreground": "#2e2e2e",
     border: "#ededed",
-    input: "#e0e0e0",
+    input: "#ffffff",
   },
   zinc: {
     background: "#ffffff",
@@ -105,7 +105,7 @@ export const DARK_BASE_COLORS: Record<string, BaseColorTokens> = {
     accent: "#363636",
     "accent-foreground": "#d1d1d1",
     border: "#363636",
-    input: "#363636",
+    input: "#1c1c1c",
   },
   zinc: {
     background: "#09090b",


### PR DESCRIPTION
## Summary
- Update `BASE_COLORS.neutral.input` from `#e0e0e0` → `#ffffff` (Figma `gray/50` light)
- Update `DARK_BASE_COLORS.neutral.input` from `#363636` → `#1c1c1c` (Figma `gray/50` dark)
- Propagates through `--bf-input` → `--form-input-bg`, so editor, preview, and live form all match the Figma input spec without further changes (the `form-input` utility already has the correct radius and hairline shadow).

## Test plan
- [x] `bun x tsc --noEmit` clean
- [x] Pre-push test suite (268/268) green
- [ ] Visual check: light + dark mode form input bg matches Figma `23536-5319` / `23979-5881`