### PR TITLE
fix(og): load font over HTTP and stop redirecting bare form URLs

### DIFF
--- a/src/lib/config/app-config.ts
+++ b/src/lib/config/app-config.ts
@@ -1,5 +1,10 @@
 export const APP_NAME = import.meta.env.VITE_APP_NAME || "Reform";
-export const APP_WEBSITE_URL = import.meta.env.VITE_APP_WEBSITE_URL || "https://betterforms.com";
+// Trailing slash stripped at the source so callers can safely concat paths
+// without producing `//api/...`. `VITE_APP_WEBSITE_URL` is sometimes set with
+// a trailing slash (e.g. preview deploys), so normalize once here.
+export const APP_WEBSITE_URL = (
+  import.meta.env.VITE_APP_WEBSITE_URL || "https://betterforms.com"
+).replace(/\/+$/, "");
 
 /** Default icon identifier used throughout the app (forms, pickers, previews) */
 export const DEFAULT_ICON = "default-icon";

--- a/src/lib/og/url.test.ts
+++ b/src/lib/og/url.test.ts
@@ -9,8 +9,7 @@ describe("buildOgImageUrl", () => {
       title: "Hi",
       description: "World",
     });
-    const origin = APP_WEBSITE_URL.replace(/\/+$/, "");
-    expect(url.startsWith(`${origin}/api/og/abc/`)).toBeTruthy();
+    expect(url.startsWith(`${APP_WEBSITE_URL}/api/og/abc/`)).toBeTruthy();
     expect(url.endsWith(".png")).toBeTruthy();
   });
 

--- a/src/lib/og/url.ts
+++ b/src/lib/og/url.ts
@@ -18,8 +18,5 @@ export type BuildOgImageUrlInput = {
  */
 export const buildOgImageUrl = ({ formId, title, description }: BuildOgImageUrlInput): string => {
   const hash = computeOgHash({ title, description });
-  // VITE_APP_WEBSITE_URL may include a trailing slash (e.g. preview deploys);
-  // strip it so the path concat doesn't produce `//api/og/...`.
-  const origin = APP_WEBSITE_URL.replace(/\/+$/, "");
-  return `${origin}/api/og/${formId}/${hash}.png`;
+  return `${APP_WEBSITE_URL}/api/og/${formId}/${hash}.png`;
 };

--- a/src/routes/api/og/$formId/$hash.tsx
+++ b/src/routes/api/og/$formId/$hash.tsx
@@ -1,28 +1,40 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ImageResponse } from "@vercel/og";
 import { and, eq } from "drizzle-orm";
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import { db } from "@/db";
 import { formVersions, forms } from "@/db/schema";
+import { APP_WEBSITE_URL } from "@/lib/config/app-config";
 import { FORM_ID_RE } from "@/lib/config/embed-cors";
 import { computeOgHash } from "@/lib/og/hash";
 import { resolveOgInputs } from "@/lib/og/resolve-inputs";
 import { OgCard } from "@/lib/og/template";
 import { formCacheTag } from "@/lib/server-fn/cdn-cache";
 
-const FONT_PATH = path.join(
-  process.cwd(),
-  "public/fonts/inter-variable/fonts/inter-variable-latin.woff2",
-);
+// Fetch the font from the deployed origin instead of `process.cwd()/public/...`.
+// Vercel serves `public/` from the static CDN; the serverless function bundle
+// at /var/task does NOT contain it, so `readFile` would ENOENT. The first
+// invocation pays one HTTP round-trip; subsequent warm invocations reuse the
+// module-scope promise.
+const FONT_URL = `${APP_WEBSITE_URL}/fonts/inter-variable/fonts/inter-variable-latin.woff2`;
 
