### PR TITLE
perf: per-primitive Base UI chunks, sonner lazy mount

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -2,7 +2,6 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import Loader from "@/components/ui/loader";
 import { NotFound } from "@/components/ui/not-found";
-import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Session } from "@/lib/auth/auth";
 import { seo } from "@/lib/seo";
@@ -10,6 +9,12 @@ import { HotkeysProvider } from "@tanstack/react-hotkeys";
 import type { QueryClient } from "@tanstack/react-query";
 import { createRootRouteWithContext, HeadContent, Scripts } from "@tanstack/react-router";
 import { lazy, Suspense } from "react";
+
+// Lazy: sonner is ~14 kB gz and the public form never fires a toast. Static
+// `import { toast } from "sonner"` calls still pull sonner into their own
+// route chunks (auth/login/builder) — lazying the Toaster MOUNT just keeps
+// the library out of the root entry chunk, which loads on every page.
+const Toaster = lazy(() => import("@/components/ui/sonner").then((m) => ({ default: m.Toaster })));
 // Side-effect import (not `?url`) so the Vite/Start manifest owns the asset:
 // HeadContent emits the <link> automatically, static Early Hints picks it up,
 // and `server.build.inlineCss` (vite.config.ts) can embed it as an inline
@@ -59,7 +64,9 @@ const RootDocument = ({ children }: { children: React.ReactNode }) => (
         <ThemeProvider defaultTheme="system">
           <TooltipProvider>
             {children}
-            <Toaster richColors />
+            <Suspense fallback={null}>
+              <Toaster richColors />
+            </Suspense>
             {process.env.NODE_ENV === "development" && (
               <Suspense>
                 <LazyDevtools />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,15 +83,16 @@ const config = defineConfig({
       rsc: {
         enabled: true,
       },
-      // Embed manifest-managed CSS as an inline <style> in SSR HTML on prod
-      // builds. Drops the high-priority 45 kB stylesheet round-trip on cold
-      // visits. Originally OOM'd the Vercel build when V8 was capped at 8 GB
-      // — paired with the bump to 12 GB in package.json (`build` script) it
-      // should fit. If the build OOMs again, flip back to `false` and revisit
-      // the Vercel build container size.
+      // CSS inlining tried twice (96f4a09, 1d99bb8) — both times it
+      // regressed mobile Perf score by trading a background stylesheet
+      // download for a synchronous ~3s parse/style-recalc block on slow
+      // CPUs (Lighthouse mobile shows 4× ~800 ms "Unattributable" long
+      // tasks at HTML-parse time when 45 kB of CSS lands inline). The
+      // network savings (~one RTT) don't recover the main-thread cost.
+      // Revisit only if the CSS graph is trimmed under ~10 kB.
       server: {
         build: {
-          inlineCss: true,
+          inlineCss: false,
         },
       },
     }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -151,12 +151,21 @@ const config = defineConfig({
             return "shared-runtime";
           if (id.includes("@platejs/") || id.includes("platejs")) return "editor";
           if (id.includes("@radix-ui/")) return "ui";
-          // Pin Base UI primitives to their own chunk. Without this, modules
-          // like `getDisabledMountTransitionStyles` / `useOpenInteractionType`
-          // end up grouped with `editor` by Rollup's auto-chunker, which forces
-          // every field chunk (InputField, TextareaField, …) that uses a Base
-          // UI primitive to pull the full 361 kB platejs chunk + KaTeX CSS.
-          if (id.includes("@base-ui/")) return "ui";
+          // Base UI: split per-primitive (menu, select, popover, …). The
+          // previous one-bucket "ui" chunk shipped 117 kB / 89 kB unused
+          // (76% dead) on the public form because that route only uses a
+          // few primitives. Each primitive gets its own chunk so importing
+          // a field that uses Popover doesn't drag Dialog/Tabs/Accordion/…
+          // along. The umbrella `ui-base-shared` covers `@base-ui/utils`,
+          // `react-remove-scroll`, and any module the regex doesn't match
+          // (cross-primitive internals), still kept out of the editor chunk
+          // for the same reason as before (auto-chunker would otherwise
+          // group these with platejs and drag KaTeX CSS).
+          const baseUiPrimitive = id.match(/@base-ui\/react\/esm\/([^/]+)\//);
+          if (baseUiPrimitive) return `ui-base-${baseUiPrimitive[1]}`;
+          if (id.includes("@base-ui/") || id.includes("react-remove-scroll"))
+            return "ui-base-shared";
+          if (id.includes("@floating-ui/")) return "ui-floating";
           if (id.includes("@sentry/")) return "sentry";
         },
       },


### PR DESCRIPTION
## Summary

Pulls three perf-focused commits from `dev` into `main`. Targets the public form's mobile/cold-cache cost — validated on dev while the desktop side was being tuned on `main`.

- **`743cc0e perf(build): split @base-ui chunks per-primitive`** — old single `ui` bucket shipped 117 kB / 89 kB unused (76% dead) on `/forms/*` because that route only uses popover, select, combobox, checkbox, tooltip while the chunk also pulled in dialog/tabs/accordion/menu/drawer/toolbar etc. that only the builder needs. Splits `@base-ui/react/esm/<primitive>/...` into per-primitive chunks via regex, with `ui-base-shared` for cross-primitive helpers and `ui-floating` for `@floating-ui/*`.

- **`64b3670 perf(root): lazy-load sonner Toaster from __root`** — sonner (~14 kB gz) was eagerly imported via `__root.tsx`'s `<Toaster>` mount, putting it in the main client entry chunk that loads on every page. Public form never fires a toast. Static `import { toast } from "sonner"` callers in auth/login/builder routes still work (sonner stays in those route chunks). Local build: entry chunk 1047 → 1013 kB raw.

- **`1b7df41 perf(build): disable inlineCss — regresses mobile TBT by ~3s`** — disable-trial commit, now superseded. **Main has since landed `8605e55 perf(root): inline CSS via styles.css?inline`** which already keeps the framework `inlineCss` off but uses Vite's `?inline` query to manually inline only `styles.css` (Tailwind output), avoiding the 309 kB multi-chunk inline that triggered the 3s style-recalc on mobile. The 1b7df41 comment is stale — needs to be reconciled with main's newer comment on the same lines.

## Merge note

Conflicts expected — main has diverged with three commits that touch the same files:

- `vite.config.ts` (this PR adds the Base UI per-primitive split; main has the newer inlineCss comment from `8605e55`) → keep main's comment, take this PR's `manualChunks` block
- `__root.tsx` (this PR makes Toaster lazy; main has `styles.css?inline` + manual `<style>` + still-eager Toaster) → combine: keep main's `?inline` CSS, take this PR's lazy Toaster

## Test plan
- [ ] Resolve `vite.config.ts` conflict (main's inlineCss comment + this PR's manualChunks Base UI regex)
- [ ] Resolve `__root.tsx` conflict (main's `?inline` CSS + this PR's lazy Toaster)
- [ ] `pnpm exec tsc --noEmit` clean
- [ ] `pnpm run test` green (51 files / 392 tests baseline)
- [ ] After merge + deploy: confirm `/forms/PrDHp3R` still hits Perf 100 desktop, mobile improves toward 90+
- [ ] Confirm `x-vercel-cache: HIT` still works (cdn-cache fix on main is untouched)