### PR TITLE
fix(og): drop custom Inter font, surface render errors, bump cache key

### DIFF
--- a/src/lib/og/hash.ts
+++ b/src/lib/og/hash.ts
@@ -5,7 +5,7 @@ import { createHash } from "node:crypto";
  * The next HTML render will emit a new URL for every form, naturally
  * invalidating every form's edge-cached OG image without manual purge.
  */
-export const TEMPLATE_VERSION = 1;
+export const TEMPLATE_VERSION = 2;
 
 export type OgHashInput = {
   title: string;

--- a/src/lib/og/template.tsx
+++ b/src/lib/og/template.tsx
@@ -32,7 +32,6 @@ export const OgCard = ({ title, description, icon, themeColorName }: OgCardProps
         flexDirection: "column",
         background: tint,
         padding: "64px",
-        fontFamily: "Inter",
         color: "#0a0a0a",
       }}
     >

--- a/src/routes/api/og/$formId/$hash.tsx
+++ b/src/routes/api/og/$formId/$hash.tsx
@@ -3,42 +3,21 @@ import { ImageResponse } from "@vercel/og";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { formVersions, forms } from "@/db/schema";
-import { APP_WEBSITE_URL } from "@/lib/config/app-config";
 import { FORM_ID_RE } from "@/lib/config/embed-cors";
 import { computeOgHash } from "@/lib/og/hash";
 import { resolveOgInputs } from "@/lib/og/resolve-inputs";
 import { OgCard } from "@/lib/og/template";
 import { formCacheTag } from "@/lib/server-fn/cdn-cache";
 
-// Fetch the font from the deployed origin instead of `process.cwd()/public/...`.
-// Vercel serves `public/` from the static CDN; the serverless function bundle
-// at /var/task does NOT contain it, so `readFile` would ENOENT. The first
-// invocation pays one HTTP round-trip; subsequent warm invocations reuse the
-// module-scope promise.
-const FONT_URL = `${APP_WEBSITE_URL}/fonts/inter-variable/fonts/inter-variable-latin.woff2`;
-
-// Cache the in-flight Promise (not just the resolved buffer) so two cold
-// requests racing the first cold start don't double-fetch. On rejection we
-// null it out so a retry isn't poisoned forever.
-let fontPromise: Promise<ArrayBuffer> | null = null;
-const loadFont = (): Promise<ArrayBuffer> => {
-  if (!fontPromise) {
-    fontPromise = (async () => {
-      const res = await fetch(FONT_URL);
-      if (!res.ok) {
-        throw new Error(`Failed to fetch OG font (${res.status}) from ${FONT_URL}`);
-      }
-      return res.arrayBuffer();
-    })().catch((err) => {
-      fontPromise = null;
-      throw err;
-    });
-  }
-  return fontPromise;
-};
-
 const NOT_FOUND_HEADERS = {
   "Cache-Control": "public, max-age=60, s-maxage=60",
+  "Content-Type": "text/plain",
+};
+
+// Short TTL on errors so a transient failure doesn't poison the edge cache for
+// a year (the success path uses `immutable, max-age=31536000`).
+const ERROR_HEADERS = {
+  "Cache-Control": "public, max-age=30, s-maxage=30",
   "Content-Type": "text/plain",
 };
 
@@ -74,12 +53,6 @@ export const Route = createFileRoute("/api/og/$formId/$hash")({
           return new Response("not_found", { status: 404, headers: NOT_FOUND_HEADERS });
         }
 
-        // Kick off the font fetch in parallel with the version query — saves
-        // ~1 RTT on cold starts. Detach the rejection handler from the early
-        // 404 path so an unawaited rejection can't crash the worker.
-        const fontPromise = loadFont();
-        fontPromise.catch(() => {});
-
         const [version] = form.lastPublishedVersionId
           ? await db
               .select({
@@ -104,28 +77,36 @@ export const Route = createFileRoute("/api/og/$formId/$hash")({
           return new Response("hash_mismatch", { status: 404, headers: NOT_FOUND_HEADERS });
         }
 
-        const fontData = await fontPromise;
-
-        return new ImageResponse(
-          <OgCard
-            description={og.description}
-            icon={og.icon}
-            themeColorName={og.themeColorName}
-            title={og.title}
-          />,
-          {
-            width: 1200,
-            height: 630,
-            fonts: [
-              { name: "Inter", data: fontData, weight: 400, style: "normal" },
-              { name: "Inter", data: fontData, weight: 700, style: "normal" },
-            ],
+        // Buffer the streaming PNG so render errors surface here instead of
+        // silently truncating the body to 0 bytes (which the edge then caches
+        // as `immutable` for a year). Use @vercel/og's bundled Geist by
+        // omitting `fonts` — eliminates a class of font-loading failures.
+        try {
+          const image = new ImageResponse(
+            <OgCard
+              description={og.description}
+              icon={og.icon}
+              themeColorName={og.themeColorName}
+              title={og.title}
+            />,
+            { width: 1200, height: 630 },
+          );
+          const body = await image.arrayBuffer();
+          return new Response(body, {
+            status: 200,
             headers: {
+              "Content-Type": "image/png",
               "Cache-Control": "public, max-age=31536000, immutable",
               "Cache-Tag": formCacheTag(params.formId),
             },
-          },
-        );
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return new Response(`og_render_failed: ${message}`, {
+            status: 500,
+            headers: ERROR_HEADERS,
+          });
+        }
       },
     },
   },


### PR DESCRIPTION
After fixing the 500 from the missing public/ font path, the endpoint started returning 200 with an empty 0-byte body that Vercel cached as `immutable, max-age=31536000` for a year. The empty body means Satori or resvg threw mid-stream, after `ImageResponse` already sent headers, so the failure never surfaced as an HTTP error.

- Buffer the image into an ArrayBuffer before responding so streaming- time render errors throw at the await and hit our try/catch — which now returns 500 with the underlying message and a 30s cache TTL, preventing any future failure from poisoning the edge for a year.
- Drop the custom Inter font config (and the HTTP fetch path it required). @vercel/og bundles Geist as its default; using that removes font decoding as a variable on the streaming render path.
- Bump TEMPLATE_VERSION to 2 so every form's OG URL rotates on the next HTML render, bypassing the cached empty PNGs without needing a manual edge-cache purge.