-let cachedFont: ArrayBuffer | null = null;
-const loadFont = async (): Promise<ArrayBuffer> => {
-  if (cachedFont) return cachedFont;
-  const buf = await readFile(FONT_PATH);
-  const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
-  cachedFont = ab;
-  return ab;
+// Cache the in-flight Promise (not just the resolved buffer) so two cold
+// requests racing the first cold start don't double-fetch. On rejection we
+// null it out so a retry isn't poisoned forever.
+let fontPromise: Promise<ArrayBuffer> | null = null;
+const loadFont = (): Promise<ArrayBuffer> => {
+  if (!fontPromise) {
+    fontPromise = (async () => {
+      const res = await fetch(FONT_URL);
+      if (!res.ok) {
+        throw new Error(`Failed to fetch OG font (${res.status}) from ${FONT_URL}`);
+      }
+      return res.arrayBuffer();
+    })().catch((err) => {
+      fontPromise = null;
+      throw err;
+    });
+  }
+  return fontPromise;
 };
 
 const NOT_FOUND_HEADERS = {
@@ -62,6 +74,12 @@ export const Route = createFileRoute("/api/og/$formId/$hash")({
           return new Response("not_found", { status: 404, headers: NOT_FOUND_HEADERS });
         }
 
+        // Kick off the font fetch in parallel with the version query — saves
+        // ~1 RTT on cold starts. Detach the rejection handler from the early
+        // 404 path so an unawaited rejection can't crash the worker.
+        const fontPromise = loadFont();
+        fontPromise.catch(() => {});
+
         const [version] = form.lastPublishedVersionId
           ? await db
               .select({
@@ -86,7 +104,7 @@ export const Route = createFileRoute("/api/og/$formId/$hash")({
           return new Response("hash_mismatch", { status: 404, headers: NOT_FOUND_HEADERS });
         }
 
-        const fontData = await loadFont();
+        const fontData = await fontPromise;
 
         return new ImageResponse(
           <OgCard

--- a/src/routes/f/$formId.tsx
+++ b/src/routes/f/$formId.tsx
@@ -87,8 +87,8 @@ const CustomDomainFormIdRoute = () => {
     title: search.hideTitle ? "hidden" : "visible",
     background: isTransparent ? "transparent" : "solid",
     alignment: search.alignLeft ? "left" : "center",
-    dynamicHeight: search.dynamicHeight,
-    dynamicWidth: search.dynamicWidth,
+    dynamicHeight: search.dynamicHeight ?? false,
+    dynamicWidth: search.dynamicWidth ?? false,
   };
 
   const customization = useMemo(
@@ -179,14 +179,16 @@ export const Route = createFileRoute("/f/$formId")({
   notFoundComponent: CustomDomainNotFound,
   validateSearch: zodValidator(
     z.object({
-      transparentBackground: z.boolean().optional().default(false),
+      // No `.default()` — would 307-redirect bare URLs to a canonical form
+      // with all defaults appended, breaking link-preview crawlers.
+      transparentBackground: z.boolean().optional(),
       transparent: z.coerce.boolean().optional(),
-      popup: z.coerce.boolean().optional().default(false),
-      hideTitle: z.coerce.boolean().optional().default(false),
-      alignLeft: z.coerce.boolean().optional().default(false),
+      popup: z.coerce.boolean().optional(),
+      hideTitle: z.coerce.boolean().optional(),
+      alignLeft: z.coerce.boolean().optional(),
       originPage: z.string().optional(),
-      dynamicHeight: z.coerce.boolean().optional().default(false),
-      dynamicWidth: z.coerce.boolean().optional().default(false),
+      dynamicHeight: z.coerce.boolean().optional(),
+      dynamicWidth: z.coerce.boolean().optional(),
     }),
   ),
 });

--- a/src/routes/forms/$formId.tsx
+++ b/src/routes/forms/$formId.tsx
@@ -88,8 +88,8 @@ const PublicFormRoute = () => {
     title: search.hideTitle ? "hidden" : "visible",
     background: isTransparent ? "transparent" : "solid",
     alignment: search.alignLeft ? "left" : "center",
-    dynamicHeight: search.dynamicHeight,
-    dynamicWidth: search.dynamicWidth,
+    dynamicHeight: search.dynamicHeight ?? false,
+    dynamicWidth: search.dynamicWidth ?? false,
   };
 
   // Dual-mode CSS — both light and dark tokens are emitted; the root `.dark`
@@ -192,14 +192,17 @@ export const Route = createFileRoute("/forms/$formId")({
   notFoundComponent: NotFound,
   validateSearch: zodValidator(
     z.object({
-      transparentBackground: z.boolean().optional().default(false),
+      // No `.default()` on these — TanStack Router would canonicalize the URL
+      // by 307-redirecting `/forms/$formId` to `/forms/$formId?popup=false&…`,
+      // which strips link-preview bots that don't follow redirects.
+      transparentBackground: z.boolean().optional(),
       transparent: z.coerce.boolean().optional(),
-      popup: z.coerce.boolean().optional().default(false),
-      hideTitle: z.coerce.boolean().optional().default(false),
-      alignLeft: z.coerce.boolean().optional().default(false),
+      popup: z.coerce.boolean().optional(),
+      hideTitle: z.coerce.boolean().optional(),
+      alignLeft: z.coerce.boolean().optional(),
       originPage: z.string().optional(),
-      dynamicHeight: z.coerce.boolean().optional().default(false),
-      dynamicWidth: z.coerce.boolean().optional().default(false),
+      dynamicHeight: z.coerce.boolean().optional(),
+      dynamicWidth: z.coerce.boolean().optional(),
     }),
   ),
 });

--- a/src/routes/forms/$i8n.$formId.tsx
+++ b/src/routes/forms/$i8n.$formId.tsx
@@ -21,8 +21,8 @@ const PublicFormRoute = () => {
     title: search.hideTitle ? "hidden" : "visible",
     background: isTransparent ? "transparent" : "solid",
     alignment: search.alignLeft ? "left" : "center",
-    dynamicHeight: search.dynamicHeight,
-    dynamicWidth: search.dynamicWidth,
+    dynamicHeight: search.dynamicHeight ?? false,
+    dynamicWidth: search.dynamicWidth ?? false,
   };
 
   return (
@@ -75,21 +75,17 @@ export const Route = createFileRoute("/forms/$i8n/$formId")({
   notFoundComponent: NotFound,
   validateSearch: zodValidator(
     z.object({
-      // Transparent background for iframe embeds
-      transparentBackground: z.boolean().optional().default(false),
+      // No `.default()` here — TanStack Router would canonicalize a bare URL
+      // to `?popup=false&…`, breaking link-preview bots that don't follow
+      // redirects.
+      transparentBackground: z.boolean().optional(),
       transparent: z.coerce.boolean().optional(), // Alias for transparentBackground
-      // Popup mode (embedded via popup.js)
-      popup: z.coerce.boolean().optional().default(false),
-      // Hide form title in popup
-      hideTitle: z.coerce.boolean().optional().default(false),
-      // Align form content to the left
-      alignLeft: z.coerce.boolean().optional().default(false),
-      // Origin page for tracking
+      popup: z.coerce.boolean().optional(),
+      hideTitle: z.coerce.boolean().optional(),
+      alignLeft: z.coerce.boolean().optional(),
       originPage: z.string().optional(),
-      // Dynamic height for standard iframe embeds
-      dynamicHeight: z.coerce.boolean().optional().default(false),
-      // Dynamic width — form fields fill full width with padding
-      dynamicWidth: z.coerce.boolean().optional().default(false),
+      dynamicHeight: z.coerce.boolean().optional(),
+      dynamicWidth: z.coerce.boolean().optional(),
     }),
   ),
 });


### PR DESCRIPTION
The `/api/og/$formId/$hash.png` endpoint was 500ing because it tried to read `inter-variable-latin.woff2` from `process.cwd()/public/...`, but Vercel serves `public/` from the static CDN and never bundles it into the serverless function at `/var/task`. Fetch the font from the deployed origin instead, dedupe via a module-scope in-flight promise so two cold requests don't double-fetch, and kick the fetch off in parallel with the version DB query.

Separately, `/forms/$formId` 307-redirected to itself with all default search params appended (`?popup=false&hideTitle=false&...`) because the zod validator filled defaults that didn't match the URL, triggering the router's canonical-URL redirect. Most link-preview crawlers (Twitter, Discord, occasionally Slack) don't follow redirects and saw nothing. Drop `.default(false)` from the embed search params and coerce `?? false` at the two consumer sites that needed `boolean`.

Also normalize `APP_WEBSITE_URL` once at the config layer so callers don't repeat the trailing-slash strip.