### PR TITLE
fix(icon-picker): derive dark mode from theme, not render-time ref read

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,10 +142,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@faker-js/faker": "^10.4.0",
     "@tanstack/devtools-vite": "^0.5.5",
     "@tanstack/eslint-plugin-query": "^5.100.9",
-    "@tanstack/intent": "^0.0.29",
     "@tanstack/router-devtools-core": "^1.167.3",
     "@tanstack/router-generator": "^1.166.42",
     "@testing-library/jest-dom": "^6.9.1",
@@ -154,7 +152,6 @@
     "@types/node": "^22.19.18",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@typescript/native-preview": "^7.0.0-dev.20260511.1",
     "@vitejs/plugin-react": "^5.2.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "dotenv": "^16.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,18 +342,12 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@faker-js/faker':
-        specifier: ^10.4.0
-        version: 10.4.0
       '@tanstack/devtools-vite':
         specifier: ^0.5.5
         version: 0.5.5(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/eslint-plugin-query':
         specifier: ^5.100.9
         version: 5.100.10(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)
-      '@tanstack/intent':
-        specifier: ^0.0.29
-        version: 0.0.29
       '@tanstack/router-devtools-core':
         specifier: ^1.167.3
         version: 1.167.3(@tanstack/router-core@1.169.2)(csstype@3.2.3)
@@ -378,9 +372,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
-      '@typescript/native-preview':
-        specifier: ^7.0.0-dev.20260511.1
-        version: 7.0.0-dev.20260511.1
       '@vitejs/plugin-react':
         specifier: ^5.2.0
         version: 5.2.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -481,9 +472,11 @@ packages:
 
   '@ariakit/core@0.4.20':
     resolution: {integrity: sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==}
+    deprecated: This package has been split into smaller packages. Use @ariakit/components, @ariakit/store, or @ariakit/utils depending on the APIs you need.
 
   '@ariakit/react-core@0.4.26':
     resolution: {integrity: sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==}
+    deprecated: This package has been split into smaller packages. Use @ariakit/react-components or @ariakit/react-utils depending on the APIs you need.
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1350,10 +1343,6 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
-
-  '@faker-js/faker@10.4.0':
-    resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
   '@fastify/otel@0.18.0':
     resolution: {integrity: sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==}
@@ -3423,10 +3412,6 @@ packages:
     resolution: {integrity: sha512-YHVO1z6wnvUCu7bg870Kv5k2D+FIuIOSIcbN0dAmTTsJ3mLMDLwcTVx0qVaq+SZp1B514JJTqGVstvUp85yIpQ==}
     engines: {node: '>=18'}
 
-  '@tanstack/intent@0.0.29':
-    resolution: {integrity: sha512-tJcWapEkXGRLHE7mQYvQS0xIWrzKm2n7fQ/lOy4LCdR1hX0Yxb9QnwRwd0oqmmr54ObP9/5sfiD8vELxL/r30g==}
-    hasBin: true
-
   '@tanstack/pacer-devtools@1.2.1':
     resolution: {integrity: sha512-812A+OtUNYXLs8S9U0eVwO/SkYi0178HgVZYa18LAB8fge+4ACyf4EJmWXyN/6eOBQRCgbVMt8Lye/GFi86qaQ==}
     engines: {node: '>=18'}
@@ -3962,53 +3947,6 @@ packages:
   '@typescript-eslint/visitor-keys@8.59.3':
     resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260511.1':
-    resolution: {integrity: sha512-SYrqVOlapDxDG7FzHBIJbfgaix+mXPkYzYGqwpz/TAhoPA7sgbfAoGLaqi3ut9N88C/OYNhEX4tjz/0PC9i1nw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260511.1':
-    resolution: {integrity: sha512-zIe31OYgBvkgTIQEwJtKim6SYyuVTkr+9fK/87hVwKN15X3Ikjeh0C0g2W/Vl4rXeMvy95wBGDN1jpW11DIvgg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260511.1':
-    resolution: {integrity: sha512-YbmCQXGYkDChGFG7hXJzIgmRjtU1kE5VK/+k322nGnbq4ePqSjS3dS0+ehPATmvfO1XjCDfh3ekED+AtmWk6aQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260511.1':
-    resolution: {integrity: sha512-02b45lpPmYf125PvcnK67WW93N55qwKmtInwfVefV997S17Ib3h6hlCW4e24BDhNsGRCSLhPA4Lu7ZvTq5pLkw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm]
-    os: [linux]
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260511.1':
-    resolution: {integrity: sha512-e+TweaVJFaM96tV1UM1kRfk2y8QBkZtz7+0wcxrDGmyJz3IIRUlg1btocaBkhsmVtQPXMr37RutBBMgpl3vgUg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260511.1':
-    resolution: {integrity: sha512-zgkoGiCpOrly5h8ghcuu6ZNSfrnRqtHoCq584Q92+s4D/j1MU3oKkGPvmkezp5Mj2v7ffR9AjU+lWRDkrfm6eA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260511.1':
-    resolution: {integrity: sha512-SUm7iVYzKaflol+QwH0Ny5jZtco6PJduI+h/TEg0sgBJzVBa+9RN4I9+Xu9v+EJ1bci3XI7835IRdSP36lCgCw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@typescript/native-preview@7.0.0-dev.20260511.1':
-    resolution: {integrity: sha512-cUyY4Sr6065280lB6hCwTMCBMTxlEIGjSLzHym28yikA5sFiEsAzlwiU0i+XkTUIqr5K5M/SzSJiioDN+vpjtA==}
-    engines: {node: '>=16.20.0'}
-    hasBin: true
 
   '@udecode/cn@52.3.4':
     resolution: {integrity: sha512-mf+vcfWl1N3Vo5lqiX79zggiun0ftbue0/DMoWfQiZrym64nxJ7emfOMm8Hb5MI0MoTEncg2Zvr7ntoIgrMN8g==}
@@ -8698,8 +8636,6 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.2.0
 
-  '@faker-js/faker@10.4.0': {}
-
   '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -10576,11 +10512,6 @@ snapshots:
     dependencies:
       '@tanstack/store': 0.9.3
 
-  '@tanstack/intent@0.0.29':
-    dependencies:
-      cac: 6.7.14
-      yaml: 2.9.0
-
   '@tanstack/pacer-devtools@1.2.1(@tanstack/pacer@0.20.1)(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@tanstack/devtools-ui': 0.5.1(csstype@3.2.3)(solid-js@1.9.12)
@@ -11261,37 +11192,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.59.3
       eslint-visitor-keys: 5.0.1
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260511.1':
-    optional: true
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260511.1':
-    optional: true
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260511.1':
-    optional: true
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260511.1':
-    optional: true
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260511.1':
-    optional: true
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260511.1':
-    optional: true
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260511.1':
-    optional: true
-
-  '@typescript/native-preview@7.0.0-dev.20260511.1':
-    optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260511.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260511.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260511.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260511.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260511.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260511.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260511.1
 
   '@udecode/cn@52.3.4(@types/react@19.2.14)(class-variance-authority@0.7.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwind-merge@3.6.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,49 @@ minimumReleaseAgeExclude:
   - "@ai-sdk/openai"
   - "@ai-sdk/google"
   - "@ai-sdk/gateway@3.0.119"
+  # Re-enabling minimumReleaseAge (2026-05-27): the lockfile currently pins
+  # these packages to versions published within the last 7 days (publish dates
+  # 2026-05-20 .. 2026-05-22). Without excluding them, `pnpm install
+  # --frozen-lockfile` fails the quarantine. Remove individual entries once
+  # their pinned version ages past the 7-day window.
+  #  - TanStack Start / Router 1.168.x–1.171.x bump
+  - "@tanstack/react-start-client"
+  - "@tanstack/react-start-rsc"
+  - "@tanstack/react-start-server"
+  - "@tanstack/router-core"
+  - "@tanstack/router-generator"
+  - "@tanstack/router-plugin"
+  - "@tanstack/router-utils"
+  - "@tanstack/start-client-core"
+  - "@tanstack/start-plugin-core"
+  - "@tanstack/start-server-core"
+  - "@tanstack/start-storage-context"
+  #  - Rolldown 1.0.2 + per-platform bindings (transitive via Vite/Start)
+  - "rolldown"
+  - "@rolldown/binding-android-arm64"
+  - "@rolldown/binding-darwin-arm64"
+  - "@rolldown/binding-darwin-x64"
+  - "@rolldown/binding-freebsd-x64"
+  - "@rolldown/binding-linux-arm-gnueabihf"
+  - "@rolldown/binding-linux-arm64-gnu"
+  - "@rolldown/binding-linux-arm64-musl"
+  - "@rolldown/binding-linux-ppc64-gnu"
+  - "@rolldown/binding-linux-s390x-gnu"
+  - "@rolldown/binding-linux-x64-gnu"
+  - "@rolldown/binding-linux-x64-musl"
+  - "@rolldown/binding-openharmony-arm64"
+  - "@rolldown/binding-wasm32-wasi"
+  - "@rolldown/binding-win32-arm64-msvc"
+  - "@rolldown/binding-win32-x64-msvc"
+  #  - Nitro 3 beta + transitive server deps
+  - "nitro"
+  - "env-runner"
+  - "httpxy"
+
+# 7-day supply-chain quarantine (see CLAUDE.md). Freshly published registry
+# versions are held back for 10080 minutes; the explicit exclude list above
+# carries the deliberate exceptions.
+minimumReleaseAge: 10080
 
 # Hoist these transitive deps to the node_modules root so direct imports keep
 # resolving:

--- a/src/components/form-builder/insights/dropoff-sankey.lazy.tsx
+++ b/src/components/form-builder/insights/dropoff-sankey.lazy.tsx
@@ -1,0 +1,6 @@
+import { lazy } from "react";
+
+// Recharts is heavy; code-split the Flow funnel so it only loads when the Flow tab renders.
+export const DropoffSankey = lazy(() =>
+  import("./dropoff-sankey").then((m) => ({ default: m.DropoffSankey })),
+);

--- a/src/components/form-builder/settings-content.tsx
+++ b/src/components/form-builder/settings-content.tsx
@@ -20,7 +20,7 @@ import {
   setFormInAppNotificationPreference,
 } from "@/lib/server-fn/notifications";
 import { defaultFormSettings } from "@/types/form-settings";
-import { EyeIcon, EyeOffIcon } from "@/components/ui/icons";
+import { EyeIcon, EyeOffIcon, Loader2Icon } from "@/components/ui/icons";
 import { IconSwap } from "@/components/transitions/icon-swap";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { parseError } from "@/lib/errors/parse";
@@ -77,6 +77,22 @@ const getBrowserPermissionLabel = (permission: BrowserNotificationPermission) =>
 };
 
 export const SettingsContent = ({ formId, isLocal }: { formId: string; isLocal?: boolean }) => {
+  const cloudForm = useForm(isLocal ? undefined : formId);
+  const localFormResult = useLocalForm(isLocal ? formId : undefined);
+  const formResult = isLocal ? localFormResult : cloudForm;
+  // Gate so useAppForm below initializes from loaded draftSettings, not the
+  // empty defaults it would capture before the collection is ready.
+  if (formResult.data === undefined) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <Loader2Icon aria-hidden="true" className="size-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+  return <SettingsContentInner formId={formId} isLocal={isLocal} />;
+};
+
+const SettingsContentInner = ({ formId, isLocal }: { formId: string; isLocal?: boolean }) => {
   const cloudForm = useForm(isLocal ? undefined : formId);
   const localFormResult = useLocalForm(isLocal ? formId : undefined);
   const formResult = isLocal ? localFormResult : cloudForm;

--- a/src/components/icon-picker/color-picker.tsx
+++ b/src/components/icon-picker/color-picker.tsx
@@ -1,5 +1,4 @@
-import { useRef } from "react";
-
+import { useResolvedTheme } from "@/components/theme-provider";
 import { cn } from "@/lib/utils";
 
 // prettier-ignore
@@ -18,8 +17,7 @@ type ColorPickerProps = {
 };
 
 export const ColorPicker = ({ onChange, selectedColor, colors }: ColorPickerProps) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const isDark = ref.current?.closest(".dark") != null;
+  const isDark = useResolvedTheme() === "dark";
 
   const COLORS = colors || DEFAULT_COLORS;
 
@@ -47,7 +45,7 @@ export const ColorPicker = ({ onChange, selectedColor, colors }: ColorPickerProp
   const baseLightColor = !colors ? COLORS[0] : null;
 
   return (
-    <div ref={ref} className={cn("flex", "cursor-pointer", "items-center", "space-x-1")}>
+    <div className={cn("flex", "cursor-pointer", "items-center", "space-x-1")}>
       {displayColors.map((colorItem) => (
         <div
           className={cn("rounded-md", "p-1", "hover:bg-muted", {

--- a/src/components/icon-picker/icon-picker-preview.tsx
+++ b/src/components/icon-picker/icon-picker-preview.tsx
@@ -1,5 +1,3 @@
-import { useRef } from "react";
-
 import { useResolvedTheme } from "@/components/theme-provider";
 import { getThemeStyleVars } from "@/lib/theme/generate-theme-css";
 import { DEFAULT_ICON, SPRITE_PATH } from "@/lib/config/app-config";
@@ -63,15 +61,13 @@ export const IconPickerPreview = ({
   useThemeColor = false,
   standaloneIcon = false,
 }: IconPickerPreviewProps) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const isDarkMode = ref.current?.closest(".dark") != null;
+  const isDarkMode = useResolvedTheme() === "dark";
 
   const matchedIcon = icon ? iconMap.get(icon) : undefined;
 
   if (useThemeColor) {
     return (
       <div
-        ref={ref}
         className="flex items-center justify-center rounded-full bg-primary text-primary-foreground"
         style={{
           width: `${size}px`,
@@ -94,7 +90,6 @@ export const IconPickerPreview = ({
 
   return (
     <div
-      ref={ref}
       className="flex items-center justify-center rounded-full"
       style={{
         backgroundColor: adjustedBgColor,

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -507,12 +507,12 @@ const AppSidebar = () => {
     setIsOpen: setIsPaletteOpen,
   } = useCommandPalette();
 
+  const [trashDialogOpen, setTrashDialogOpen] = useState(false);
+  const [paletteSearch, setPaletteSearch] = useState("");
+
   const handleOpenSettings = useCallback(() => settingsDialogStore.open(), []);
 
   const handleOpenTrash = useCallback(() => setTrashDialogOpen(true), []);
-
-  const [trashDialogOpen, setTrashDialogOpen] = useState(false);
-  const [paletteSearch, setPaletteSearch] = useState("");
 
   // Subscribe to loader-primed org query (not loader data) to stay active: refetch on focus/reconnect, react to invalidation, no GC while on screen.
   const { data: activeOrg } = useQuery({

--- a/src/routes/_authenticated/-components/settings/account-settings-content.tsx
+++ b/src/routes/_authenticated/-components/settings/account-settings-content.tsx
@@ -181,8 +181,22 @@ const profileFormDefaults = {
 };
 
 export const AccountSettingsContent = () => {
+  const { data: session, isPending } = useSession();
+  // Gate before the form so useAppForm initializes from loaded session data —
+  // TanStack Form reads defaultValues once on mount and won't re-sync later.
+  if (isPending || !session?.user) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <Loader2Icon aria-hidden="true" className="size-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+  return <AccountSettingsForm />;
+};
+
+const AccountSettingsForm = () => {
   const queryClient = useQueryClient();
-  const { data: session, isPending: isSessionPending } = useSession();
+  const { data: session } = useSession();
   const user = session?.user;
 
   const profileForm = useAppForm({
@@ -297,14 +311,6 @@ export const AccountSettingsContent = () => {
     () => handleDisconnectAccount("google"),
     [handleDisconnectAccount],
   );
-
-  if (isSessionPending) {
-    return (
-      <div className="flex items-center justify-center p-12">
-        <Loader2Icon aria-hidden="true" className="size-8 animate-spin text-muted-foreground" />
-      </div>
-    );
-  }
 
   return (
     <profileForm.AppForm>

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/$formId/insights.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/$formId/insights.tsx
@@ -1,11 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useCallback, useState } from "react";
+import { Suspense, useCallback, useState } from "react";
+import { DropoffSankey } from "@/components/form-builder/insights/dropoff-sankey.lazy";
 import { toast } from "sonner";
 
 import { BreakdownCards } from "@/components/form-builder/insights/breakdown-cards";
 import { DropoffFunnel } from "@/components/form-builder/insights/dropoff-funnel";
-import { DropoffSankey } from "@/components/form-builder/insights/dropoff-sankey";
 import { EmptyState } from "@/components/form-builder/insights/empty-state";
 import { MetricsRow } from "@/components/form-builder/insights/metrics-row";
 import { TimeRangeSelector } from "@/components/form-builder/insights/time-range-selector";
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { RefreshCwIcon } from "@/components/ui/icons";
 import Loader from "@/components/ui/loader";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsIndicator, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import {
@@ -252,7 +253,9 @@ const InsightsPage = () => {
                   <DropoffFunnel dropoff={dropoff} />
                 </TabsContent>
                 <TabsContent value="flow">
-                  <DropoffSankey dropoff={dropoff} />
+                  <Suspense fallback={<Skeleton className="h-[320px] w-full" />}>
+                    <DropoffSankey dropoff={dropoff} />
+                  </Suspense>
                 </TabsContent>
               </Tabs>
             </CardContent>


### PR DESCRIPTION
color-picker and icon-picker-preview detected dark mode via
`ref.current?.closest(".dark")` during render. The ref is null on the
first render and SSR, so the swap computed light and never corrected
(refs don't trigger re-render) — wrong palette ordering and icon colors
in dark mode. Switch to useResolvedTheme(); the global app theme is the
single source of truth for mode, so this is equivalent and reactive.

Also reorder AppSidebar's useState above the handleOpenTrash callback
that references the setter, so the React Compiler can memoize it.

Resolves the react-doctor compiler `refs` and `immutability` errors on
these files.color-picker and icon-picker-preview detected dark mode via
`ref.current?.closest(".dark")` during render. The ref is null on the
first render and SSR, so the swap computed light and never corrected
(refs don't trigger re-render) — wrong palette ordering and icon colors
in dark mode. Switch to useResolvedTheme(); the global app theme is the
single source of truth for mode, so this is equivalent and reactive.

Also reorder AppSidebar's useState above the handleOpenTrash callback
that references the setter, so the React Compiler can memoize it.

Resolves the react-doctor compiler `refs` and `immutability` errors on
these files.