### PR TITLE
feat(og): redesign card to match app aesthetic + render sprite icons

### DIFF
--- a/src/lib/og/hash.ts
+++ b/src/lib/og/hash.ts
@@ -5,7 +5,7 @@ import { createHash } from "node:crypto";
  * The next HTML render will emit a new URL for every form, naturally
  * invalidating every form's edge-cached OG image without manual purge.
  */
-export const TEMPLATE_VERSION = 2;
+export const TEMPLATE_VERSION = 3;
 
 export type OgHashInput = {
   title: string;

--- a/src/lib/og/sprite-icon.ts
+++ b/src/lib/og/sprite-icon.ts
@@ -1,0 +1,51 @@
+// Shared sprite-icon extraction. The form's icon field can be a sprite name
+// (e.g. "fingerprint-03"), an uploaded image URL, or null. Satori (used by
+// @vercel/og) doesn't render <svg>/<use> tags directly — it only rasterizes
+// images via <img>. So we extract the matching <symbol> from the bundled
+// sprite, wrap it in a complete <svg>, and return a base64 data URL the
+// OG card can use as <img src={...}>.
+
+const NAME_RE = /^[a-z0-9-]{1,64}$/i;
+const URL_RE = /^https?:\/\//i;
+
+const sanitizeSvgFragment = (fragment: string): string =>
+  fragment
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/\son[a-z]+\s*=\s*"[^"]*"/gi, "")
+    .replace(/\son[a-z]+\s*=\s*'[^']*'/gi, "");
+
+export const isIconUrl = (icon: string | null | undefined): boolean => !!icon && URL_RE.test(icon);
+
+export const isSpriteIconName = (icon: string | null | undefined): boolean =>
+  !!icon && NAME_RE.test(icon);
+
+/**
+ * Extract a single icon symbol from the bundled sprite and return a complete,
+ * standalone SVG document with the requested fill applied. Returns `null` if
+ * the symbol isn't present.
+ */
+export const extractStandaloneIconSvg = (
+  sprite: string,
+  name: string,
+  fill: string,
+): string | null => {
+  if (!isSpriteIconName(name)) return null;
+  const re = new RegExp(`<symbol[^>]*\\bid="${name}"[^>]*>([\\s\\S]*?)</symbol>`, "i");
+  const match = sprite.match(re);
+  if (!match) return null;
+  const inner = sanitizeSvgFragment(match[1]);
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="${fill}">${inner}</svg>`;
+};
+
+/**
+ * Returns a `data:image/svg+xml;base64,...` URL for the given sprite icon, or
+ * null if the symbol isn't found. Satori's <img> can rasterize the data URL
+ * directly without a network round-trip.
+ */
+export const buildIconDataUrl = (sprite: string, name: string, fill: string): string | null => {
+  const svg = extractStandaloneIconSvg(sprite, name, fill);
+  if (!svg) return null;
+  // `Buffer` is fine here; this module only runs in the server function.
+  const base64 = Buffer.from(svg, "utf8").toString("base64");
+  return `data:image/svg+xml;base64,${base64}`;
+};

--- a/src/lib/og/template.tsx
+++ b/src/lib/og/template.tsx
@@ -2,26 +2,23 @@ import { THEME_COLORS } from "@/lib/theme/theme-presets";
 
 const DEFAULT_ACCENT = THEME_COLORS.neutral.primary;
 
-const tintHex = (hex: string, alpha = 0.08): string => {
-  // satori does NOT support rgba()/oklch() — append two hex digits for alpha.
-  const a = Math.round(Math.max(0, Math.min(1, alpha)) * 255)
-    .toString(16)
-    .padStart(2, "0");
-  return `${hex}${a}`;
-};
+const BG = "#0a0a0a";
+const FG = "#fafafa";
+const FG_MUTED = "#a3a3a3";
+const FG_DIM = "#525252";
 
 export type OgCardProps = {
   title: string;
   description: string;
-  icon?: string | null;
+  /** Absolute URL or data URL for the icon. Sprite names are pre-resolved by the handler. */
+  iconUrl?: string | null;
   themeColorName?: string | null;
 };
 
-export const OgCard = ({ title, description, icon, themeColorName }: OgCardProps) => {
+export const OgCard = ({ title, description, iconUrl, themeColorName }: OgCardProps) => {
   const accent =
     (themeColorName && THEME_COLORS[themeColorName as keyof typeof THEME_COLORS]?.primary) ||
     DEFAULT_ACCENT;
-  const tint = tintHex(accent, 0.08);
 
   return (
     <div
@@ -29,54 +26,58 @@ export const OgCard = ({ title, description, icon, themeColorName }: OgCardProps
         width: "1200px",
         height: "630px",
         display: "flex",
-        flexDirection: "column",
-        background: tint,
-        padding: "64px",
-        color: "#0a0a0a",
+        background: BG,
+        padding: "80px",
+        color: FG,
       }}
     >
-      <div style={{ display: "flex", alignItems: "center" }}>
-        {icon ? (
+      <div
+        style={{
+          width: "200px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        {iconUrl ? (
+          // eslint-disable-next-line jsx-a11y/alt-text
+          <img src={iconUrl} width={140} height={140} style={{ opacity: 0.9 }} />
+        ) : (
           <div
             style={{
-              width: "72px",
-              height: "72px",
-              borderRadius: "20px",
-              background: "#ffffff",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              fontSize: "40px",
-              boxShadow: "0 1px 2px rgba(0,0,0,0.06)",
+              fontFamily: "serif",
+              fontStyle: "italic",
+              fontSize: "140px",
+              fontWeight: 400,
+              color: FG_DIM,
+              lineHeight: 1,
             }}
           >
-            {icon}
+            f.
           </div>
-        ) : (
-          <div style={{ width: "72px", height: "72px" }} />
         )}
       </div>
 
       <div
         style={{
+          flex: 1,
           display: "flex",
           flexDirection: "column",
-          flex: 1,
           justifyContent: "center",
-          marginTop: "32px",
+          marginLeft: "40px",
         }}
       >
         <div
           style={{
             fontSize: "72px",
             fontWeight: 700,
-            lineHeight: 1.1,
-            letterSpacing: "-0.02em",
-            color: "#0a0a0a",
-            display: "-webkit-box",
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: "vertical",
-            overflow: "hidden",
+            lineHeight: 1.05,
+            letterSpacing: "-0.025em",
+            color: FG,
+            display: "flex",
           }}
         >
           {title}
@@ -84,42 +85,38 @@ export const OgCard = ({ title, description, icon, themeColorName }: OgCardProps
         {description ? (
           <div
             style={{
-              marginTop: "24px",
+              marginTop: "28px",
               fontSize: "30px",
               lineHeight: 1.4,
-              color: "#525252",
-              display: "-webkit-box",
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: "vertical",
-              overflow: "hidden",
+              color: FG_MUTED,
+              display: "flex",
             }}
           >
             {description}
           </div>
         ) : null}
-      </div>
-
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-        }}
-      >
         <div
           style={{
-            width: "120px",
-            height: "6px",
-            borderRadius: "999px",
-            background: accent,
+            display: "flex",
+            alignItems: "center",
+            gap: "16px",
+            marginTop: "auto",
+            paddingTop: "48px",
           }}
-        />
-        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        >
           <div
             style={{
-              fontSize: "24px",
+              width: "32px",
+              height: "4px",
+              borderRadius: "999px",
+              background: accent,
+            }}
+          />
+          <div
+            style={{
+              fontSize: "22px",
               fontWeight: 600,
-              color: "#737373",
+              color: FG_MUTED,
               letterSpacing: "-0.01em",
             }}
           >

--- a/src/routes/api/og/$formId/$hash.tsx
+++ b/src/routes/api/og/$formId/$hash.tsx
@@ -1,13 +1,20 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ImageResponse } from "@vercel/og";
 import { and, eq } from "drizzle-orm";
+// `?raw` inlines the sprite at build time so the function bundle on Vercel
+// (where /var/task has no public/) can extract <symbol> bodies for OG icons.
+import spriteSvg from "../../../../../public/sprite.svg?raw";
 import { db } from "@/db";
 import { formVersions, forms } from "@/db/schema";
 import { FORM_ID_RE } from "@/lib/config/embed-cors";
 import { computeOgHash } from "@/lib/og/hash";
 import { resolveOgInputs } from "@/lib/og/resolve-inputs";
+import { buildIconDataUrl, isIconUrl, isSpriteIconName } from "@/lib/og/sprite-icon";
 import { OgCard } from "@/lib/og/template";
 import { formCacheTag } from "@/lib/server-fn/cdn-cache";
+
+// Light icon fill against the dark card background.
+const ICON_FILL = "#fafafa";
 
 const NOT_FOUND_HEADERS = {
   "Cache-Control": "public, max-age=60, s-maxage=60",
@@ -77,6 +84,17 @@ export const Route = createFileRoute("/api/og/$formId/$hash")({
           return new Response("hash_mismatch", { status: 404, headers: NOT_FOUND_HEADERS });
         }
 
+        // Resolve the form's icon to something Satori can rasterize via <img>.
+        // Sprite names (e.g. "fingerprint-03") are extracted from the bundled
+        // sprite into a data URL; uploaded images come through as absolute URLs;
+        // anything else falls back to the `f.` brand mark inside OgCard.
+        let iconUrl: string | null = null;
+        if (isIconUrl(og.icon)) {
+          iconUrl = og.icon;
+        } else if (og.icon && isSpriteIconName(og.icon)) {
+          iconUrl = buildIconDataUrl(spriteSvg, og.icon, ICON_FILL);
+        }
+
         // Buffer the streaming PNG so render errors surface here instead of
         // silently truncating the body to 0 bytes (which the edge then caches
         // as `immutable` for a year). Use @vercel/og's bundled Geist by
@@ -85,7 +103,7 @@ export const Route = createFileRoute("/api/og/$formId/$hash")({
           const image = new ImageResponse(
             <OgCard
               description={og.description}
-              icon={og.icon}
+              iconUrl={iconUrl}
               themeColorName={og.themeColorName}
               title={og.title}
             />,


### PR DESCRIPTION
## Summary

Two visible problems in the per-form OG card on production after PR #71 shipped:

- The card used a light pink/cream tinted background that didn't match the app's dark static OG at `/metadata/og.png` — visually inconsistent for link previews.
- The form's icon was a sprite name (e.g. `fingerprint-03`) that Satori was rendering as raw *text* inside a 72px white box, overflowing the container.

## Changes

- **New `src/lib/og/sprite-icon.ts`** — extracts a single `<symbol>` from the bundled `sprite.svg` (`?raw` import) and emits a base64 SVG data URL. Satori does not render `<svg>`/`<use>` tags but does rasterize `<img src="data:image/svg+xml;base64,...">`.
- **OG handler** now resolves `og.icon` to an `iconUrl`:
  - http(s) URL → pass through (uploaded images)
  - sprite name → data URL via the helper
  - anything else → null, OgCard falls back to an italic `f.` brand mark
- **OgCard redesign** to match the static app OG aesthetic: `#0a0a0a` background, white title, `#a3a3a3` description, two-column layout with icon left + title/description right, small theme-color accent dot + small "Reform" wordmark.
- **Bump `TEMPLATE_VERSION` to 3** so every form's OG URL rotates and bypasses any CDN-cached PNGs from the previous designs.

## Test plan

- [ ] Visit a published form's page, view source — `og:image` URL hash differs from the previous deploy
- [ ] Open that URL — dark card, sprite icon rendered as a clean white SVG (or `f.` fallback if no icon)
- [ ] Re-paste the form link in Slack with a `#v2` fragment to force a fresh unfurl — preview matches app aesthetic
- [x] `bun x tsc --noEmit` clean
- [x] `bun run test` — all OG tests pass
- [x] `bun fix` — no new warnings (18 pre-existing cycle warnings unchanged)