### PR TITLE
feat(public-forms): field-by-field RSC, local draft resume, analytics…

### DIFF
--- a/src/components/form-builder/insights/empty-state.tsx
+++ b/src/components/form-builder/insights/empty-state.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, LineChart, Rocket, Share2 } from "lucide-react";
+import { BarChart3, LineChart, Lock, Rocket, Share2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -10,27 +10,29 @@ interface EmptyStateProps {
   submissionCount: number;
   /** Whether any raw visit has been recorded (writers run unconditionally). */
   hasAnyVisits: boolean;
-  /** Whether the analytics toggle is on AND the org plan unlocks analytics. */
+  /** Raw `formSettings.analytics` — distinguishes "off" from "on but plan-locked". */
+  analyticsToggle: boolean;
+  /** Toggle AND the org plan unlocks analytics. */
   analyticsEnabled: boolean;
-  /** Spinner state on the "Enable analytics" button while the mutation runs. */
   isEnablingAnalytics?: boolean;
-  /** Caller-supplied actions for the relevant prompt. */
   onPublishClick?: () => void;
   onShareClick?: () => void;
   onEnableAnalyticsClick?: () => void;
+  onUpgradeClick?: () => void;
 }
 
 export const EmptyState = ({
   formStatus,
   submissionCount,
   hasAnyVisits,
+  analyticsToggle,
   analyticsEnabled,
   isEnablingAnalytics = false,
   onPublishClick,
   onShareClick,
   onEnableAnalyticsClick,
+  onUpgradeClick,
 }: EmptyStateProps) => {
-  // Branch 1: form isn't published yet — nothing else matters until it is.
   if (formStatus !== "published") {
     return (
       <PromptCard
@@ -48,9 +50,29 @@ export const EmptyState = ({
     );
   }
 
-  // Branch 2: form is published and there's something to look at (submissions
-  // or raw visits) but the analytics toggle/plan is off — we already kept the
-  // data, just need the user to flip the switch (or upgrade) to see it.
+  // Toggle on but plan-locked → upgrade prompt (flipping the toggle is a no-op).
+  if (!analyticsEnabled && analyticsToggle && (submissionCount > 0 || hasAnyVisits)) {
+    return (
+      <PromptCard
+        icon={<Lock className="size-6 text-muted-foreground" aria-hidden="true" />}
+        title="Analytics is on, but your plan blocks the view"
+        body={
+          submissionCount > 0
+            ? `Your form has ${submissionCount} ${submissionCount === 1 ? "submission" : "submissions"} so far. Upgrade to Pro to see visits, drop-off, and device breakdowns — your data has been kept and will appear here once you upgrade.`
+            : "Visits are being recorded. Upgrade to Pro to surface them as charts — your data has been kept and will appear here once you upgrade."
+        }
+        action={
+          onUpgradeClick && (
+            <Button size="sm" onClick={onUpgradeClick}>
+              Upgrade to Pro
+            </Button>
+          )
+        }
+      />
+    );
+  }
+
+  // Toggle off → enable prompt. `setFormAnalytics` re-checks the plan server-side.
   if (!analyticsEnabled && (submissionCount > 0 || hasAnyVisits)) {
     return (
       <PromptCard
@@ -72,8 +94,6 @@ export const EmptyState = ({
     );
   }
 
-  // Branch 3: published, no data yet (and analytics-enabled if applicable) —
-  // the user just needs to send people to the form.
   return (
     <PromptCard
       icon={<Share2 className="size-6 text-muted-foreground" aria-hidden="true" />}

--- a/src/components/form-components/form-preview-from-plate.tsx
+++ b/src/components/form-components/form-preview-from-plate.tsx
@@ -8,12 +8,15 @@ import type { PublicFormTracking, TrackingBase } from "@/contexts/step-form-cont
 import { useTranslation } from "@/contexts/translation-context";
 import { CUSTOMIZATION_AUTO_DEFAULTS } from "@/lib/theme/customization-defaults";
 import { extractFormHeader } from "@/lib/editor/transform-plate-to-form";
-import { transformPlateForPreview } from "@/lib/editor/transform-plate-for-preview";
+import {
+  chunkSegmentsForFieldByField,
+  transformPlateForPreview,
+} from "@/lib/editor/transform-plate-for-preview";
 import type { PreviewSegment } from "@/lib/editor/transform-plate-for-preview";
 import { extractQuestionsForStep } from "@/lib/forms/extract-questions";
 import type { QuestionRef } from "@/lib/forms/extract-questions";
 import { DEFAULT_ICON } from "@/lib/config/app-config";
-import { cn, DEFAULT_ICON_NAME, isValidUrl } from "@/lib/utils";
+import { cn, DEFAULT_ICON_NAME, isHexColor, isValidUrl } from "@/lib/utils";
 import type { PublicFormSettings } from "@/types/form-settings";
 import { IconPickerPreview } from "@/components/icon-picker";
 import { AnimatePresence, domAnimation, LazyMotion, m } from "motion/react";
@@ -101,8 +104,6 @@ interface FormPreviewFromPlateProps {
    * tracking. */
   trackingBase?: TrackingBase;
 }
-
-export const isHexColor = (str: string): boolean => /^#([0-9A-Fa-f]{3}){1,2}$/.test(str);
 
 const PAGE_MAX_WIDTH = {
   editor: `var(--bf-page-width, ${CUSTOMIZATION_AUTO_DEFAULTS.pageWidth})`,
@@ -424,28 +425,13 @@ export const FormPreviewFromPlate = ({
     [content],
   );
 
-  // Field-by-field mode: re-chunk so each field becomes its own step, with
-  // preceding static content carried into the same step as the next field.
-  // Skip authored Button fields entirely — page boundaries are invisible here,
-  // so a standalone Next/Previous button step would just be noise. The
-  // auto-rendered submit/next button on each input step handles navigation.
-  const steps = useMemo(() => {
-    if (settings?.presentationMode !== "field-by-field") return rawSteps;
-    const flattened: PreviewSegment[][] = [];
-    let pending: PreviewSegment[] = [];
-    for (const step of rawSteps) {
-      for (const seg of step) {
-        if (seg.type === "field" && seg.field.fieldType === "Button") continue;
-        pending.push(seg);
-        if (seg.type === "field") {
-          flattened.push(pending);
-          pending = [];
-        }
-      }
-    }
-    if (pending.length > 0) flattened.push(pending);
-    return flattened.length > 0 ? flattened : rawSteps;
-  }, [rawSteps, settings?.presentationMode]);
+  const steps = useMemo(
+    () =>
+      settings?.presentationMode === "field-by-field"
+        ? chunkSegmentsForFieldByField(rawSteps)
+        : rawSteps,
+    [rawSteps, settings?.presentationMode],
+  );
 
   // Pre-compute per-Step Question lists once so analytics emitters in
   // `StepForm` / `useStepPreviewForm` don't re-walk the Plate tree on every

--- a/src/components/form-components/form-preview-rsc.tsx
+++ b/src/components/form-components/form-preview-rsc.tsx
@@ -4,6 +4,7 @@ import { CompositeComponent } from "@tanstack/react-start/rsc";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { RenderFieldComponent } from "@/components/form-components/render-step-preview-input";
+import { ServerFormIcon } from "@/components/form-components/server-form-icon";
 import { Button } from "@/components/ui/button";
 import { ChevronLeftIcon, ChevronRightIcon } from "@/components/ui/icons";
 import { ProgressBar } from "@/routes/forms/-components/progress-bar";
@@ -14,8 +15,9 @@ import { useFocusFirstField } from "@/hooks/use-focus-first-field";
 import { useMountEffect } from "@/hooks/use-mount-effect";
 import { useStepPreviewForm } from "@/hooks/use-preview-form";
 import { enqueueQuestionProgress } from "@/lib/analytics/track-client";
+import { DEFAULT_ICON } from "@/lib/config/app-config";
 import { CUSTOMIZATION_AUTO_DEFAULTS } from "@/lib/theme/customization-defaults";
-import { cn } from "@/lib/utils";
+import { cn, DEFAULT_ICON_NAME, isHexColor, isValidUrl } from "@/lib/utils";
 import type { PlateFormField } from "@/lib/editor/transform-plate-to-form";
 import { extractQuestionsForStepRSC } from "@/lib/forms/extract-questions";
 import type { QuestionRef } from "@/lib/forms/extract-questions";
@@ -23,7 +25,7 @@ import type {
   ButtonGroupSlotProps,
   FieldSlotProps,
 } from "@/lib/server-fn/public-form-view-rsc.types";
-import type { PublicFormSettings } from "@/types/form-settings";
+import type { PresentationMode, PublicFormSettings } from "@/types/form-settings";
 
 // `src` is the opaque Composite Component payload; `fields` travels alongside
 // so the client can build the TanStack Form instance.
@@ -50,6 +52,8 @@ interface FormPreviewRSCProps {
    * Pre-rendered header composite (cover + icon + title). Server-rendered so
    * the client ships no cover/icon rendering code. `null` when the form has
    * no header content, `undefined` when the viewer requested `hideTitle`.
+   * Skipped server-side for field-by-field mode — that layout renders its
+   * own icon+title client-side.
    */
   header?: unknown;
   settings?: PublicFormSettings;
@@ -62,6 +66,19 @@ interface FormPreviewRSCProps {
    * public form route — builder previews leave this undefined to disable
    * tracking. */
   trackingBase?: TrackingBase;
+  /** Field-by-field metadata. Required when settings.presentationMode is
+   * "field-by-field" — the client renders the icon+title+cover-as-background
+   * layout instead of using the pre-rendered card-mode header composite.
+   * `iconColor` mirrors the builder's icon picker bg color (extracted from
+   * the Plate `formHeader` node server-side). */
+  fieldByFieldMeta?: {
+    title?: string;
+    icon?: string | null;
+    iconColor?: string | null;
+    cover?: string | null;
+    hideTitle?: boolean;
+    isPopup?: boolean;
+  };
 }
 
 const PAGE_MAX_WIDTH = `var(--bf-page-width, ${CUSTOMIZATION_AUTO_DEFAULTS.pageWidth})`;
@@ -213,11 +230,15 @@ const StepFormRSC = ({
   stepRSC,
   isLastStep,
   questions,
+  autoActionButton = false,
 }: {
   stepIndex: number;
   stepRSC: StepRSC;
   isLastStep: boolean;
   questions: QuestionRef[];
+  /** Field-by-field mode: server strips Button fields from segments, so render
+   * an auto Submit/Next here with the Enter/Esc keyboard shortcuts. */
+  autoActionButton?: boolean;
 }) => {
   const { currentStep, totalSteps, goToPrevStep, isSubmitting } = useStepForm();
   const { t } = useTranslation();
@@ -232,7 +253,51 @@ const StepFormRSC = ({
   });
 
   const formRef = useRef<HTMLFormElement>(null);
+  const [isTextareaFocused, setIsTextareaFocused] = useState(false);
   useFocusFirstField(formRef);
+
+  // Field-by-field shortcuts: Enter advances/submits (textareas keep native
+  // newline unless ⌘/Ctrl is held), Esc steps back. Mirrors step-form.tsx.
+  const handleFieldByFieldKeyDown = (event: React.KeyboardEvent<HTMLFormElement>) => {
+    const target = event.target as HTMLElement | null;
+    if (target && formRef.current && !formRef.current.contains(target)) return;
+
+    if (event.key === "Escape") {
+      if (currentStep === 0) return;
+      if (formRef.current?.querySelector('[aria-expanded="true"]')) return;
+      event.preventDefault();
+      event.stopPropagation();
+      goToPrevStep();
+      return;
+    }
+
+    if (event.key !== "Enter") return;
+    if (!target) return;
+    const isInQuestion = target.closest("[data-bf-input]") !== null;
+    const isNavButton =
+      (target.tagName === "BUTTON" || target.getAttribute("role") === "button") && !isInQuestion;
+    if (isNavButton) return;
+
+    const isTextarea = target.tagName === "TEXTAREA";
+    const isMetaEnter = event.metaKey || event.ctrlKey;
+    if (isTextarea && !isMetaEnter) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    formRef.current?.requestSubmit();
+  };
+
+  const handleTextareaFocusChange =
+    (focused: boolean) => (event: React.FocusEvent<HTMLFormElement>) => {
+      if ((event.target as HTMLElement).tagName === "TEXTAREA") {
+        setIsTextareaFocused(focused);
+      }
+    };
+
+  const handleFormFocus = (event: React.FocusEvent<HTMLFormElement>) => {
+    if (autoActionButton) handleTextareaFocusChange(true)(event);
+    handleFieldFocus(event);
+  };
 
   const { tracking } = useStepForm();
 
@@ -341,10 +406,50 @@ const StepFormRSC = ({
         ref={formRef}
         noValidate
         data-bf-field-list
-        onFocus={handleFieldFocus}
+        onKeyDownCapture={autoActionButton ? handleFieldByFieldKeyDown : undefined}
+        onFocus={handleFormFocus}
+        onBlur={autoActionButton ? handleTextareaFocusChange(false) : undefined}
         className="focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
       >
         <TypedComposite src={stepRSC.src} Field={FieldSlot} ButtonGroup={ButtonGroupSlot} />
+        {autoActionButton && (
+          <div
+            className="flex w-full items-center gap-3 pt-2"
+            style={{ maxWidth: "var(--bf-input-width)" }}
+          >
+            <Button
+              type="submit"
+              style={{ fontSize: "13px" }}
+              className="h-9 gap-1.5 rounded-lg px-4"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? t("submitting") : isLastStep ? t("submit") : t("next")}
+            </Button>
+            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+              press{" "}
+              {isTextareaFocused && (
+                <>
+                  <kbd className="rounded border border-border bg-muted/50 px-1.5 py-0.5 font-medium text-foreground">
+                    ⌘
+                  </kbd>
+                  +
+                </>
+              )}
+              <kbd className="rounded border border-border bg-muted/50 px-1.5 py-0.5 font-medium text-foreground">
+                Enter
+              </kbd>
+              <span aria-hidden="true">↵</span>
+            </span>
+            {currentStep > 0 && (
+              <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                <kbd className="rounded border border-border bg-muted/50 px-1.5 py-0.5 font-medium text-foreground">
+                  Esc
+                </kbd>
+                to go back
+              </span>
+            )}
+          </div>
+        )}
       </form.Form>
     </form.AppForm>
   );
@@ -478,6 +583,255 @@ const FormPreviewRSCContent = ({
   );
 };
 
+const WHITE_HEX = "#ffffff";
+const BLACK_HEX = "#000000";
+
+/**
+ * Sprite-icon variant for field-by-field that honors the picker's custom
+ * iconColor. When a color is set we render with that bg + contrasting fg
+ * (white on dark, black on white). Mirrors IconPickerPreview's static
+ * behavior. Falls back to the theme-tinted ServerFormIcon when no color
+ * is set, matching card-mode header rendering.
+ */
+const ColoredSpriteIcon = ({
+  iconName,
+  iconColor,
+  iconSize = "40",
+  size = "80",
+}: {
+  iconName: string;
+  iconColor: string;
+  iconSize?: string;
+  size?: string;
+}) => {
+  const fgColor = iconColor.toLowerCase() === WHITE_HEX ? BLACK_HEX : WHITE_HEX;
+  return (
+    <div
+      className="flex items-center justify-center rounded-full"
+      style={{
+        width: `${size}px`,
+        height: `${size}px`,
+        backgroundColor: iconColor,
+        color: fgColor,
+      }}
+    >
+      <svg height={iconSize} style={{ color: "currentColor" }} viewBox="0 0 18 18" width={iconSize}>
+        <use href={`/api/icons/${iconName}.svg#${iconName}`} />
+      </svg>
+    </div>
+  );
+};
+
+const FieldByFieldHeaderIconRSC = ({
+  icon,
+  iconColor,
+}: {
+  icon: string;
+  iconColor?: string | null;
+}) => {
+  if (icon === DEFAULT_ICON) {
+    return (
+      <span className="flex-shrink-0" data-bf-logo-icon>
+        {iconColor ? (
+          <ColoredSpriteIcon iconName={DEFAULT_ICON_NAME} iconColor={iconColor} />
+        ) : (
+          <ServerFormIcon iconName={DEFAULT_ICON_NAME} iconSize="40" size="80" />
+        )}
+      </span>
+    );
+  }
+
+  if (isValidUrl(icon)) {
+    return (
+      <img
+        src={icon}
+        alt=""
+        width={80}
+        height={80}
+        className="size-20 flex-shrink-0 rounded-md object-cover"
+        data-bf-logo
+      />
+    );
+  }
+
+  return (
+    <span className="flex-shrink-0" data-bf-logo-icon>
+      {iconColor ? (
+        <ColoredSpriteIcon iconName={icon} iconColor={iconColor} />
+      ) : (
+        <ServerFormIcon iconName={icon} iconSize="40" size="80" />
+      )}
+    </span>
+  );
+};
+
+const FieldByFieldRSCContent = ({
+  steps,
+  thankYou,
+  settings,
+  meta,
+}: {
+  steps: StepRSC[];
+  thankYou?: string | null;
+  settings?: PublicFormSettings;
+  meta: NonNullable<FormPreviewRSCProps["fieldByFieldMeta"]>;
+}) => {
+  const { currentStep, totalSteps, isSubmitted, direction, reset } = useStepForm();
+  const { t } = useTranslation();
+  const [redirectCountdown, setRedirectCountdown] = useState<number | null>(null);
+  const currentStepQuestions = useMemo(
+    () => extractQuestionsForStepRSC(steps, currentStep),
+    [steps, currentStep],
+  );
+
+  // eslint-disable-next-line react-doctor/no-cascading-set-state -- single state updated via initial set + interval functional updater
+  useEffect(() => {
+    if (!isSubmitted) return;
+    if (!settings?.redirectOnCompletion || !settings?.redirectUrl) return;
+
+    const delay = settings.redirectDelay ?? 0;
+    if (delay === 0) {
+      window.location.href = settings.redirectUrl;
+      return;
+    }
+
+    setRedirectCountdown(delay);
+    const interval = setInterval(() => {
+      setRedirectCountdown((prev) => {
+        if (prev === null || prev <= 1) {
+          clearInterval(interval);
+          if (settings.redirectUrl) window.location.href = settings.redirectUrl;
+          return null;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [isSubmitted, settings?.redirectOnCompletion, settings?.redirectUrl, settings?.redirectDelay]);
+
+  const { title, icon, iconColor, cover, hideTitle, isPopup } = meta;
+  const coverImage = cover && isValidUrl(cover) ? cover : null;
+  const coverColor = cover && isHexColor(cover) ? cover : null;
+  // In popup mode the avatar/icon is already used as the popup bubble, so
+  // hide it inside the popup to save space and avoid duplication.
+  const hasIcon = !!icon && !isPopup;
+  const showHeader = !hideTitle && (!!title || hasIcon);
+  const hasTint = coverImage?.includes("tint=true") ?? false;
+  const isLastStep = currentStep === steps.length - 1;
+  const currentStepRSC = steps[currentStep];
+
+  return (
+    <div
+      className="relative flex size-full min-h-full flex-col overflow-hidden"
+      style={{
+        backgroundImage: coverImage ? `url("${coverImage}")` : undefined,
+        backgroundColor: coverColor ?? undefined,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        backgroundRepeat: "no-repeat",
+      }}
+      data-bf-cover
+    >
+      {hasTint && (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 z-0 bg-primary opacity-50 mix-blend-color"
+        />
+      )}
+
+      {showHeader && (
+        <div
+          className={cn(
+            "relative z-10 flex items-center gap-4",
+            isPopup ? "px-4.5 pt-3" : "mx-auto w-full px-4 pt-6 sm:px-6 sm:pt-8",
+          )}
+          style={isPopup ? undefined : { maxWidth: PAGE_MAX_WIDTH }}
+        >
+          {hasIcon && icon && <FieldByFieldHeaderIconRSC icon={icon} iconColor={iconColor} />}
+          {title && (
+            <h1
+              data-bf-title
+              style={{ textWrap: "pretty" }}
+              className={cn(
+                "font-serif leading-none font-light -tracking-[0.03em] text-foreground",
+                isPopup ? "text-2xl sm:text-3xl" : "text-6xl sm:text-[48px]",
+              )}
+            >
+              {title}
+            </h1>
+          )}
+        </div>
+      )}
+
+      <div
+        className="relative z-10 mx-auto flex min-h-0 w-full flex-1 flex-col justify-center overflow-hidden px-4 pb-12 sm:px-6"
+        style={{ maxWidth: PAGE_MAX_WIDTH }}
+        data-bf-form-container
+      >
+        {!isSubmitted && settings?.progressBar && totalSteps > 1 && (
+          <div className="mb-4 w-full">
+            <ProgressBar currentStep={currentStep} totalSteps={totalSteps} />
+          </div>
+        )}
+
+        <div className="w-full">
+          {isSubmitted ? (
+            <div className="animate-in duration-300 fade-in slide-in-from-bottom-2">
+              {thankYou ? (
+                <div data-bf-field-list className="space-y-4">
+                  <TypedComposite src={thankYou} />
+                  {reset && (
+                    <div className="flex justify-center pt-4">
+                      <Button
+                        type="button"
+                        onClick={reset}
+                        variant="outline"
+                        size="sm"
+                        className="rounded-lg"
+                      >
+                        {t("submitAnother")}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <DefaultThankYou onReset={reset} />
+              )}
+              {redirectCountdown !== null && (
+                <p className="mt-4 text-center text-muted-foreground">
+                  {t("redirecting", {
+                    n: redirectCountdown,
+                    s: redirectCountdown !== 1 ? "s" : "",
+                  })}
+                </p>
+              )}
+            </div>
+          ) : (
+            <div
+              key={currentStep}
+              className={cn(
+                "w-full animate-in duration-200 fade-in",
+                direction >= 0 ? "slide-in-from-right-2" : "slide-in-from-left-2",
+              )}
+            >
+              {currentStepRSC && (
+                <StepFormRSC
+                  key={currentStep}
+                  stepIndex={currentStep}
+                  stepRSC={currentStepRSC}
+                  isLastStep={isLastStep}
+                  questions={currentStepQuestions}
+                  autoActionButton
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
 export const FormPreviewRSC = ({
   steps,
   thankYou,
@@ -489,6 +843,7 @@ export const FormPreviewRSC = ({
   initialFormData,
   initialCurrentStep,
   trackingBase,
+  fieldByFieldMeta,
 }: FormPreviewRSCProps) => {
   if (steps.length === 0 || stepCount === 0) {
     return (
@@ -502,10 +857,11 @@ export const FormPreviewRSC = ({
     );
   }
 
-  // RSC variant only handles card-mode presentation; field-by-field renders
-  // through FormPreviewFromPlate. Tracking is always `"card"` — single-page
-  // forms emit per-Question events too, matching the plate variant (ADR-0002).
-  const trackingMode: PublicFormTracking["mode"] = "card";
+  const presentationMode: PresentationMode = settings?.presentationMode ?? "card";
+  const isFieldByField = presentationMode === "field-by-field";
+  // Per ADR-0002, tracking is always on — single-page card forms still emit
+  // per-Question view/start/complete events.
+  const trackingMode: PublicFormTracking["mode"] = isFieldByField ? "field-by-field" : "card";
   const tracking: PublicFormTracking | null =
     trackingBase && formId
       ? {
@@ -526,12 +882,21 @@ export const FormPreviewRSC = ({
       initialCurrentStep={initialCurrentStep}
       tracking={tracking}
     >
-      <FormPreviewRSCContent
-        steps={steps}
-        thankYou={thankYou}
-        header={header}
-        settings={settings}
-      />
+      {isFieldByField && fieldByFieldMeta ? (
+        <FieldByFieldRSCContent
+          steps={steps}
+          thankYou={thankYou}
+          settings={settings}
+          meta={fieldByFieldMeta}
+        />
+      ) : (
+        <FormPreviewRSCContent
+          steps={steps}
+          thankYou={thankYou}
+          header={header}
+          settings={settings}
+        />
+      )}
     </StepFormProvider>
   );
 };

--- a/src/hooks/use-draft-autosave.ts
+++ b/src/hooks/use-draft-autosave.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { createPublicSubmission } from "@/lib/server-fn/public-submissions";
 
 const draftKey = (formId: string) => `bf-draft-${formId}`;
+const draftDataKey = (formId: string) => `bf-draft-data-${formId}`;
 
 /**
  * Read the persisted draftId for a form, or generate and persist a fresh one.
@@ -34,8 +35,41 @@ export const clearDraftId = (formId: string) => {
   if (typeof window === "undefined") return;
   try {
     localStorage.removeItem(draftKey(formId));
+    localStorage.removeItem(draftDataKey(formId));
   } catch {
     // localStorage unavailable
+  }
+};
+
+/**
+ * Local mirror of the in-progress draft. Read on every page load to decide
+ * whether to show the resume prompt without a server roundtrip. The server
+ * still has the canonical row (for the operator's submissions dashboard);
+ * this is just the read-path cache.
+ */
+export interface LocalDraft {
+  data: Record<string, unknown>;
+  lastStepReached: number | null;
+  savedAt: number;
+}
+
+export const readLocalDraft = (formId: string): LocalDraft | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(draftDataKey(formId));
+    if (!raw) return null;
+    return JSON.parse(raw) as LocalDraft;
+  } catch {
+    return null;
+  }
+};
+
+const writeLocalDraft = (formId: string, payload: LocalDraft): void => {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(draftDataKey(formId), JSON.stringify(payload));
+  } catch {
+    // quota / private mode — server save still happened, just no local resume
   }
 };
 
@@ -73,6 +107,15 @@ export const useDraftAutoSave = (formId: string) => {
         return true;
       });
       if (!hasAnyValue) return;
+
+      // Mirror locally first so a tab closed mid-flight still leaves a
+      // resumable copy. The read-path uses this; the server row is only for
+      // the operator's submissions dashboard.
+      writeLocalDraft(formId, {
+        data: sanitized,
+        lastStepReached,
+        savedAt: Date.now(),
+      });
 
       const draftId = getOrCreateDraftId(formId);
       try {

--- a/src/lib/editor/transform-plate-for-preview.ts
+++ b/src/lib/editor/transform-plate-for-preview.ts
@@ -294,6 +294,30 @@ const createSegments = (nodes: Value): PreviewSegment[] => {
   return segments;
 };
 
+/**
+ * Re-chunk preview segments for field-by-field presentation: each non-Button
+ * field becomes its own step, with preceding static content carried into the
+ * same step. Authored Button fields are dropped — the runtime auto-renders a
+ * submit/next button per step. If the result is empty (form has no fields),
+ * falls back to the original chunking so static-only previews still render.
+ */
+export const chunkSegmentsForFieldByField = (steps: PreviewSegment[][]): PreviewSegment[][] => {
+  const flattened: PreviewSegment[][] = [];
+  let pending: PreviewSegment[] = [];
+  for (const step of steps) {
+    for (const seg of step) {
+      if (seg.type === "field" && seg.field.fieldType === "Button") continue;
+      pending.push(seg);
+      if (seg.type === "field") {
+        flattened.push(pending);
+        pending = [];
+      }
+    }
+  }
+  if (pending.length > 0) flattened.push(pending);
+  return flattened.length > 0 ? flattened : steps;
+};
+
 export const getFieldsFromSegments = (segments: PreviewSegment[]): PlateFormField[] =>
   segments.filter((seg): seg is FieldSegment => seg.type === "field").map((seg) => seg.field);
 

--- a/src/lib/server-fn/analytics.server.ts
+++ b/src/lib/server-fn/analytics.server.ts
@@ -24,6 +24,7 @@ import { resolveTimeRange, splitTodayVsPast, toDateKey } from "@/lib/analytics/t
 import { planUnlocks } from "@/lib/config/plan-gates";
 import { authForm } from "@/lib/server-fn/auth-helpers.server";
 import { isServerPlan } from "@/lib/server-fn/plan-helpers";
+import { getOrgPlanWithPolarSync } from "@/lib/server-fn/plan-helpers.server";
 import type { FormInsightsMetrics, QuestionDropoffMetrics } from "@/types/analytics";
 
 export type RecordFormVisitInput = {
@@ -76,6 +77,22 @@ export type InsightsFilterInput = {
 // window where a Polar downgrade webhook hasn't yet flipped any cached
 // state.
 export const isAnalyticsEnabled = async (formId: string): Promise<boolean> => {
+  const { display } = await getAnalyticsState(formId);
+  return display;
+};
+
+/**
+ * Returns the two booleans that drive every analytics-availability decision:
+ *   - `toggle`: raw `formSettings.settings.analytics` (what the user can flip)
+ *   - `display`: whether visits/dropoff should render — toggle AND plan unlock
+ *
+ * `display` consults the cached `organization.plan` column. UI surfaces that
+ * need Polar-confirmed state should ignore `display` and re-derive it against
+ * `getOrgPlanWithPolarSync` themselves; recorders are fine with the column.
+ */
+export const getAnalyticsState = async (
+  formId: string,
+): Promise<{ toggle: boolean; display: boolean }> => {
   // Read the LIVE settings (form_settings table), not the working draft —
   // analytics display should reflect what's published, not pending edits.
   const [row] = await db
@@ -85,8 +102,9 @@ export const isAnalyticsEnabled = async (formId: string): Promise<boolean> => {
     .innerJoin(organization, eq(organization.id, workspaces.organizationId))
     .leftJoin(formSettings, eq(formSettings.formId, forms.id))
     .where(eq(forms.id, formId));
-  if (row?.settings?.analytics !== true) return false;
-  return isServerPlan(row.plan) && planUnlocks(row.plan, "analytics");
+  const toggle = row?.settings?.analytics === true;
+  const display = toggle && isServerPlan(row?.plan) && planUnlocks(row.plan, "analytics");
+  return { toggle, display };
 };
 
 export const recordFormVisitImpl = async (
@@ -341,31 +359,44 @@ export interface InsightsAvailability {
    *  unconditionally now, so this is true once anyone has loaded the public
    *  form even if the analytics toggle has never been flipped on. */
   hasAnyVisits: boolean;
-  /** Live `forms.analytics` setting + plan unlock — only true when both the
-   *  toggle is on AND the org plan allows analytics. Drives the "enable
-   *  analytics" prompt vs. showing the dashboard. */
+  /** Raw `formSettings.settings.analytics` value — whether the per-form
+   *  toggle is flipped on, regardless of whether the org plan allows it.
+   *  Lets the empty state tell "off" apart from "on-but-plan-locked". */
+  analyticsToggle: boolean;
+  /** Live toggle AND plan-unlock both true — drives the actual dashboard
+   *  render. False when the toggle is off OR the plan doesn't include
+   *  analytics. */
   analyticsEnabled: boolean;
 }
 
 export const getInsightsAvailabilityImpl = async (
   data: { formId: string },
-  context: { session: { user: { id: string } } },
+  context: { session: { user: { id: string; email?: string | null } } },
   orgId: string,
 ): Promise<InsightsAvailability> => {
   await authForm(data.formId, context.session.user.id, orgId);
 
-  const [[form], [{ value: submissionCount }], [{ value: visitCount }], analyticsEnabled] =
+  // Plan resolves via Polar-sync (the `organization.plan` column drifts if a
+  // webhook missed) but the count queries don't depend on it — run them in
+  // parallel with the Polar roundtrip rather than serializing.
+  const [plan, [form], [{ value: submissionCount }], [{ value: visitCount }], analyticsState] =
     await Promise.all([
+      getOrgPlanWithPolarSync(orgId, context.session.user.email ?? null),
       db.select({ status: forms.status }).from(forms).where(eq(forms.id, data.formId)).limit(1),
       db.select({ value: count() }).from(submissions).where(eq(submissions.formId, data.formId)),
       db.select({ value: count() }).from(formVisits).where(eq(formVisits.formId, data.formId)),
-      isAnalyticsEnabled(data.formId),
+      getAnalyticsState(data.formId),
     ]);
+
+  // `getAnalyticsState` ran without the override (so it could parallelize with
+  // the Polar fetch); re-derive `display` against the Polar-confirmed plan.
+  const analyticsEnabled = analyticsState.toggle && planUnlocks(plan, "analytics");
 
   return {
     formStatus: form?.status ?? "draft",
     submissionCount,
     hasAnyVisits: visitCount > 0,
+    analyticsToggle: analyticsState.toggle,
     analyticsEnabled,
   };
 };

--- a/src/lib/server-fn/forms.ts
+++ b/src/lib/server-fn/forms.ts
@@ -12,7 +12,7 @@ import { defaultFormSettings } from "@/types/form-settings";
 import type { FormSettings } from "@/types/form-settings";
 import { getActiveOrgId } from "./auth-helpers";
 import { authForm, authFormsBulk } from "./auth-helpers.server";
-import { getOrgPlan } from "./plan-helpers.server";
+import { getOrgPlan, getOrgPlanWithPolarSync } from "./plan-helpers.server";
 import { generateShortId } from "@/lib/short-id";
 
 const MAX_SHORT_ID_ATTEMPTS = 5;
@@ -161,6 +161,19 @@ export const setFormAnalytics = createServerFn({ method: "POST" })
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     await authForm(data.formId, context.session.user.id, orgId);
+
+    // Explicit plan gate. `formProSettingsMiddleware` scans input *field names*
+    // for gated settings; this fn's input is `{ enabled }`, not `{ analytics }`,
+    // so the middleware finds zero gates and waves it through. Re-check here
+    // when turning analytics ON. Polar-sync flavour because `organization.plan`
+    // drifts if a webhook missed — same reason getInsightsAvailability uses it.
+    // Turning OFF is always allowed (downgrade path).
+    if (data.enabled) {
+      const plan = await getOrgPlanWithPolarSync(orgId, context.session.user.email ?? null);
+      if (!planUnlocks(plan, "analytics")) {
+        throw new Error("Analytics requires a Pro subscription. Please upgrade to continue.");
+      }
+    }
 
     const now = new Date();
     await db.transaction(async (tx) => {

--- a/src/lib/server-fn/public-form-view-rsc.impl.tsx
+++ b/src/lib/server-fn/public-form-view-rsc.impl.tsx
@@ -7,18 +7,22 @@ import { ServerFormIcon } from "@/components/form-components/server-form-icon";
 import { EditorStatic } from "@/components/ui/editor-static";
 import { DEFAULT_ICON } from "@/lib/config/app-config";
 import { CUSTOMIZATION_AUTO_DEFAULTS } from "@/lib/theme/customization-defaults";
-import { cn, DEFAULT_ICON_NAME, isValidUrl } from "@/lib/utils";
+import { cn, DEFAULT_ICON_NAME, isHexColor, isValidUrl } from "@/lib/utils";
 import {
   fieldLabelId,
   getFieldLabelProps,
   GROUP_FIELD_TYPES,
 } from "@/components/form-components/fields/shared";
-import { transformPlateForPreview } from "@/lib/editor/transform-plate-for-preview";
+import {
+  chunkSegmentsForFieldByField,
+  transformPlateForPreview,
+} from "@/lib/editor/transform-plate-for-preview";
 import type {
   FieldSegment,
   PreviewSegment,
   PreviewStepResult,
 } from "@/lib/editor/transform-plate-for-preview";
+import { extractFormHeader } from "@/lib/editor/transform-plate-to-form";
 import type { PlateFormField } from "@/lib/editor/transform-plate-to-form";
 import { applyFormCacheHeaders } from "@/lib/server-fn/cdn-cache";
 import { getFieldChunkUrls } from "@/lib/server-fn/field-chunk-manifest.server";
@@ -244,7 +248,6 @@ export const renderStepComponent = async (segments: PreviewSegment[]) => {
 };
 
 const VERCEL_BLOB_HOST = ".public.blob.vercel-storage.com";
-const HEX_COLOR_RE = /^#([0-9A-Fa-f]{3}){1,2}$/;
 const PAGE_MAX_WIDTH = `var(--bf-page-width, ${CUSTOMIZATION_AUTO_DEFAULTS.pageWidth})`;
 
 const vercelImg = (url: string, w: number, q = 75) =>
@@ -282,7 +285,7 @@ export const renderHeaderComponent = async ({
   cover,
   customization,
 }: PublicFormHeaderData) => {
-  const coverIsHex = !!cover && HEX_COLOR_RE.test(cover);
+  const coverIsHex = !!cover && isHexColor(cover);
   const coverIsUrl = !!cover && isValidUrl(cover);
   const hasCover = coverIsHex || coverIsUrl;
   const iconIsUrl = !!icon && isValidUrl(icon);
@@ -386,14 +389,25 @@ export const runPublicFormViewRSC = async (data: { shortId: string }) => {
   // skips Cache-Tag entirely, so an empty placeholder is fine here.
   applyFormCacheHeaders(base.form?.id ?? "", { gated: !(base.form && !base.gated) });
 
-  const { steps, thankYouNodes }: PreviewStepResult = base.form
+  const { steps: rawSteps, thankYouNodes }: PreviewStepResult = base.form
     ? transformPlateForPreview(base.form.content as Value)
     : { steps: [], thankYouNodes: null };
+
+  const isFieldByField = base.form?.settings?.presentationMode === "field-by-field";
+  const steps = isFieldByField ? chunkSegmentsForFieldByField(rawSteps) : rawSteps;
+  // Custom icon color lives in the Plate `formHeader` node, not the form row.
+  // Extract here so the field-by-field client header can match the builder.
+  const formHeaderIconColor =
+    isFieldByField && base.form
+      ? (extractFormHeader(base.form.content as Value)?.iconColor ?? null)
+      : null;
 
   const [stepComponents, thankYou, header] = await Promise.all([
     Promise.all(steps.map((segs) => renderStepComponent(segs))),
     renderThankYouComponent(thankYouNodes),
-    base.form
+    // Field-by-field renders its own icon+title header client-side (different
+    // layout: icon beside title, no cover band). Skip the card-mode header.
+    base.form && !isFieldByField
       ? renderHeaderComponent({
           title: base.form.title,
           icon: base.form.icon,
@@ -415,5 +429,6 @@ export const runPublicFormViewRSC = async (data: { shortId: string }) => {
     thankYou,
     header,
     preloadModuleUrls,
+    formHeaderIconColor,
   };
 };

--- a/src/lib/server-fn/public-submissions.ts
+++ b/src/lib/server-fn/public-submissions.ts
@@ -292,41 +292,6 @@ export const createPublicSubmission = createServerFn({ method: "POST" })
     return { submissionId, success: true };
   });
 
-/**
- * Fetch an in-progress draft for a given (formId, draftId) pair so the client
- * can rehydrate the form on refresh. Returns null if no draft exists or the
- * row is already completed (completed rows are not resumable).
- */
-export const getPublicDraft = createServerFn({ method: "GET" })
-  .inputValidator(
-    z.object({
-      formId: z.uuid(),
-      draftId: z.uuid(),
-    }),
-  )
-  .handler(async ({ data }) => {
-    const [row] = await db
-      .select({
-        id: submissions.id,
-        data: submissions.data,
-        isCompleted: submissions.isCompleted,
-        lastStepReached: submissions.lastStepReached,
-      })
-      .from(submissions)
-      .where(and(eq(submissions.formId, data.formId), eq(submissions.draftId, data.draftId)))
-      .limit(1);
-
-    if (!row || row.isCompleted) return { draft: null };
-    return {
-      draft: {
-        submissionId: row.id,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- passed through as opaque JSON
-        data: row.data as Record<string, any>,
-        lastStepReached: row.lastStepReached,
-      },
-    };
-  });
-
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,6 +15,10 @@ export const parseTimestampAsUTC = (value: string | undefined): Date | null => {
 /** Fallback sprite icon name when no icon is set */
 export const DEFAULT_ICON_NAME = "file-06";
 
+/** Matches `#rgb` and `#rrggbb`. Use `HEX_COLOR_WITH_ALPHA_RE` for 8-digit variants. */
+const HEX_COLOR_RE = /^#([0-9A-Fa-f]{3}){1,2}$/;
+export const isHexColor = (str: string): boolean => HEX_COLOR_RE.test(str);
+
 /** Check if a string is a valid URL (absolute, relative path, blob, or data URI) */
 export const isValidUrl = (str: string): boolean => {
   if (!str) return false;

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/$formId/insights.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/$formId/insights.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/lib/server-fn/analytics";
 import { setFormAnalytics } from "@/lib/server-fn/forms";
 import type { TimeRangeFilter } from "@/types/analytics";
+import { settingsDialogStore } from "@/hooks/use-settings-dialog";
 
 const DEFAULT_FILTER: TimeRangeFilter = "last_30_days";
 
@@ -199,11 +200,13 @@ const InsightsPage = () => {
           formStatus={availability?.formStatus ?? "draft"}
           submissionCount={availability?.submissionCount ?? 0}
           hasAnyVisits={availability?.hasAnyVisits ?? false}
+          analyticsToggle={availability?.analyticsToggle ?? false}
           analyticsEnabled={availability?.analyticsEnabled ?? false}
           isEnablingAnalytics={isEnablingAnalytics}
           onPublishClick={goToEditor}
           onShareClick={goToEditor}
           onEnableAnalyticsClick={() => enableAnalytics()}
+          onUpgradeClick={() => settingsDialogStore.open("billing")}
         />
       )}
     </div>

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
@@ -4,10 +4,7 @@ import { SparklesIcon, XIcon } from "@/components/ui/icons";
 import { useState, useCallback, useMemo } from "react";
 import { PopoverContainerContext } from "@/components/ui/popover";
 import type { Value } from "platejs";
-import {
-  FormPreviewFromPlate,
-  isHexColor,
-} from "@/components/form-components/form-preview-from-plate";
+import { FormPreviewFromPlate } from "@/components/form-components/form-preview-from-plate";
 import { extractFormHeader } from "@/lib/editor/transform-plate-to-form";
 import { RenderStepPreviewInputEager } from "@/components/form-components/render-step-preview-input-eager";
 import { PreviewRendererContext } from "@/components/form-components/render-step-preview-input";
@@ -19,7 +16,7 @@ import { useFormThemeContextValue } from "@/hooks/use-form-theme";
 import { useForm } from "@/hooks/use-live-hooks";
 import { useResolvedTheme } from "@/components/theme-provider";
 import { EditorThemeProvider } from "@/contexts/editor-theme-context";
-import { cn, isValidUrl } from "@/lib/utils";
+import { cn, isHexColor, isValidUrl } from "@/lib/utils";
 import { buildPublicFormSettings } from "@/types/form-settings";
 import type { PublicFormSettings } from "@/types/form-settings";
 

--- a/src/routes/forms/$shortId.tsx
+++ b/src/routes/forms/$shortId.tsx
@@ -118,6 +118,7 @@ const PublicFormRoute = () => {
                 thankYou: loaderData.thankYou,
                 stepCount: loaderData.stepCount,
                 header: loaderData.header,
+                formHeaderIconColor: loaderData.formHeaderIconColor,
               }
             : undefined
         }

--- a/src/routes/forms/-components/public-form-page.tsx
+++ b/src/routes/forms/-components/public-form-page.tsx
@@ -6,29 +6,18 @@ import {
   SunIcon,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
-import type { Value } from "platejs";
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-// Lazy: pulls StaticContentBlock → platejs runtime + BaseEditorKit + Plate CSS
-// (~370 kB). The RSC path renders static content server-side, so this fallback
-// only runs when `rsc` is unavailable.
-const FormPreviewFromPlate = lazy(() =>
-  import("@/components/form-components/form-preview-from-plate").then((m) => ({
-    default: m.FormPreviewFromPlate,
-  })),
-);
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FormPreviewRSC } from "@/components/form-components/form-preview-rsc";
 import type { StepRSC } from "@/components/form-components/form-preview-rsc";
 import { BrandingFooter } from "./branding-footer";
 import { AlreadySubmitted, FormClosed } from "@/routes/forms/-components/form-closed";
 import { PasswordGate } from "@/routes/forms/-components/password-gate";
 import { TranslationProvider, useTranslation } from "@/contexts/translation-context";
-import { createPublicSubmission, getPublicDraft } from "@/lib/server-fn/public-submissions";
-import { clearDraftId, readDraftId } from "@/hooks/use-draft-autosave";
+import { createPublicSubmission } from "@/lib/server-fn/public-submissions";
+import { clearDraftId, readDraftId, readLocalDraft } from "@/hooks/use-draft-autosave";
 import { usePublicFormTracking } from "@/lib/analytics/use-public-form-tracking";
 import { getTranslations } from "@/lib/translations";
 import { cn } from "@/lib/utils";
-import { AnimatePresence, motion } from "motion/react";
 import {
   Empty,
   EmptyDescription,
@@ -103,6 +92,9 @@ interface PublicFormPageProps {
     stepCount: number;
     /** Pre-rendered header composite (cover + icon + title). */
     header?: unknown;
+    /** Icon background color extracted from the Plate formHeader node;
+     * field-by-field only (card mode uses the pre-rendered header composite). */
+    formHeaderIconColor?: string | null;
   };
 }
 
@@ -161,49 +153,32 @@ type DraftState =
   | { status: "dismissed" };
 
 const usePublicDraftState = (formId: string) => {
-  const draftId = readDraftId(formId);
-  const draftQuery = useQuery({
-    queryKey: ["publicDraft", formId, draftId],
-    enabled: !!draftId,
-    queryFn: async () => {
-      if (!draftId) return null;
-      const res = await getPublicDraft({ data: { formId, draftId } });
-      return res.draft ?? null;
-    },
-    staleTime: Number.POSITIVE_INFINITY,
-    retry: false,
-  });
+  // Start "loading" so SSR HTML and the first client render match (no
+  // DraftResumePrompt in either). useEffect resolves on mount by reading
+  // localStorage synchronously — no server roundtrip.
+  const [draftState, setDraftState] = useState<DraftState>({ status: "loading" });
 
-  if (draftQuery.isError) {
-    console.error("[Reform] Failed to load draft:", draftQuery.error);
-  }
-
-  const [draftOverride, setDraftOverride] = useState<DraftState | null>(null);
-
-  const computedDraftState: DraftState = useMemo(() => {
-    if (!draftId) return { status: "dismissed" };
-    if (draftQuery.isLoading) return { status: "loading" };
-    if (draftQuery.isError || !draftQuery.data) return { status: "dismissed" };
-    return {
+  useEffect(() => {
+    const local = readLocalDraft(formId);
+    if (!local) {
+      setDraftState({ status: "dismissed" });
+      return;
+    }
+    setDraftState({
       status: "prompt",
-      draft: {
-        data: draftQuery.data.data,
-        lastStepReached: draftQuery.data.lastStepReached,
-      },
-    };
-  }, [draftId, draftQuery.isLoading, draftQuery.isError, draftQuery.data]);
-
-  const draftState: DraftState = draftOverride ?? computedDraftState;
+      draft: { data: local.data, lastStepReached: local.lastStepReached },
+    });
+  }, [formId]);
 
   const handleResumeDraft = useCallback(() => {
-    if (computedDraftState.status === "prompt") {
-      setDraftOverride({ status: "resumed", draft: computedDraftState.draft });
-    }
-  }, [computedDraftState]);
+    setDraftState((prev) =>
+      prev.status === "prompt" ? { status: "resumed", draft: prev.draft } : prev,
+    );
+  }, []);
 
   const handleStartOver = useCallback(() => {
     clearDraftId(formId);
-    setDraftOverride({ status: "dismissed" });
+    setDraftState({ status: "dismissed" });
   }, [formId]);
 
   return { draftState, handleResumeDraft, handleStartOver };
@@ -450,6 +425,15 @@ export const PublicFormPage = ({
     );
   }
 
+  // Loader invariant: when `form` is set so is `rsc`. Defensive only.
+  if (!rsc) {
+    return (
+      <TranslationProvider language={resolvedLanguage}>
+        <FormNotFound />
+      </TranslationProvider>
+    );
+  }
+
   const settings = form.settings ?? defaultPublicFormSettings;
 
   const formContent = (
@@ -524,16 +508,11 @@ const DraftResumePrompt = ({
   handleResumeDraft: () => void;
   handleStartOver: () => void;
 }) => (
-  // x: "-50%" centers via motion's transform (Tailwind -translate-x-1/2 would be clobbered).
   // Anchored top-6: users miss bottom toasts (eyes are on the form), so the
   // resume affordance lives where the gaze already is on first paint.
-  <motion.div
+  <div
     role="status"
-    initial={{ opacity: 0, y: -16, x: "-50%" }}
-    animate={{ opacity: 1, y: 0, x: "-50%" }}
-    exit={{ opacity: 0, y: -16, x: "-50%" }}
-    transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
-    className="fixed top-6 left-1/2 z-50 w-[min(560px,90vw)]"
+    className="fixed top-6 left-1/2 z-50 w-[min(560px,90vw)] -translate-x-1/2 animate-in duration-250 ease-out fade-in slide-in-from-top-4"
   >
     <div className="flex items-center justify-between rounded-xl bg-background px-2.75 py-2.25 shadow-md ring-1 ring-border/60">
       <div className="flex items-center gap-2 ps-1">
@@ -549,7 +528,7 @@ const DraftResumePrompt = ({
         </Button>
       </div>
     </div>
-  </motion.div>
+  </div>
 );
 
 const SubmitErrorToast = ({ submitError }: { submitError: string }) => (
@@ -582,7 +561,7 @@ interface PublicFormMainProps {
     | { status: "dismissed" };
   handleResumeDraft: () => void;
   handleStartOver: () => void;
-  rsc: PublicFormPageProps["rsc"];
+  rsc: NonNullable<PublicFormPageProps["rsc"]>;
   previewKey: string;
   hideTitle: boolean;
   handleSubmit: (values: Record<string, unknown>) => Promise<void>;
@@ -637,47 +616,33 @@ const PublicFormMain = ({
     aria-live="polite"
   >
     {themeToggle && <ThemeToggleButton themeToggle={themeToggle} />}
-    <AnimatePresence>
-      {draftState.status === "prompt" && (
-        <DraftResumePrompt
-          handleResumeDraft={handleResumeDraft}
-          handleStartOver={handleStartOver}
-        />
-      )}
-    </AnimatePresence>
-    {rsc && settings.presentationMode !== "field-by-field" ? (
-      <FormPreviewRSC
-        key={previewKey}
-        steps={rsc.steps}
-        thankYou={(rsc.thankYou as string | null) ?? null}
-        stepCount={rsc.stepCount}
-        header={hideTitle ? null : rsc.header}
-        onSubmit={handleSubmit}
-        settings={settings}
-        formId={formId}
-        trackingBase={trackingBase}
-        {...resumeProps}
-      />
-    ) : (
-      <Suspense fallback={null}>
-        <FormPreviewFromPlate
-          key={previewKey}
-          content={form.content as Value}
-          title={hideTitle ? undefined : form.title}
-          icon={hideTitle ? undefined : (form.icon ?? undefined)}
-          cover={hideTitle ? undefined : (form.cover ?? undefined)}
-          onSubmit={handleSubmit}
-          hideTitle={hideTitle}
-          settings={settings}
-          formId={formId}
-          shortId={form.shortId}
-          customization={form.customization}
-          isPopup={isPopup}
-          trackingBase={trackingBase}
-          {...resumeProps}
-        />
-      </Suspense>
+    {draftState.status === "prompt" && (
+      <DraftResumePrompt handleResumeDraft={handleResumeDraft} handleStartOver={handleStartOver} />
     )}
+    <FormPreviewRSC
+      key={previewKey}
+      steps={rsc.steps}
+      thankYou={(rsc.thankYou as string | null) ?? null}
+      stepCount={rsc.stepCount}
+      header={hideTitle ? null : rsc.header}
+      onSubmit={handleSubmit}
+      settings={settings}
+      formId={formId}
+      trackingBase={trackingBase}
+      fieldByFieldMeta={
+        settings.presentationMode === "field-by-field"
+          ? {
+              title: form.title,
+              icon: form.icon,
+              iconColor: rsc.formHeaderIconColor ?? null,
+              cover: form.cover,
+              hideTitle,
+              isPopup,
+            }
+          : undefined
+      }
+      {...resumeProps}
+    />
     {submitError && <SubmitErrorToast submitError={submitError} />}
     {settings.branding && <BrandingFooter />}
   </main>


### PR DESCRIPTION
… plan gate

- Render field-by-field presentation through the RSC pipeline so static prose stays server-rendered and we can drop the lazy plate fallback on the public form route (one less ~370 kB chunk in the hot path).
- Resolve draft resume from a localStorage mirror instead of a per-load `getPublicDraft` server call; remove the now-unused server fn.
- Distinguish "analytics toggle off" from "toggle on but plan blocks" in the insights empty state and route the locked branch to billing.
- Enforce the analytics plan gate inside `setFormAnalytics` itself (the field-name middleware can't see `{ enabled }` payloads), with Polar sync to avoid drift from a missed webhook.
- Parallelize the Polar plan fetch with the count queries in `getInsightsAvailabilityImpl` so the Polar roundtrip stops blocking the dashboard's submission/visit counts.
- Hoist `isHexColor` to `lib/utils` and share `chunkSegmentsForFieldByField` between the plate and RSC pipelines so they can't drift.