### PR TITLE
fix(build): externalize @vercel/og to ship Geist-Regular.ttf to Vercel

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -150,6 +150,12 @@ const config = defineConfig({
       "postgres",
       "drizzle-orm",
       "drizzle-orm/postgres-js",
+      // Keep @vercel/og resolved from node_modules at runtime so the package's
+      // sibling `Geist-Regular.ttf` (read at module load via
+      // `new URL("./Geist-Regular.ttf", import.meta.url)`) ships intact into
+      // the Vercel function. Inlining it into the SSR bundle drops the .ttf
+      // and crashes with ENOENT on first import in /var/task/_ssr/.
+      "@vercel/og",
     ],
   },
   environments: {


### PR DESCRIPTION
@vercel/og's node entry reads `./Geist-Regular.ttf` synchronously at module load via `new URL(..., import.meta.url)`. When the package is inlined into the SSR bundle, the .ttf is not emitted next to the bundled JS, so the Vercel function crashes with ENOENT on the first import (before any handler runs, regardless of custom `fonts`).

Marking it external keeps the package resolved from node_modules at runtime, so the .ttf sibling file is colocated correctly.