### PR TITLE
chore(deps): patch @tanstack/router-core for cross-realm RawStream instanceof bug (Vite dev RSC)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -161,6 +161,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@tanstack/router-core@1.169.2": "patches/@tanstack%2Frouter-core@1.169.2.patch",
+  },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
 

--- a/package.json
+++ b/package.json
@@ -183,5 +183,8 @@
     "vitest": "^3.2.4",
     "web-vitals": "^5.1.0"
   },
-  "packageManager": "bun@1.2.14"
+  "packageManager": "bun@1.2.14",
+  "patchedDependencies": {
+    "@tanstack/router-core@1.169.2": "patches/@tanstack%2Frouter-core@1.169.2.patch"
+  }
 }

--- a/patches/@tanstack%2Frouter-core@1.169.2.patch
+++ b/patches/@tanstack%2Frouter-core@1.169.2.patch
@@ -1,0 +1,31 @@
+diff --git a/dist/esm/ssr/serializer/RawStream.js b/dist/esm/ssr/serializer/RawStream.js
+index 60b8321ce8643733d04aa342420b11b2d47de234..dc295b9b62de3f6c1d174cb85ccfafa74cb85f45 100644
+--- a/dist/esm/ssr/serializer/RawStream.js
++++ b/dist/esm/ssr/serializer/RawStream.js
+@@ -16,7 +16,7 @@ import { createPlugin, createStream } from "seroval";
+ var RawStream = class {
+ 	constructor(stream, options) {
+ 		this.stream = stream;
+-		this.hint = options?.hint ?? "binary";
++		this.hint = options?.hint ?? "binary"; this[Symbol.for("tanstack.router.RawStream")] = true;
+ 	}
+ };
+ const BufferCtor = globalThis.Buffer;
+@@ -193,7 +193,7 @@ const RawStreamSSRPlugin = /* @__PURE__ */ createPlugin({
+ 		}
+ 	})],
+ 	test(value) {
+-		return value instanceof RawStream;
++		return value !== null && typeof value === "object" && value[Symbol.for("tanstack.router.RawStream")] === true;
+ 	},
+ 	parse: {
+ 		sync(value, ctx, _data) {
+@@ -244,7 +244,7 @@ function createRawStreamRPCPlugin(onRawStream) {
+ 	return /* @__PURE__ */ createPlugin({
+ 		tag: "tss/RawStream",
+ 		test(value) {
+-			return value instanceof RawStream;
++			return value !== null && typeof value === "object" && value[Symbol.for("tanstack.router.RawStream")] === true;
+ 		},
+ 		parse: {
+ 			async async(value, ctx, _data) {


### PR DESCRIPTION
## Summary

Adds a `bun patch` workaround for an upstream bug in `@tanstack/router-core@1.169.2` that crashes RSC dehydration in Vite dev mode. **Production is unaffected** — this is a dev-only regression caused by Vite's per-environment module-runner loading the `RawStream` class into multiple realms, breaking the `instanceof RawStream` check in `RawStreamSSRPlugin.test`.

- Affected routes locally: `/rsc-test`, `/forms/$formId`, `/$slug`, `/f/$formId`
- Same routes on the Vercel deploy: working (`https://better-forms-mu.vercel.app/rsc-test`)

## What changed

- `patches/@tanstack%2Frouter-core@1.169.2.patch` — Symbol.for brand swap (3 hunks, 6 lines)
- `package.json` — `patchedDependencies` registration
- `bun.lock` — auto-updated by `bun install`

## The patch (3 hunks)

```diff
 var RawStream = class {
   constructor(stream, options) {
     this.stream = stream;
-    this.hint = options?.hint ?? "binary";
+    this.hint = options?.hint ?? "binary"; this[Symbol.for("tanstack.router.RawStream")] = true;
   }
 };
 ...
 // RawStreamSSRPlugin.test
-  return value instanceof RawStream;
+  return value !== null && typeof value === "object" && value[Symbol.for("tanstack.router.RawStream")] === true;
 ...
 // createRawStreamRPCPlugin().test — same change
```

`Symbol.for(...)` returns the same symbol across realms regardless of which module instance defined it, so the brand survives Vite's multi-env class duplication.

## Why not a docs change / config flag instead

Verified upstream code is the only path:

- `@tanstack/react-start-rsc/src/serialization.server.ts:183` constructs `new RawStream(stream, { hint: 'text' })` in the RSC env; the SSR seroval pipeline runs in a different env. There is no toggle for this.
- TanStack Server Components are flagged experimental in the docs. Our codebase follows the documented `createCompositeComponent` pattern verbatim — confirmed against the [Server Components → Composite (slots)](https://tanstack.com/start/latest/docs/framework/react/guide/server-components#composite-slots) example.
- Disabling `rsc.enabled` would forfeit the perf wins on the form routes. Patching the shared symptom is cheaper.

## Verification

| Route | Before | After |
|---|---|---|
| `/rsc-test` | Server: `SerovalUnsupportedTypeError`, client: hydration invariant | Renders with interactive Counter slot |
| `/forms/4262a7c9-bf22-4d5b-8e14-8512b291ff7e` | Same crash | Form renders cleanly with `<h1>`, text input, Next button |

Dev server log post-restart: zero seroval / RawStream / hydration errors.

`bun x tsc --noEmit` clean.

## Removal plan

Once upstream lands a fix (issue + PR drafted in `docs/plans/2026-05-07-rsc-rawstream-cross-realm-{issue,pr}.md`):

```bash
rm patches/@tanstack%2Frouter-core@1.169.2.patch
# remove the patchedDependencies block from package.json
bun install
```

## Test plan

- [ ] `bun install` on a fresh clone applies the patch (Bun reports `Resolved, downloaded and extracted [1]`)
- [ ] `bun dev` and visit `/rsc-test` — should render without the dev overlay
- [ ] `bun dev` and visit `/forms/<any-form-id>` — should render the form, not the seroval error page
- [ ] `bun run check` and `bun typecheck` pass
- [ ] CI / Vercel preview deploy still builds and serves correctly (production path is untouched)