### PR TITLE
fix(auth): safe post-login redirects + harden orphan-user provisioning

### DIFF
--- a/src/collections/init.ts
+++ b/src/collections/init.ts
@@ -45,10 +45,14 @@ export const initCollections = (queryClient: QueryClient, serverFns: ServerFns) 
     queryFn: serverFns.getWorkspacesWithForms,
     onInsert: async ({ transaction }) => {
       const ws = transaction.mutations[0].modified;
+      // sortIndex is forwarded so the server writes the workspace row and the
+      // per-user sort entry in a single transaction; that keeps the new
+      // workspace at the top after the refetch reconciles.
       await serverFns.createWorkspace({
         id: ws.id,
         organizationId: ws.organizationId,
         name: ws.name,
+        sortIndex: ws.sortIndex ?? undefined,
       });
     },
     onUpdate: async ({ transaction }) => {

--- a/src/collections/operations.ts
+++ b/src/collections/operations.ts
@@ -221,6 +221,7 @@ export const bulkPermanentDeleteFormsLocal = async (ids: string[]) => {
 export const createWorkspaceLocal = async (
   organizationId: string,
   name = "Workspace",
+  sortIndex: string | null = null,
 ): Promise<WorkspaceSummary> => {
   const { workspaces } = getInit();
   const id = crypto.randomUUID();
@@ -232,6 +233,7 @@ export const createWorkspaceLocal = async (
     createdByUserId: null,
     createdAt: now,
     updatedAt: now,
+    sortIndex,
     forms: [],
   };
   workspaces.insert(ws);
@@ -295,14 +297,6 @@ export const moveFormToWorkspaceLocal = async (formId: string, workspaceId: stri
     draft.workspaceId = workspaceId;
     draft.updatedAt = new Date().toISOString();
     draft.sortIndex = null;
-  });
-};
-
-export const renameFormLocal = async (formId: string, title: string) => {
-  const { formListings } = getInit();
-  formListings.update(formId, (draft: Record<string, unknown>) => {
-    draft.title = title;
-    draft.updatedAt = new Date().toISOString();
   });
 };
 

--- a/src/components/sidebar-item.tsx
+++ b/src/components/sidebar-item.tsx
@@ -14,6 +14,7 @@ export interface SidebarItemProps<
   isActive?: boolean;
   onClick?: () => void;
   prefix?: React.ReactNode;
+  className?: string;
 }
 
 export function SidebarItem<TRouter extends RegisteredRouter, TOptions>(
@@ -26,6 +27,7 @@ export function SidebarItem({
   onClick,
   prefix,
   children,
+  className,
 }: SidebarItemProps & { children?: React.ReactNode }): React.ReactNode {
   const Component: React.ElementType = linkOptions ? Link : SidebarMenuButton;
   const componentProps = linkOptions ?? { type: "button" as const };
@@ -39,6 +41,7 @@ export function SidebarItem({
         "text-sidebar-foreground",
         !isActive && "hover:bg-secondary",
         isActive && "bg-secondary text-sidebar-foreground",
+        className,
       )}
     >
       <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">

--- a/src/components/ui/app-header.tsx
+++ b/src/components/ui/app-header.tsx
@@ -536,6 +536,11 @@ const buildFormBuilderMenuItems = ({
       key: "analytics",
       label: "Analytics",
       onClick: onNavigateInsights,
+      // Analytics has nothing to show until the form has been published at
+      // least once — and routing into /insights for a never-published form
+      // crashes the Recharts bundle. Gate on the same flag share + version
+      // history use.
+      show: hasPublishedVersion,
     },
     {
       key: "customization",

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -73,13 +73,16 @@ function PhoneInput({
       <BasePhoneInput.default
         key={defaultCountry ?? "no-default"}
         // The wrapper carries the visual outline (drop-shadow recipe in
-        // light mode, just bg-input contrast in dark — same as every other
-        // input on the page; no borders in either mode). The two inner
-        // pieces (country select + number field) stay transparent and just
-        // butt together inside this shared surface. `[&]:` bumps specificity
-        // past react-phone-number-input's own defaults.
+        // light mode, just bg contrast in dark — same as every other input
+        // on the page; no borders in either mode). The two inner pieces
+        // (country select + number field) stay transparent and just butt
+        // together inside this shared surface. Surface is driven by the
+        // same `--form-input-bg` token the `form-input` utility uses so
+        // themed and unthemed pages stay consistent with other inputs.
+        // `[&]:` bumps specificity past react-phone-number-input's own
+        // defaults.
         className={cn(
-          "flex flex-row items-stretch overflow-hidden rounded-lg text-foreground elevation-sm dark:shadow-none [&]:bg-card dark:[&]:bg-input",
+          "flex flex-row items-stretch overflow-hidden rounded-lg text-foreground elevation-sm dark:shadow-none [&]:bg-[var(--form-input-bg,var(--color-gray-50))]",
           phoneInputSize === "sm" && "[&]:h-7",
           phoneInputSize === "lg" && "[&]:h-9",
           phoneInputSize === "default" && "[&]:h-8",

--- a/src/lib/auth/middleware.ts
+++ b/src/lib/auth/middleware.ts
@@ -8,6 +8,27 @@ import { formSettingsFeatureGates } from "@/lib/server-fn/plan-helpers";
 import type { FormProSettingsInput } from "@/lib/server-fn/plan-helpers";
 import { getOrgPlan } from "@/lib/server-fn/plan-helpers.server";
 
+// Paths that are valid serverFn / API endpoints but not user-navigable. If the
+// auth middleware fires for a request to one of these (e.g. a serverFn invoked
+// from a route loader during SSR), sending it back as the post-login redirect
+// target lands the user on a blank serverFn endpoint after login. Filter them
+// out so we only ever round-trip the user through a real page route.
+const INTERNAL_PATH_PREFIX = /^\/(?:_|api\/)/;
+
+export const pickPostLoginRedirect = (pathname: string, headers: Headers): string => {
+  if (!INTERNAL_PATH_PREFIX.test(pathname)) return pathname;
+  const referer = headers.get("referer");
+  if (referer) {
+    try {
+      const refPath = new URL(referer).pathname;
+      if (!INTERNAL_PATH_PREFIX.test(refPath)) return refPath;
+    } catch {
+      // malformed referer — fall through to default
+    }
+  }
+  return "/dashboard";
+};
+
 export const authMiddleware = createMiddleware().server(async ({ next }) => {
   const headers = getRequestHeaders();
   const session = await auth.api.getSession({ headers });
@@ -17,7 +38,7 @@ export const authMiddleware = createMiddleware().server(async ({ next }) => {
     const pathname = new URL(url).pathname;
     throw redirect({
       to: "/login",
-      search: { redirect: pathname },
+      search: { redirect: pickPostLoginRedirect(pathname, headers) },
     });
   }
 

--- a/src/lib/auth/safe-redirect.ts
+++ b/src/lib/auth/safe-redirect.ts
@@ -1,0 +1,14 @@
+// Whitelist of redirect paths the login form will use as `callbackURL` after
+// a successful signin. Rejects:
+// - paths not starting with `/` (no absolute URLs — open-redirect guard)
+// - paths starting with `//` (protocol-relative URLs — same open-redirect risk
+//   because browsers treat `//host` as `https://host`)
+// - paths starting with `/_` (TanStack internals like `/_serverFn/`) or
+//   `/api/` — they're valid endpoints but not user-navigable. Sending the user
+//   here lands them on a blank screen because serverFns and API routes don't
+//   render HTML on GET-without-body.
+// - paths containing chars outside the conservative slug set.
+export const SAFE_REDIRECT_PATTERN = /^\/(?![/_]|api\/)[a-zA-Z0-9\-_/$.~]+$/;
+
+export const isSafeRedirect = (path: string | undefined | null): path is string =>
+  typeof path === "string" && SAFE_REDIRECT_PATTERN.test(path);

--- a/src/lib/server-fn/workspaces.ts
+++ b/src/lib/server-fn/workspaces.ts
@@ -34,22 +34,44 @@ export const createWorkspace = createServerFn({ method: "POST" })
     workspaceSchema.pick({ organizationId: true, name: true }).extend({
       id: z.uuid().optional(),
       name: workspaceSchema.shape.name.optional().default("Workspace"),
+      sortIndex: z.string().optional(),
     }),
   )
   .handler(async ({ data, context }) => {
     const now = new Date();
+    const userId = context.session.user.id;
+    const workspaceId = data.id ?? crypto.randomUUID();
 
-    const [workspace] = await db
-      .insert(workspaces)
-      .values({
-        id: data.id ?? crypto.randomUUID(),
-        organizationId: data.organizationId,
-        createdByUserId: context.session.user.id,
-        name: data.name,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning();
+    // Insert workspace + per-user sort entry in one transaction so the
+    // subsequent client-side refetch of getWorkspaces always sees the joined
+    // sortIndex; otherwise the new workspace would briefly come back without a
+    // sort row and fall to the bottom of the sidebar.
+    const [workspace] = await db.transaction(async (tx) => {
+      const [ws] = await tx
+        .insert(workspaces)
+        .values({
+          id: workspaceId,
+          organizationId: data.organizationId,
+          createdByUserId: userId,
+          name: data.name,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+
+      if (data.sortIndex) {
+        await tx.insert(userWorkspaceOrder).values({
+          id: `${userId}:${workspaceId}`,
+          userId,
+          workspaceId,
+          sortIndex: data.sortIndex,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+
+      return [ws];
+    });
 
     return {
       workspace: {

--- a/src/lib/sort-utils.ts
+++ b/src/lib/sort-utils.ts
@@ -25,3 +25,19 @@ export const sortByManualOrder = <T extends { sortIndex?: string | null }>(
     if (bIdx) return 1;
     return fallback(a, b);
   });
+
+/**
+ * Lowest existing `sortIndex` in a list, or `null` if none have one yet.
+ * Pass to `generateKeyBetween(null, leading)` to produce an index that places
+ * a new item before every other.
+ */
+export const getLeadingSortIndex = (
+  items: readonly { sortIndex?: string | null }[],
+): string | null => {
+  let leading: string | null = null;
+  for (const item of items) {
+    const idx = item.sortIndex ?? null;
+    if (idx && (leading === null || idx < leading)) leading = idx;
+  }
+  return leading;
+};

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -40,25 +40,15 @@ import {
   HomeIcon,
   Loader2Icon,
   LogOutIcon,
-  MoreHorizontalIcon,
-  Pencil2Icon,
   PlusIcon,
   SearchIcon,
   SettingsIcon,
+  StarIcon,
   Trash2Icon,
   Undo2Icon,
   UsersIcon,
   XIcon,
 } from "@/components/ui/icons";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import Loader from "@/components/ui/loader";
 import { LogoToggle } from "@/components/ui/logo";
@@ -100,7 +90,6 @@ import {
   isInitialized as isCollectionsInitialized,
   bulkPermanentDeleteFormsLocal,
   permanentDeleteFormLocal,
-  renameFormLocal,
   reorderFavoriteLocal,
   reorderFormLocal,
   reorderWorkspaceLocal,
@@ -161,6 +150,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Outlet, useLocation, useParams, useRouter } from "@tanstack/react-router";
 import { createClientOnlyFn } from "@tanstack/react-start";
+import { generateKeyBetween } from "fractional-indexing";
 import {
   closestCenter,
   DndContext,
@@ -178,7 +168,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { generateOrderedIndexes, sortByManualOrder } from "@/lib/sort-utils";
+import { generateOrderedIndexes, getLeadingSortIndex, sortByManualOrder } from "@/lib/sort-utils";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatDistanceToNow } from "date-fns";
@@ -711,7 +701,11 @@ const AppSidebar = () => {
                 <CommandItem
                   onSelect={() => {
                     if (activeOrg) {
-                      createWorkspaceLocal(activeOrg.id, "New Workspace")
+                      const leadingSortIndex = generateKeyBetween(
+                        null,
+                        getLeadingSortIndex(workspacesData ?? []),
+                      );
+                      createWorkspaceLocal(activeOrg.id, "New Workspace", leadingSortIndex)
                         .then((workspace) => {
                           void router.navigate({
                             to: "/workspace/$workspaceId",
@@ -2216,7 +2210,7 @@ const WorkspaceRenameDialog = ({
   onKeyDown,
 }: WorkspaceRenameDialogProps) => (
   <Dialog open={open} onOpenChange={onOpenChange}>
-    <DialogContent>
+    <DialogContent className="gap-4 sm:max-w-md">
       <DialogHeader>
         <DialogTitle>Rename workspace</DialogTitle>
         <DialogDescription>Enter a new name for this workspace.</DialogDescription>
@@ -2382,7 +2376,6 @@ const SortableFavoriteItem = ({
   userId: string;
 }) => {
   const pathname = useLocation({ select: (s) => s.pathname });
-  const [renameOpen, setRenameOpen] = useState(false);
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: form.favoriteId,
     data: { type: "favorite" },
@@ -2424,96 +2417,21 @@ const SortableFavoriteItem = ({
             customization={form.customization as Record<string, string> | null | undefined}
           />
         }
+        className="group-hover/row:pe-7 group-has-[[data-state=open]]/row:pe-7"
       />
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <button
-              type="button"
-              aria-label="Favorite options"
-              onPointerDown={(e) => e.stopPropagation()}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-              }}
-              className="hover:bg-sidebar-active absolute top-1/2 right-2 z-10 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity group-hover/row:opacity-100 hover:text-foreground data-[state=open]:opacity-100"
-            />
-          }
-        >
-          <MoreHorizontalIcon className="size-3.5" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="start"
-          sideOffset={4}
-          className="w-48"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <DropdownMenuGroup>
-            <DropdownMenuLabel>Favorite</DropdownMenuLabel>
-            <DropdownMenuItem onClick={() => setRenameOpen(true)}>
-              <Pencil2Icon />
-              <span className="flex-1 text-left">Rename</span>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={handleUnfavorite}>
-              <Trash2Icon />
-              <span className="flex-1 text-left">Remove from favorites</span>
-            </DropdownMenuItem>
-          </DropdownMenuGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      {renameOpen && (
-        <FavoriteInlineRename
-          initialValue={form.title || ""}
-          onClose={() => setRenameOpen(false)}
-          onSubmit={(next) => {
-            renameFormLocal(form.id, next).catch(() => toast.error("Failed to rename form"));
-            setRenameOpen(false);
-          }}
-        />
-      )}
-    </div>
-  );
-};
-
-const FavoriteInlineRename = ({
-  initialValue,
-  onSubmit,
-  onClose,
-}: {
-  initialValue: string;
-  onSubmit: (value: string) => void;
-  onClose: () => void;
-}) => {
-  // eslint-disable-next-line react-doctor/no-derived-useState -- uncontrolled rename input; parent hands ownership to local state
-  const [value, setValue] = useState(initialValue);
-  const inputRef = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
-  const commitOrClose = () => {
-    const trimmed = value.trim();
-    if (trimmed) onSubmit(trimmed);
-    else onClose();
-  };
-  return (
-    <div className="px-2 py-1">
-      <input
-        ref={inputRef}
-        type="text"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onBlur={onClose}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            commitOrClose();
-          } else if (e.key === "Escape") {
-            onClose();
-          }
+      <button
+        type="button"
+        aria-label="Remove from favorites"
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          handleUnfavorite();
         }}
-        className="w-full rounded-md bg-secondary px-2 py-1 text-[13px] ring-1 ring-foreground/20 outline-hidden"
-        aria-label="Rename form"
-      />
+        className="hover:bg-sidebar-active absolute top-1/2 right-2 z-10 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity group-hover/row:opacity-100 hover:text-foreground"
+      >
+        <StarIcon className="size-3.5" />
+      </button>
     </div>
   );
 };

--- a/src/routes/_authenticated/-components/settings/account-settings-content.tsx
+++ b/src/routes/_authenticated/-components/settings/account-settings-content.tsx
@@ -161,7 +161,7 @@ const ThemeSelect = () => {
     <Select value={theme} onValueChange={handleThemeChange}>
       <SelectTrigger
         size="md"
-        className="shrink-0 rounded-lg border-0 bg-neutral-50 pr-2.5 pl-3 text-sm text-foreground capitalize shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] outline-1 -outline-offset-1 outline-transparent"
+        className="shrink-0 rounded-lg border-0 bg-popover pr-2.5 pl-3 text-sm text-popover-foreground capitalize shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] outline-1 -outline-offset-1 outline-transparent"
       >
         <SelectValue />
       </SelectTrigger>
@@ -357,7 +357,7 @@ export const AccountSettingsContent = () => {
                         );
                       }}
                       disabled={updateProfileMutation.isPending}
-                      className="h-[24px] w-[47px] rounded-lg bg-neutral-50 px-3 text-sm text-neutral-800 shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-neutral-200"
+                      className="h-[24px] w-[47px] rounded-lg bg-popover px-3 text-sm text-popover-foreground shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-muted"
                     >
                       Save
                     </InputGroupButton>
@@ -408,7 +408,7 @@ export const AccountSettingsContent = () => {
                         );
                       }}
                       disabled={updateProfileMutation.isPending}
-                      className="h-[24px] w-[47px] rounded-lg bg-neutral-50 px-3 text-sm text-neutral-800 shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-neutral-200"
+                      className="h-[24px] w-[47px] rounded-lg bg-popover px-3 text-sm text-popover-foreground shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-muted"
                     >
                       Save
                     </InputGroupButton>
@@ -504,7 +504,7 @@ const AvatarSection = ({
         variant="ghost"
         size="sm"
         prefix={<ImageIcon />}
-        className="h-[30px] rounded-lg bg-popover px-2 text-sm text-popover-foreground filter-[drop-shadow(0_0_0.5px_rgba(0,0,0,0.6))_drop-shadow(0_1px_1px_rgba(0,0,0,0.1))] hover:bg-neutral-200"
+        className="h-[30px] rounded-lg bg-popover px-2 text-sm text-popover-foreground filter-[drop-shadow(0_0_0.5px_rgba(0,0,0,0.6))_drop-shadow(0_1px_1px_rgba(0,0,0,0.1))] hover:bg-muted"
         onClick={handleOpenFileDialog}
       >
         Upload image
@@ -558,7 +558,7 @@ const EmailSection = withForm({
             variant="secondary"
             size="sm"
             onClick={emailChange.toggle}
-            className="h-[30px] rounded-lg bg-neutral-50 px-3 font-sans text-sm font-medium text-neutral-800 shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-neutral-200"
+            className="h-[30px] rounded-lg bg-popover px-3 font-sans text-sm font-medium text-popover-foreground shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-muted"
           >
             Change email
           </Button>
@@ -585,7 +585,7 @@ const EmailSection = withForm({
                     emailChange.submit(field.state.value);
                   }}
                   disabled={emailChange.isPending || !field.state.value}
-                  className="h-[24px] rounded-lg bg-neutral-50 px-3 text-sm text-neutral-800 shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-neutral-200"
+                  className="h-[24px] rounded-lg bg-popover px-3 text-sm text-popover-foreground shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-muted"
                 >
                   {emailChange.isPending ? "Sending..." : "Verify"}
                 </InputGroupButton>
@@ -652,7 +652,7 @@ const ConnectedAccountSection = ({
             variant="secondary"
             size="sm"
             onClick={handleDisconnectGoogle}
-            className="h-[30px] rounded-lg bg-neutral-50 px-3 text-sm text-neutral-800 shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-neutral-200"
+            className="h-[30px] rounded-lg bg-popover px-3 text-sm text-popover-foreground shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-muted"
           >
             Disconnect
           </Button>
@@ -661,7 +661,7 @@ const ConnectedAccountSection = ({
             variant="secondary"
             size="sm"
             onClick={handleGoogleSignIn}
-            className="h-[30px] w-[95px] rounded-lg bg-neutral-50 px-3 text-sm text-neutral-800 shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-neutral-200"
+            className="h-[30px] w-[95px] rounded-lg bg-popover px-3 text-sm text-popover-foreground shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6)] hover:bg-muted"
           >
             Connect
           </Button>

--- a/src/routes/_authenticated/-components/settings/settings-dialog.tsx
+++ b/src/routes/_authenticated/-components/settings/settings-dialog.tsx
@@ -88,7 +88,7 @@ export const SettingsDialog = () => {
         className="flex h-[calc(100vh-2rem)] w-[calc(100vw-1rem)] max-w-none flex-col overflow-clip rounded-5xl p-0 shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1),0px_0px_0.5px_0px_rgba(0,0,0,0.6),0px_105px_29px_0px_rgba(0,0,0,0),0px_67px_27px_0px_rgba(0,0,0,0.01),0px_38px_23px_0px_rgba(0,0,0,0.04),0px_17px_17px_0px_rgba(0,0,0,0.08),0px_4px_9px_0px_rgba(0,0,0,0.09)] ring-0 duration-150 sm:max-w-none md:h-[min(700px,calc(100vh-80px))] md:w-[740px] md:flex-row data-open:zoom-in-[0.98] data-closed:zoom-out-[0.98]"
       >
         {/* Left Sidebar (top tabs on mobile) */}
-        <div className="relative flex w-full shrink-0 flex-col after:absolute after:right-0 after:bottom-0 after:left-0 after:h-[0.5px] after:bg-neutral-100 md:w-[180px] md:after:top-0 md:after:left-auto md:after:h-auto md:after:w-[0.5px]">
+        <div className="relative flex w-full shrink-0 flex-col after:absolute after:right-0 after:bottom-0 after:left-0 after:h-[0.5px] after:bg-[var(--color-gray-100)] md:w-[180px] md:after:top-0 md:after:left-auto md:after:h-auto md:after:w-[0.5px]">
           {/* Settings label */}
           <div className="hidden px-[18px] pt-5 pb-[12.21px] md:block">
             <p className="text-sm font-medium tracking-[0.26px] text-muted-foreground">Settings</p>
@@ -113,7 +113,10 @@ export const SettingsDialog = () => {
         </div>
 
         {/* Right Content Area — entire section scrolls */}
-        <ScrollArea className="min-h-0 flex-1" hideScrollbar>
+        <ScrollArea
+          className="min-h-0 flex-1 [&_[data-slot=scroll-area-viewport]]:focus-visible:ring-0"
+          hideScrollbar
+        >
           <div className="px-5 pt-5 pb-5 md:px-12.25 md:pt-8 md:pb-8">
             <DialogTitle className="mb-4 text-xl font-semibold text-foreground">
               {tabTitles[activeTab]}

--- a/src/routes/_authenticated/-components/workspace-item-minimal.tsx
+++ b/src/routes/_authenticated/-components/workspace-item-minimal.tsx
@@ -8,11 +8,7 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuPortal,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -30,12 +26,7 @@ import {
   StarIcon,
   TrashIcon,
 } from "@/components/ui/icons";
-import {
-  createFormLocal,
-  moveFormToWorkspaceLocal,
-  renameFormLocal,
-  toggleFavoriteLocal,
-} from "@/collections";
+import { createFormLocal, moveFormToWorkspaceLocal, toggleFavoriteLocal } from "@/collections";
 import { useSession } from "@/lib/auth/auth-client";
 import { cn } from "@/lib/utils";
 import {
@@ -57,7 +48,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { useRouter } from "@tanstack/react-router";
 import type * as React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 export type WorkspaceWithForms = {
@@ -381,7 +372,7 @@ const WorkspaceFormMinimal = ({
 }: WorkspaceFormMinimalProps) => {
   const { data: session } = useSession();
   const userId = session?.user?.id;
-  const [renameOpen, setRenameOpen] = useState(false);
+  const [moveExpanded, setMoveExpanded] = useState(false);
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: form.id,
@@ -430,7 +421,15 @@ const WorkspaceFormMinimal = ({
       {...listeners}
       className="group/row relative"
     >
-      <SidebarItem label={label} linkOptions={linkOptions} isActive={isActive} prefix={prefix}>
+      <SidebarItem
+        label={label}
+        linkOptions={linkOptions}
+        isActive={isActive}
+        prefix={prefix}
+        // Reserve space for the absolute-positioned options button so the
+        // truncated title's ellipsis doesn't end up underneath it.
+        className="group-hover/row:pe-7 group-has-[[data-state=open]]/row:pe-7"
+      >
         {/* eslint-disable-next-line react-doctor/rendering-conditional-render -- showCount is a derived boolean (isPublished && submissionCount > 0); cannot render numeric 0 */}
         {showCount && (
           <span className="shrink-0 font-case text-[11px] tracking-5 text-muted-foreground tabular-nums transition-opacity group-hover/row:opacity-0 group-has-[[data-state=open]]/row:opacity-0">
@@ -469,10 +468,6 @@ const WorkspaceFormMinimal = ({
                 {isDuplicating ? "Duplicating…" : "Duplicate"}
               </span>
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setRenameOpen(true)}>
-              <Pencil2Icon />
-              <span className="flex-1 text-left">Rename</span>
-            </DropdownMenuItem>
             <DropdownMenuItem onClick={handleToggleFavorite} disabled={!userId}>
               <StarIcon className="size-3.5" />
               <span className="flex-1 text-left">
@@ -480,21 +475,34 @@ const WorkspaceFormMinimal = ({
               </span>
             </DropdownMenuItem>
             {otherWorkspaces.length > 0 && (
-              <DropdownMenuSub>
-                <DropdownMenuSubTrigger>
-                  <FolderIcon className="size-3.5" />
+              <Collapsible open={moveExpanded} onOpenChange={setMoveExpanded}>
+                <CollapsibleTrigger className="inline-flex h-[26px] w-full cursor-pointer items-center gap-1.5 overflow-hidden rounded-lg px-2 py-[5.5px] text-[13px] text-foreground transition-colors hover:bg-accent">
+                  <FolderIcon className="size-3.5 shrink-0" />
                   <span className="flex-1 text-left">Move to workspace</span>
-                </DropdownMenuSubTrigger>
-                <DropdownMenuPortal>
-                  <DropdownMenuSubContent className="w-48">
+                  <ChevronDownIcon
+                    className={cn(
+                      "size-3 shrink-0 transition-transform duration-200",
+                      moveExpanded && "rotate-180",
+                    )}
+                  />
+                </CollapsibleTrigger>
+                <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-200 ease-out data-ending-style:h-0 data-starting-style:h-0">
+                  <div className="flex flex-col pt-1">
                     {otherWorkspaces.map((ws) => (
-                      <DropdownMenuItem key={ws.id} onClick={() => handleMoveToWorkspace(ws.id)}>
+                      <DropdownMenuItem
+                        key={ws.id}
+                        closeOnClick={false}
+                        onClick={() => {
+                          handleMoveToWorkspace(ws.id);
+                          setMoveExpanded(false);
+                        }}
+                      >
                         <span className="flex-1 truncate text-left">{ws.name}</span>
                       </DropdownMenuItem>
                     ))}
-                  </DropdownMenuSubContent>
-                </DropdownMenuPortal>
-              </DropdownMenuSub>
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
             )}
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
@@ -507,60 +515,6 @@ const WorkspaceFormMinimal = ({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      {renameOpen && (
-        <InlineRenameForm
-          initialValue={form.title || ""}
-          onClose={() => setRenameOpen(false)}
-          onSubmit={(next) => {
-            renameFormLocal(form.id, next).catch(() => toast.error("Failed to rename form"));
-            setRenameOpen(false);
-          }}
-        />
-      )}
-    </div>
-  );
-};
-
-const InlineRenameForm = ({
-  initialValue,
-  onSubmit,
-  onClose,
-}: {
-  initialValue: string;
-  onSubmit: (value: string) => void;
-  onClose: () => void;
-}) => {
-  // eslint-disable-next-line react-doctor/no-derived-useState -- uncontrolled rename input; the parent intentionally hands ownership to local state
-  const [value, setValue] = useState(initialValue);
-  const inputRef = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
-
-  const commitOrClose = () => {
-    const trimmed = value.trim();
-    if (trimmed) onSubmit(trimmed);
-    else onClose();
-  };
-
-  return (
-    <div className="px-2 py-1">
-      <input
-        ref={inputRef}
-        type="text"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onBlur={onClose}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            commitOrClose();
-          } else if (e.key === "Escape") {
-            onClose();
-          }
-        }}
-        className="w-full rounded-md bg-secondary px-2 py-1 text-[13px] ring-1 ring-foreground/20 outline-hidden"
-        aria-label="Rename form"
-      />
     </div>
   );
 };

--- a/src/routes/_authenticated/dashboard.tsx
+++ b/src/routes/_authenticated/dashboard.tsx
@@ -10,10 +10,29 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
 import { Card } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { Input } from "@/components/ui/input";
 import {
   CheckIcon,
+  ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   CopyIcon,
@@ -39,10 +58,12 @@ import { useSession } from "@/lib/auth/auth-client";
 import { formatForDisplay, HOTKEYS } from "@/lib/hotkeys";
 import { clearLocalDraftIds } from "@/db/local-draft";
 import { hasLocalDataToSync, syncLocalDataToCloud } from "@/db/sync";
+import { getLeadingSortIndex, sortByManualOrder } from "@/lib/sort-utils";
 import { parseTimestampAsUTC } from "@/lib/utils";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { createFileRoute, Link, useLoaderData, useNavigate } from "@tanstack/react-router";
 import { formatDistanceToNow } from "date-fns";
+import { generateKeyBetween } from "fractional-indexing";
 import { FolderPlus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -135,6 +156,9 @@ const DashboardPage = () => {
   const duplicateFormFn = useDuplicateForm();
   const activeOrg = useLoaderData({ from: "/_authenticated", select: (d) => d.activeOrg });
   const [isCreating, setIsCreating] = useState(false);
+  const [createWorkspaceOpen, setCreateWorkspaceOpen] = useState(false);
+  const [newWorkspaceName, setNewWorkspaceName] = useState("");
+  const [isCreatingWorkspace, setIsCreatingWorkspace] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
   const [formToDelete, setFormToDelete] = useState<{
@@ -170,34 +194,82 @@ const DashboardPage = () => {
   const startIndex = (currentPage - 1) * FORMS_PER_PAGE;
   const paginatedForms = orgForms.slice(startIndex, startIndex + FORMS_PER_PAGE);
 
-  const handleCreateWorkspace = useCallback(async () => {
-    if (!activeOrg?.id) return;
+  const handleOpenCreateWorkspace = useCallback(() => {
+    setNewWorkspaceName("");
+    setCreateWorkspaceOpen(true);
+  }, []);
+
+  const handleCloseCreateWorkspace = useCallback(() => {
+    setCreateWorkspaceOpen(false);
+    setNewWorkspaceName("");
+  }, []);
+
+  const handleConfirmCreateWorkspace = useCallback(async () => {
+    const trimmedName = newWorkspaceName.trim();
+    if (!activeOrg?.id || !trimmedName || isCreatingWorkspace) return;
+    setIsCreatingWorkspace(true);
     try {
-      await createWorkspaceLocal(activeOrg.id, "New Workspace");
+      // Place the new workspace before the current lead so it appears at the
+      // top of the sidebar; fractional-indexing keeps it stable even after
+      // future drag-reorders.
+      const leadingSortIndex = generateKeyBetween(null, getLeadingSortIndex(orgWorkspaces));
+      const workspace = await createWorkspaceLocal(activeOrg.id, trimmedName, leadingSortIndex);
+      setCreateWorkspaceOpen(false);
+      setNewWorkspaceName("");
       toast.success("Workspace created");
+      void navigate({
+        to: "/workspace/$workspaceId",
+        params: { workspaceId: workspace.id },
+      });
     } catch (error) {
       console.error("Failed to create workspace:", error);
       toast.error("Failed to create workspace");
-    }
-  }, [activeOrg?.id]);
-
-  const handleCreateForm = useCallback(async () => {
-    if (orgWorkspaces.length === 0) return;
-
-    setIsCreating(true);
-    try {
-      const defaultWorkspace = orgWorkspaces[0];
-      const { form: newForm } = createFormLocal(defaultWorkspace.id);
-      void navigate({
-        to: "/workspace/$workspaceId/form-builder/$formId/edit",
-        params: { workspaceId: defaultWorkspace.id, formId: newForm.id },
-      });
-    } catch (error) {
-      console.error("Failed to create form:", error);
     } finally {
-      setIsCreating(false);
+      setIsCreatingWorkspace(false);
     }
-  }, [orgWorkspaces, navigate]);
+  }, [activeOrg?.id, newWorkspaceName, orgWorkspaces, navigate, isCreatingWorkspace]);
+
+  const handleCreateWorkspaceKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        void handleConfirmCreateWorkspace();
+      }
+    },
+    [handleConfirmCreateWorkspace],
+  );
+
+  // Mirror the sidebar's order so the dashboard's "New form" button targets
+  // the same workspace the sidebar lists first when no explicit pick is made.
+  const orderedWorkspaces = useMemo(
+    () =>
+      sortByManualOrder(
+        orgWorkspaces,
+        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+      ),
+    [orgWorkspaces],
+  );
+
+  const handleCreateForm = useCallback(
+    (workspaceId?: string) => {
+      const targetId = workspaceId ?? orderedWorkspaces[0]?.id;
+      if (!targetId) return;
+
+      setIsCreating(true);
+      try {
+        const { form: newForm } = createFormLocal(targetId);
+        void navigate({
+          to: "/workspace/$workspaceId/form-builder/$formId/edit",
+          params: { workspaceId: targetId, formId: newForm.id },
+        });
+      } catch (error) {
+        console.error("Failed to create form:", error);
+      } finally {
+        setIsCreating(false);
+      }
+    },
+    [orderedWorkspaces, navigate],
+  );
 
   const handleDeleteClick = useCallback((form: { id: string; title: string }) => {
     setFormToDelete(form);
@@ -314,9 +386,9 @@ const DashboardPage = () => {
         <DashboardHeader
           isLoading={isLoading}
           orgFormsCount={orgForms.length}
-          orgWorkspacesCount={orgWorkspaces.length}
+          orderedWorkspaces={orderedWorkspaces}
           isCreating={isCreating}
-          handleCreateWorkspace={handleCreateWorkspace}
+          handleCreateWorkspace={handleOpenCreateWorkspace}
           handleCreateForm={handleCreateForm}
         />
 
@@ -379,60 +451,181 @@ const DashboardPage = () => {
         title={formToDelete?.title}
         onConfirm={handleConfirmDelete}
       />
+
+      <WorkspaceCreateDialog
+        open={createWorkspaceOpen}
+        name={newWorkspaceName}
+        isCreating={isCreatingWorkspace}
+        onOpenChange={setCreateWorkspaceOpen}
+        onNameChange={(e) => setNewWorkspaceName(e.target.value)}
+        onClose={handleCloseCreateWorkspace}
+        onCreate={handleConfirmCreateWorkspace}
+        onKeyDown={handleCreateWorkspaceKeyDown}
+      />
     </div>
   );
 };
 
+interface WorkspaceCreateDialogProps {
+  open: boolean;
+  name: string;
+  isCreating: boolean;
+  onOpenChange: (open: boolean) => void;
+  onNameChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onClose: () => void;
+  onCreate: () => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}
+
+const WorkspaceCreateDialog = ({
+  open,
+  name,
+  isCreating,
+  onOpenChange,
+  onNameChange,
+  onClose,
+  onCreate,
+  onKeyDown,
+}: WorkspaceCreateDialogProps) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent className="gap-4 sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>Create workspace</DialogTitle>
+        <DialogDescription>Give your new workspace a name to get started.</DialogDescription>
+      </DialogHeader>
+      <Input
+        value={name}
+        onChange={onNameChange}
+        placeholder="Workspace name"
+        aria-label="Workspace name"
+        onKeyDown={onKeyDown}
+        autoFocus
+      />
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose} disabled={isCreating}>
+          Cancel
+        </Button>
+        <Button onClick={onCreate} disabled={!name.trim() || isCreating}>
+          {isCreating ? (
+            <>
+              <Loader2Icon className="mr-1.5 size-3.5 animate-spin" />
+              Creating…
+            </>
+          ) : (
+            "Save"
+          )}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);
+
 interface DashboardHeaderProps {
   isLoading: boolean;
   orgFormsCount: number;
-  orgWorkspacesCount: number;
+  orderedWorkspaces: ReadonlyArray<{ id: string; name: string }>;
   isCreating: boolean;
   handleCreateWorkspace: () => void;
-  handleCreateForm: () => void;
+  handleCreateForm: (workspaceId?: string) => void;
 }
 
 const DashboardHeader = ({
   isLoading,
   orgFormsCount,
-  orgWorkspacesCount,
+  orderedWorkspaces,
   isCreating,
   handleCreateWorkspace,
   handleCreateForm,
-}: DashboardHeaderProps) => (
-  <div className="mb-8 flex items-center justify-between">
-    <div>
-      <h1 className="text-2xl font-semibold">Home</h1>
-      <p className="mt-1 text-sm text-muted-foreground">
-        {isLoading
-          ? "Loading..."
-          : `${orgFormsCount} form${orgFormsCount !== 1 ? "s" : ""} across ${orgWorkspacesCount} workspace${orgWorkspacesCount !== 1 ? "s" : ""}`}
-      </p>
+}: DashboardHeaderProps) => {
+  const orgWorkspacesCount = orderedWorkspaces.length;
+  const topWorkspace = orderedWorkspaces[0];
+  const hasMultipleWorkspaces = orgWorkspacesCount > 1;
+
+  return (
+    <div className="mb-8 flex items-center justify-between">
+      <div>
+        <h1 className="text-2xl font-semibold">Home</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {isLoading
+            ? "Loading..."
+            : `${orgFormsCount} form${orgFormsCount !== 1 ? "s" : ""} across ${orgWorkspacesCount} workspace${orgWorkspacesCount !== 1 ? "s" : ""}`}
+        </p>
+      </div>
+      <div className="flex items-center gap-3">
+        <Button
+          className="ml-1"
+          size="sm"
+          variant="secondary"
+          prefix={<FolderPlus className="size-4" />}
+          onClick={handleCreateWorkspace}
+          disabled={isLoading}
+        >
+          New workspace
+        </Button>
+        {hasMultipleWorkspaces ? (
+          <ButtonGroup>
+            <Button
+              size="sm"
+              prefix={
+                isCreating ? (
+                  <Loader2Icon className="animate-spin" />
+                ) : (
+                  <PlusIcon className="size-4" />
+                )
+              }
+              onClick={() => handleCreateForm(topWorkspace?.id)}
+              disabled={isLoading || isCreating || !topWorkspace}
+            >
+              New form in {topWorkspace?.name ?? "workspace"}
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <Button
+                    size="sm"
+                    aria-label="Pick a different workspace"
+                    disabled={isLoading || isCreating}
+                  >
+                    <ChevronDownIcon className="size-3" />
+                  </Button>
+                }
+              />
+              <DropdownMenuContent align="end" sideOffset={4} className="w-56">
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel>Create new form in…</DropdownMenuLabel>
+                  {orderedWorkspaces.map((ws) => (
+                    <DropdownMenuItem
+                      key={ws.id}
+                      onClick={() => handleCreateForm(ws.id)}
+                      disabled={isCreating}
+                    >
+                      <span className="flex-1 truncate text-left">{ws.name}</span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </ButtonGroup>
+        ) : (
+          <Button
+            size="sm"
+            prefix={
+              isCreating ? (
+                <Loader2Icon className="animate-spin" />
+              ) : (
+                <PlusIcon className="size-4" />
+              )
+            }
+            onClick={() => handleCreateForm()}
+            disabled={isLoading || isCreating || orgWorkspacesCount === 0}
+          >
+            New form
+          </Button>
+        )}
+      </div>
     </div>
-    <div className="flex items-center gap-3">
-      <Button
-        className="ml-1"
-        size="sm"
-        variant="secondary"
-        prefix={<FolderPlus className="size-4" />}
-        onClick={handleCreateWorkspace}
-        disabled={isLoading}
-      >
-        New workspace
-      </Button>
-      <Button
-        size="sm"
-        prefix={
-          isCreating ? <Loader2Icon className="animate-spin" /> : <PlusIcon className="size-4" />
-        }
-        onClick={handleCreateForm}
-        disabled={isLoading || isCreating || orgWorkspacesCount === 0}
-      >
-        New form
-      </Button>
-    </div>
-  </div>
-);
+  );
+};
 
 type FormListItemForm = {
   id: string;
@@ -539,7 +732,7 @@ const DashboardPagination = ({
       forms
     </p>
     <div className="flex items-center gap-2">
-      <Button variant="outline" size="sm" onClick={onPrevPage} disabled={currentPage === 1}>
+      <Button variant="secondary" size="sm" onClick={onPrevPage} disabled={currentPage === 1}>
         <ChevronLeftIcon className="size-4" />
         Previous
       </Button>
@@ -557,7 +750,7 @@ const DashboardPagination = ({
         ))}
       </div>
       <Button
-        variant="outline"
+        variant="secondary"
         size="sm"
         onClick={onNextPage}
         disabled={currentPage === totalPages}

--- a/src/routes/login/email.tsx
+++ b/src/routes/login/email.tsx
@@ -9,13 +9,12 @@ import { Input } from "@/components/ui/input";
 import { revalidateLogic, useAppForm } from "@/components/ui/tanstack-form";
 import { authClient } from "@/lib/auth/auth-client";
 import { guestMiddleware } from "@/lib/auth/middleware";
+import { isSafeRedirect } from "@/lib/auth/safe-redirect";
 import { Logo } from "@/components/ui/logo";
 
 const emailSchema = z.object({
   email: z.email({ error: "Please enter a valid email address" }),
 });
-
-const SAFE_REDIRECT_PATTERN = /^\/[a-zA-Z0-9\-_/$.~]+$/;
 
 const EmailLoginPage = () => {
   // eslint-disable-next-line react-doctor/rerender-state-only-in-handlers -- value gates between login form and "check your email" view in JSX
@@ -27,8 +26,7 @@ const EmailLoginPage = () => {
     emailInputRef.current?.focus();
   }, []);
 
-  const callbackURL =
-    redirectTo && SAFE_REDIRECT_PATTERN.test(redirectTo) ? redirectTo : "/dashboard";
+  const callbackURL = isSafeRedirect(redirectTo) ? redirectTo : "/dashboard";
 
   // eslint-disable-next-line react-doctor/query-mutation-missing-invalidation -- magic link sends email; no cache to invalidate
   const magicLinkMutation = useMutation({

--- a/src/routes/login/index.tsx
+++ b/src/routes/login/index.tsx
@@ -6,17 +6,15 @@ import * as z from "zod";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth/auth-client";
 import { guestMiddleware } from "@/lib/auth/middleware";
+import { isSafeRedirect } from "@/lib/auth/safe-redirect";
 import { Logo } from "@/components/ui/logo";
 import { toast } from "sonner";
-
-const SAFE_REDIRECT_PATTERN = /^\/[a-zA-Z0-9\-_/$.~]+$/;
 
 const LoginPage = () => {
   const navigate = useNavigate();
   const { redirect: redirectTo } = Route.useSearch();
 
-  const callbackURL =
-    redirectTo && SAFE_REDIRECT_PATTERN.test(redirectTo) ? redirectTo : "/dashboard";
+  const callbackURL = isSafeRedirect(redirectTo) ? redirectTo : "/dashboard";
 
   // eslint-disable-next-line react-doctor/query-mutation-missing-invalidation -- social sign-in redirects to OAuth provider; cache invalidation handled on callback
   const socialSignInMutation = useMutation({

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -174,7 +174,7 @@
 	--color-gray-550: #8c8c8c;
 	--color-gray-600: #7c7c7c;
 	--color-gray-700: #525252;
-	--color-gray-800: #2e2e2e;
+	--color-gray-800: #303030;
 	--color-gray-900: #212121;
 	--color-gray-950: #141414;
 	--color-gray-1000: #000;

--- a/src/test/auth-auto-provision.test.ts
+++ b/src/test/auth-auto-provision.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { eq } from "drizzle-orm";
+import * as schema from "@/db/schema";
+import { db } from "@/db";
+import { getTestUtils, cleanupTestUser } from "@/test/helpers";
+
+// Validates the `databaseHooks.user.create.after` hook in
+// `src/lib/auth/auth.ts`. When a new user is created, the hook must
+// auto-provision their starting state: one organization, an owner membership,
+// and one default workspace. This is the gate that prevented the orphan-user
+// bug we backfilled.
+
+describe("auto-provision on user creation", () => {
+  const createdUserIds: string[] = [];
+
+  afterEach(async () => {
+    for (const id of createdUserIds) {
+      await cleanupTestUser(id);
+    }
+    createdUserIds.length = 0;
+  });
+
+  it("creates an organization for a newly-saved user", async () => {
+    const t = await getTestUtils();
+    const userId = crypto.randomUUID();
+    createdUserIds.push(userId);
+
+    await t.saveUser(
+      t.createUser({ id: userId, email: `auto-${userId}@example.com`, name: "Auto" }),
+    );
+
+    const memberships = await db
+      .select({ orgId: schema.member.organizationId, role: schema.member.role })
+      .from(schema.member)
+      .where(eq(schema.member.userId, userId));
+
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0].role).toBe("owner");
+  });
+
+  it("creates a default workspace inside the user's organization", async () => {
+    const t = await getTestUtils();
+    const userId = crypto.randomUUID();
+    createdUserIds.push(userId);
+
+    await t.saveUser(
+      t.createUser({ id: userId, email: `auto-${userId}@example.com`, name: "Auto" }),
+    );
+
+    const [membership] = await db
+      .select({ orgId: schema.member.organizationId })
+      .from(schema.member)
+      .where(eq(schema.member.userId, userId));
+
+    const workspaces = await db
+      .select({ id: schema.workspaces.id, name: schema.workspaces.name })
+      .from(schema.workspaces)
+      .where(eq(schema.workspaces.organizationId, membership.orgId));
+
+    expect(workspaces).toHaveLength(1);
+    expect(workspaces[0].name).toBe("My workspace");
+  });
+});

--- a/src/test/auth-redirect.test.ts
+++ b/src/test/auth-redirect.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { pickPostLoginRedirect } from "@/lib/auth/middleware";
+import { isSafeRedirect } from "@/lib/auth/safe-redirect";
+
+describe("pickPostLoginRedirect", () => {
+  const noHeaders = new Headers();
+
+  it("returns the pathname when it's a normal page route", () => {
+    expect(pickPostLoginRedirect("/dashboard", noHeaders)).toBe("/dashboard");
+    expect(pickPostLoginRedirect("/workspace/abc/forms", noHeaders)).toBe("/workspace/abc/forms");
+  });
+
+  it("rejects /_serverFn/ paths and falls back to /dashboard when no referer", () => {
+    expect(
+      pickPostLoginRedirect("/_serverFn/3d639c1b03e217b64521063eef826d66691aac3fb", noHeaders),
+    ).toBe("/dashboard");
+  });
+
+  it("rejects /api/ paths and falls back to /dashboard when no referer", () => {
+    expect(pickPostLoginRedirect("/api/track/visit-end", noHeaders)).toBe("/dashboard");
+  });
+
+  it("uses Referer pathname when the request URL is an internal path", () => {
+    const headers = new Headers({ referer: "https://app.example.com/workspace/abc/forms" });
+    expect(pickPostLoginRedirect("/_serverFn/abcdef", headers)).toBe("/workspace/abc/forms");
+  });
+
+  it("ignores Referer that itself points at an internal path", () => {
+    const headers = new Headers({ referer: "https://app.example.com/_serverFn/cafebabe" });
+    expect(pickPostLoginRedirect("/_serverFn/abcdef", headers)).toBe("/dashboard");
+  });
+
+  it("ignores a malformed Referer header", () => {
+    const headers = new Headers({ referer: "not-a-url" });
+    expect(pickPostLoginRedirect("/_serverFn/abcdef", headers)).toBe("/dashboard");
+  });
+});
+
+describe("isSafeRedirect", () => {
+  it("accepts normal page paths", () => {
+    expect(isSafeRedirect("/dashboard")).toBe(true);
+    expect(isSafeRedirect("/workspace/abc/forms/def")).toBe(true);
+    expect(isSafeRedirect("/settings")).toBe(true);
+  });
+
+  it("rejects /_serverFn/ and other /_-prefixed paths", () => {
+    expect(isSafeRedirect("/_serverFn/3d639c1b03e217b64521063eef826d66691aac3fb")).toBe(false);
+    expect(isSafeRedirect("/_build/assets/main.js")).toBe(false);
+  });
+
+  it("rejects /api/ paths", () => {
+    expect(isSafeRedirect("/api/track/visit-end")).toBe(false);
+    expect(isSafeRedirect("/api/auth/magic-link/verify")).toBe(false);
+  });
+
+  it("rejects absolute URLs (open-redirect guard)", () => {
+    expect(isSafeRedirect("https://evil.example.com/phish")).toBe(false);
+    expect(isSafeRedirect("//evil.example.com")).toBe(false);
+  });
+
+  it("rejects paths with disallowed chars", () => {
+    expect(isSafeRedirect("/dashboard?foo=bar")).toBe(false);
+    expect(isSafeRedirect("/dashboard#section")).toBe(false);
+    expect(isSafeRedirect("/dashboard with space")).toBe(false);
+  });
+
+  it("rejects null, undefined, and empty strings", () => {
+    expect(isSafeRedirect(null)).toBe(false);
+    expect(isSafeRedirect(undefined)).toBe(false);
+    expect(isSafeRedirect("")).toBe(false);
+  });
+});

--- a/src/test/auth-session-active-org.test.ts
+++ b/src/test/auth-session-active-org.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { eq } from "drizzle-orm";
+import * as schema from "@/db/schema";
+import { db } from "@/db";
+import { auth } from "@/lib/auth/auth";
+import { cleanupTestUser } from "@/test/helpers";
+
+// Validates the `databaseHooks.session.create.before` hook in
+// `src/lib/auth/auth.ts`. When a session is created, the hook must populate
+// `session.activeOrganizationId` from the user's first membership. Without
+// this, the workspace-creation serverFn throws "No active organization" —
+// the original symptom that triggered the orphan-user investigation.
+
+// Better Auth's TestHelpers type doesn't surface `login` to consumers; the
+// runtime object has it. Narrow type here so we don't lean on `unknown`.
+type TestHelpersWithLogin = {
+  createUser: (overrides?: Record<string, unknown>) => { id: string; [key: string]: unknown };
+  saveUser: (user: { id: string; [key: string]: unknown }) => Promise<{ id: string }>;
+  login: (args: { userId: string }) => Promise<{
+    session: { activeOrganizationId: string | null; userId: string };
+  }>;
+};
+
+describe("session.create.before sets activeOrganizationId", () => {
+  const createdUserIds: string[] = [];
+
+  afterEach(async () => {
+    for (const id of createdUserIds) {
+      await cleanupTestUser(id);
+    }
+    createdUserIds.length = 0;
+  });
+
+  it("populates activeOrganizationId from the user's first membership", async () => {
+    const ctx = await auth.$context;
+    const t = ctx.test as unknown as TestHelpersWithLogin;
+    const userId = crypto.randomUUID();
+    createdUserIds.push(userId);
+
+    await t.saveUser(
+      t.createUser({ id: userId, email: `sess-${userId}@example.com`, name: "Sess" }),
+    );
+
+    const [membership] = await db
+      .select({ orgId: schema.member.organizationId })
+      .from(schema.member)
+      .where(eq(schema.member.userId, userId));
+
+    const { session } = await t.login({ userId });
+
+    expect(session.activeOrganizationId).toBe(membership.orgId);
+  });
+});

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import * as schema from "@/db/schema";
 import { db } from "@/db";
 import { auth } from "@/lib/auth/auth";
@@ -114,12 +114,37 @@ export const createTestForm = async (workspaceId: string, creatorId: string) => 
   return form;
 };
 
+// better-auth's deleteUser only removes the `user` row. The `member` table
+// has no FK to user/org (src/db/schema.ts:32-42), so member rows linger and
+// the auto-provisioned org (databaseHooks.user.create.after in
+// src/lib/auth/auth.ts:72-104) is never torn down. Walking the graph by
+// userId catches every tenant the user owns or belongs to: cascading from
+// the organization sweeps workspaces, forms, submissions, etc. via the
+// existing FK chain, and explicit member/order deletes mop up the FK-less
+// rows.
 export const cleanupTestUser = async (userId: string) => {
+  const orgRows = await db
+    .select({ organizationId: schema.member.organizationId })
+    .from(schema.member)
+    .where(eq(schema.member.userId, userId));
+  const orgIds = orgRows.map((r) => r.organizationId);
+
+  if (orgIds.length > 0) {
+    await db.delete(schema.organization).where(inArray(schema.organization.id, orgIds));
+  }
+  // Member + user_workspace_order rows have no FK cascade — clear them
+  // explicitly so deleteUser leaves a clean trail.
+  await db.delete(schema.member).where(eq(schema.member.userId, userId));
+  await db.delete(schema.userWorkspaceOrder).where(eq(schema.userWorkspaceOrder.userId, userId));
+
   const t = await getTestUtils();
   await t.deleteUser(userId);
 };
 
 export const cleanupTestOrg = async (orgId: string) => {
+  // Same shape as cleanupTestUser: drop members first (no FK cascade), then
+  // the org itself which cascades workspaces/forms/etc.
+  await db.delete(schema.member).where(eq(schema.member.organizationId, orgId));
   const t = await getTestUtils();
   await t.deleteOrganization(orgId);
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -227,7 +227,18 @@ const config = defineConfig({
     // Force-include CJS-only `use-sync-external-store` so Vite extracts its
     // named exports correctly. The shim uses a `module.exports = require(...)`
     // indirection that Vite's auto-scan misses.
-    include: ["use-sync-external-store/shim", "use-sync-external-store/shim/with-selector"],
+    //
+    // Recharts is pinned here for the same reason — its internals reach into
+    // React through a CJS shim that Vite 7's deps bundler otherwise wires up
+    // inconsistently (the dev server occasionally serves a `recharts.js` that
+    // imports a stale `react.js` chunk, surfacing as
+    // `TypeError: require_react is not a function`). Explicit inclusion makes
+    // the pre-bundle deterministic.
+    include: [
+      "use-sync-external-store/shim",
+      "use-sync-external-store/shim/with-selector",
+      "recharts",
+    ],
   },
 });
 


### PR DESCRIPTION
- Add `pickPostLoginRedirect` + `safe-redirect` helper so the auth middleware never bounces users to a serverFn / `_` route after login; fall back to the referer path, then `/dashboard`.
- Cover the existing `databaseHooks` for user-create auto-provisioning and session active-org population with regression tests.
- Make `cleanupTestUser` cascade through the user's orgs so tests no longer leak organization/member rows.
- Tidy dashboard + sidebar workspace creation: share `sortByManualOrder`
  + new `getLeadingSortIndex` helper across the dashboard and palette call sites instead of three near-duplicate `toSorted()[0]` blocks.
- Drop the now-dead `renameFormLocal` export and the favorite-row inline rename dropdown that was removed when the sidebar collapsed onto the shared SidebarItem.