### PR TITLE
perf(validation): migrate zod → valibot (−17.9 kB gz off public form)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@tanstack/react-virtual": "^3.13.24",
     "@tanstack/router-core": "^1.169.2",
     "@tanstack/router-plugin": "^1.167.35",
-    "@tanstack/zod-adapter": "^1.166.9",
     "@udecode/cn": "^52.3.4",
     "@unpic/react": "^1.0.2",
     "@vercel/blob": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "tw-animate-css": "^1.4.0",
     "type-fest": "^5.6.0",
     "use-file-picker": "2.1.2",
+    "valibot": "1.4.0",
     "vaul": "^1.1.2",
     "vite-tsconfig-paths": "^6.1.1",
     "web-vitals": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@ai-sdk/google": "^3.0.79",
     "@ai-sdk/openai": "^3.0.65",
     "@ai-sdk/react": "3.0.192",
+    "@ai-sdk/valibot": "2.0.28",
     "@ariakit/react": "^0.4.26",
     "@base-ui/react": "^1.4.1",
     "@dnd-kit/core": "^6.3.1",
@@ -87,6 +88,7 @@
     "@tanstack/router-plugin": "^1.167.35",
     "@udecode/cn": "^52.3.4",
     "@unpic/react": "^1.0.2",
+    "@valibot/to-json-schema": "1.7.0",
     "@vercel/blob": "^2.3.3",
     "@vercel/og": "^0.11.1",
     "@vercel/sdk": "^1.21.1",
@@ -137,8 +139,7 @@
     "valibot": "1.4.0",
     "vaul": "^1.1.2",
     "vite-tsconfig-paths": "^6.1.1",
-    "web-vitals": "5.2.0",
-    "zod": "^4.4.3"
+    "web-vitals": "5.2.0"
   },
   "devDependencies": {
     "@tanstack/devtools-vite": "^0.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@ai-sdk/react':
         specifier: 3.0.192
         version: 3.0.192(react@19.2.6)(zod@4.4.3)
+      '@ai-sdk/valibot':
+        specifier: 2.0.28
+        version: 2.0.28(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.9.3)))(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3)
       '@ariakit/react':
         specifier: ^0.4.26
         version: 0.4.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -182,6 +185,9 @@ importers:
       '@unpic/react':
         specifier: ^1.0.2
         version: 1.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@valibot/to-json-schema':
+        specifier: 1.7.0
+        version: 1.7.0(valibot@1.4.0(typescript@5.9.3))
       '@vercel/blob':
         specifier: ^2.3.3
         version: 2.3.3
@@ -335,9 +341,6 @@ importers:
       web-vitals:
         specifier: 5.2.0
         version: 5.2.0
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
     devDependencies:
       '@tanstack/devtools-vite':
         specifier: ^0.5.5
@@ -462,6 +465,13 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
+
+  '@ai-sdk/valibot@2.0.28':
+    resolution: {integrity: sha512-IR1o0QA9kYxnWZjbVWyuqNiLvvGPGb1rxn5LDmGSe9OBbMf4t9EGQMFkADa96vp4lKk+CFVFX04ovpDm4oyo8g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@valibot/to-json-schema': ^1.3.0
+      valibot: ^1.1.0
 
   '@antfu/ni@25.0.0':
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
@@ -3976,6 +3986,11 @@ packages:
     peerDependenciesMeta:
       next:
         optional: true
+
+  '@valibot/to-json-schema@1.7.0':
+    resolution: {integrity: sha512-Y3pPVibbIOHzohrlxSINvO7w/bvXkoYS3BQHoImV9ynE+bXKf171bdMucPurV2zp7gdmt0L1HCcNAsbo7cFRQw==}
+    peerDependencies:
+      valibot: ^1.4.0
 
   '@vercel/blob@2.3.3':
     resolution: {integrity: sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==}
@@ -7943,6 +7958,14 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  '@ai-sdk/valibot@2.0.28(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.9.3)))(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@valibot/to-json-schema': 1.7.0(valibot@1.4.0(typescript@5.9.3))
+      valibot: 1.4.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - zod
+
   '@antfu/ni@25.0.0':
     dependencies:
       ansis: 4.3.0
@@ -11221,6 +11244,10 @@ snapshots:
       '@unpic/core': 1.0.3
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+
+  '@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.9.3))':
+    dependencies:
+      valibot: 1.4.0(typescript@5.9.3)
 
   '@vercel/blob@2.3.3':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         version: 52.3.10(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(platejs@52.3.21(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@polar-sh/better-auth':
         specifier: ^1.8.4
-        version: 1.8.4(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@stripe/stripe-js@7.9.0)(better-auth@1.6.10(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.9(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@1.0.0-rc.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.6)(zod@4.4.3)
+        version: 1.8.4(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@stripe/stripe-js@7.9.0)(better-auth@1.6.10(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.9(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@1.0.0-rc.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.6)(zod@4.4.3)
       '@polar-sh/sdk':
         specifier: ^0.42.5
         version: 0.42.5
@@ -205,7 +205,7 @@ importers:
         version: 6.0.190(zod@4.4.3)
       better-auth:
         specifier: ^1.6.10
-        version: 1.6.10(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.9(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@1.0.0-rc.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.6.10(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.9(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@1.0.0-rc.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -220,13 +220,13 @@ importers:
         version: 4.1.0
       drizzle-orm:
         specifier: 1.0.0-rc.1
-        version: 1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3)
+        version: 1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3)
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.6)
       evlog:
         specifier: ^2.17.0
-        version: 2.17.0(@tanstack/start-client-core@1.170.1)(ai@6.0.190(zod@4.4.3))(express@5.2.1)(hono@4.12.18)(nitro@3.0.260522-beta(@vercel/blob@2.3.3)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.3.6)(rollup@4.60.3)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(ofetch@2.0.0-alpha.3)(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 2.17.0(@tanstack/start-client-core@1.170.1)(ai@6.0.190(zod@4.4.3))(express@5.2.1)(hono@4.12.18)(nitro@3.0.260522-beta(@vercel/blob@2.3.3)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.3.6)(rollup@4.60.3)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(ofetch@2.0.0-alpha.3)(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       fractional-indexing:
         specifier: ^3.2.0
         version: 3.2.0
@@ -253,7 +253,7 @@ importers:
         version: 5.1.11
       nitro:
         specifier: latest
-        version: 3.0.260522-beta(@vercel/blob@2.3.3)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.3.6)(rollup@4.60.3)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 3.0.260522-beta(@vercel/blob@2.3.3)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.3.6)(rollup@4.60.3)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       platejs:
         specifier: ^52.3.21
         version: 52.3.21(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6))
@@ -326,6 +326,9 @@ importers:
       use-file-picker:
         specifier: 2.1.2
         version: 2.1.2(react@19.2.6)
+      valibot:
+        specifier: 1.4.0
+        version: 1.4.0(typescript@5.9.3)
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -383,7 +386,7 @@ importers:
         version: 1.0.0-rc.1
       drizzle-seed:
         specifier: 1.0.0-rc.1
-        version: 1.0.0-rc.1(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))
+        version: 1.0.0-rc.1(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))
       esbuild:
         specifier: ^0.24.2
         version: 0.24.2
@@ -7596,6 +7599,14 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  valibot@1.4.0:
+    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -8226,12 +8237,12 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))':
+  '@better-auth/drizzle-adapter@1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3)
 
   '@better-auth/kysely-adapter@1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
     dependencies:
@@ -9693,11 +9704,11 @@ snapshots:
       - scheduler
       - use-sync-external-store
 
-  '@polar-sh/better-auth@1.8.4(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@stripe/stripe-js@7.9.0)(better-auth@1.6.10(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.9(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@1.0.0-rc.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.6)(zod@4.4.3)':
-    dependencies:
+  ? '@polar-sh/better-auth@1.8.4(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@stripe/stripe-js@7.9.0)(better-auth@1.6.10(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.9(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@1.0.0-rc.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0)))(react@19.2.6)(zod@4.4.3)'
+  : dependencies:
       '@polar-sh/checkout': 0.2.1(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@stripe/stripe-js@7.9.0)(react@19.2.6)
       '@polar-sh/sdk': 0.42.5
-      better-auth: 1.6.10(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.9(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@1.0.0-rc.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0))
+      better-auth: 1.6.10(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.9(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@1.0.0-rc.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0))
       zod: 4.4.3
     transitivePeerDependencies:
       - '@stripe/react-stripe-js'
@@ -11452,10 +11463,10 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
-  better-auth@1.6.10(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.9(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@1.0.0-rc.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0)):
+  better-auth@1.6.10(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.9(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@1.0.0-rc.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@better-auth/core': 1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))
+      '@better-auth/drizzle-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))
       '@better-auth/kysely-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -11474,7 +11485,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-start': 1.168.9(@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       drizzle-kit: 1.0.0-rc.1
-      drizzle-orm: 1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       solid-js: 1.9.12
@@ -11854,9 +11865,9 @@ snapshots:
 
   dayjs@1.11.20: {}
 
-  db0@0.3.4(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3)):
+  db0@0.3.4(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3)):
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3)
 
   debug@4.4.3:
     dependencies:
@@ -11947,16 +11958,17 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.15.6
       postgres: 3.4.9
+      valibot: 1.4.0(typescript@5.9.3)
       zod: 4.4.3
 
-  drizzle-seed@1.0.0-rc.1(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3)):
+  drizzle-seed@1.0.0-rc.1(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3)):
     dependencies:
-      drizzle-orm: 1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3)
       pure-rand: 6.1.0
 
   dunder-proto@1.0.1:
@@ -12224,13 +12236,13 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.8
 
-  evlog@2.17.0(@tanstack/start-client-core@1.170.1)(ai@6.0.190(zod@4.4.3))(express@5.2.1)(hono@4.12.18)(nitro@3.0.260522-beta(@vercel/blob@2.3.3)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.3.6)(rollup@4.60.3)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(ofetch@2.0.0-alpha.3)(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
+  evlog@2.17.0(@tanstack/start-client-core@1.170.1)(ai@6.0.190(zod@4.4.3))(express@5.2.1)(hono@4.12.18)(nitro@3.0.260522-beta(@vercel/blob@2.3.3)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.3.6)(rollup@4.60.3)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))(ofetch@2.0.0-alpha.3)(react@19.2.6)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
       '@tanstack/start-client-core': 1.170.1
       ai: 6.0.190(zod@4.4.3)
       express: 5.2.1
       hono: 4.12.18
-      nitro: 3.0.260522-beta(@vercel/blob@2.3.3)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.3.6)(rollup@4.60.3)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      nitro: 3.0.260522-beta(@vercel/blob@2.3.3)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.3.6)(rollup@4.60.3)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       ofetch: 2.0.0-alpha.3
       react: 19.2.6
       vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -13609,11 +13621,11 @@ snapshots:
 
   nf3@0.3.17: {}
 
-  nitro@3.0.260522-beta(@vercel/blob@2.3.3)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.3.6)(rollup@4.60.3)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
+  nitro@3.0.260522-beta(@vercel/blob@2.3.3)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.3.6)(rollup@4.60.3)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.15)
-      db0: 0.3.4(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))
+      db0: 0.3.4(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))
       env-runner: 0.1.9
       h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15))
       hookable: 6.1.1
@@ -13624,7 +13636,7 @@ snapshots:
       rolldown: 1.0.2
       srvx: 0.11.15
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(@vercel/blob@2.3.3)(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3)))(lru-cache@11.3.6)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(@vercel/blob@2.3.3)(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3)))(lru-cache@11.3.6)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 16.6.1
       jiti: 2.7.0
@@ -14924,11 +14936,11 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unstorage@2.0.0-alpha.7(@vercel/blob@2.3.3)(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3)))(lru-cache@11.3.6)(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(@vercel/blob@2.3.3)(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3)))(lru-cache@11.3.6)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       '@vercel/blob': 2.3.3
       chokidar: 5.0.0
-      db0: 0.3.4(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(zod@4.4.3))
+      db0: 0.3.4(drizzle-orm@1.0.0-rc.1(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)(valibot@1.4.0(typescript@5.9.3))(zod@4.4.3))
       lru-cache: 11.3.6
       ofetch: 2.0.0-alpha.3
 
@@ -15004,6 +15016,10 @@ snapshots:
       react: 19.2.6
 
   util-deprecate@1.0.2: {}
+
+  valibot@1.4.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   validate-npm-package-name@7.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,9 +176,6 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.167.35
         version: 1.167.35(@tanstack/react-router@1.170.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@tanstack/zod-adapter':
-        specifier: ^1.166.9
-        version: 1.166.9(@tanstack/react-router@1.170.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(zod@4.4.3)
       '@udecode/cn':
         specifier: ^52.3.4
         version: 52.3.4(@types/react@19.2.14)(class-variance-authority@0.7.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwind-merge@3.6.0)
@@ -3746,13 +3743,6 @@ packages:
   '@tanstack/virtual-file-routes@1.162.0':
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
     engines: {node: '>=20.19'}
-
-  '@tanstack/zod-adapter@1.166.9':
-    resolution: {integrity: sha512-HHllQ/CKGi8YBbftv6OmzojtHM6Rk4UszAFICAgUMbwiqtKqjlIZQ/7mv2IPNxBb8YlOQgzyQ4jz2UTEXIi6YA==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@tanstack/react-router': '>=1.43.2'
-      zod: ^3.23.8
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -10963,11 +10953,6 @@ snapshots:
   '@tanstack/virtual-file-routes@1.161.7': {}
 
   '@tanstack/virtual-file-routes@1.162.0': {}
-
-  '@tanstack/zod-adapter@1.166.9(@tanstack/react-router@1.170.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(zod@4.4.3)':
-    dependencies:
-      '@tanstack/react-router': 1.170.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      zod: 4.4.3
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/src/collections/local/form.ts
+++ b/src/collections/local/form.ts
@@ -1,6 +1,6 @@
 /** Local-only form collection (localStorage-backed) for unauthenticated drafts; independent of the query-based collections. */
 import { createCollection, localStorageCollectionOptions } from "@tanstack/react-db";
-import { z } from "zod";
+import * as v from "valibot";
 import { createFormHeaderNode } from "@/lib/form-schema/form-header-factory";
 import { defaultFormSettings } from "@/types/form-settings";
 import type { FormSettings } from "@/types/form-settings";
@@ -11,33 +11,39 @@ const parseAsUTC = (val: string): string => {
   return new Date(val.replace(" ", "T") + "Z").toISOString();
 };
 
-const timestampField = z
-  .string()
-  .optional()
-  .transform((val) => (val ? parseAsUTC(val) : new Date().toISOString()));
+const timestampField = v.pipe(
+  v.optional(v.string()),
+  v.transform((val) => (val ? parseAsUTC(val) : new Date().toISOString())),
+);
 
-export const FormSchema = z.object({
-  id: z.uuid(),
-  createdByUserId: z.string().optional(),
-  workspaceId: z.uuid(),
-  title: z.string().default("Untitled"),
-  formName: z.string().default("draft"),
-  schemaName: z.string().default("draftFormSchema"),
-  content: z.array(z.any()).default([]),
-  icon: z.string().nullable().optional(),
-  cover: z.string().nullable().optional(),
-  status: z.enum(["draft", "published", "archived"]).default("draft"),
-  lastPublishedVersionId: z.string().nullable().optional(),
-  publishedContentHash: z.string().nullable().optional(),
-  draftSettings: z.custom<FormSettings>().default(() => defaultFormSettings),
+export const FormSchema = v.object({
+  id: v.pipe(v.string(), v.uuid()),
+  createdByUserId: v.optional(v.string()),
+  workspaceId: v.pipe(v.string(), v.uuid()),
+  title: v.optional(v.string(), "Untitled"),
+  formName: v.optional(v.string(), "draft"),
+  schemaName: v.optional(v.string(), "draftFormSchema"),
+  content: v.optional(v.array(v.any()), []),
+  icon: v.nullish(v.string()),
+  cover: v.nullish(v.string()),
+  status: v.optional(v.picklist(["draft", "published", "archived"]), "draft"),
+  lastPublishedVersionId: v.nullish(v.string()),
+  publishedContentHash: v.nullish(v.string()),
+  draftSettings: v.optional(
+    v.custom<FormSettings>(() => true),
+    () => defaultFormSettings,
+  ),
   // Live settings — no server row for local drafts; mirrors draft until sign-in + publish.
-  liveSettings: z.custom<FormSettings | null>().default(() => null),
-  customization: z.record(z.string(), z.any()).default({}),
+  liveSettings: v.optional(
+    v.custom<FormSettings | null>(() => true),
+    () => null,
+  ),
+  customization: v.optional(v.record(v.string(), v.any()), {}),
   createdAt: timestampField,
   updatedAt: timestampField,
 });
 
-export type Form = z.infer<typeof FormSchema>;
+export type Form = v.InferOutput<typeof FormSchema>;
 
 export const localFormCollection = createCollection(
   localStorageCollectionOptions({

--- a/src/components/editor/hooks/use-form-gen-stream.ts
+++ b/src/components/editor/hooks/use-form-gen-stream.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { experimental_useObject as useObject } from "@ai-sdk/react";
+import { valibotSchema } from "@ai-sdk/valibot";
 import { useMutation } from "@tanstack/react-query";
 import { PathApi } from "platejs";
 import type { TElement } from "platejs";
@@ -383,8 +384,7 @@ export const useFormGenStream = ({
 
   const hook = useObject({
     api: "/api/ai/form-generate",
-    // eslint-disable-next-line typescript-eslint/no-explicit-any -- AI SDK schema generic mismatches with Zod v4
-    schema: formGenSchema as any,
+    schema: valibotSchema(formGenSchema),
     onFinish: ({ object: finalObject }: { object: FormGenResult | undefined }) => {
       // Apply set-theme atomically once full theme arrived (skip partial-state churn while streaming).
       applyFinalThemeOps(finalObject);

--- a/src/lib/ai/ops-schema.ts
+++ b/src/lib/ai/ops-schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as v from "valibot";
 
 export const FIELD_TYPES = [
   "input",
@@ -16,28 +16,28 @@ export const FIELD_TYPES = [
   "ranking",
 ] as const;
 
-export const fieldTypeEnum = z.enum(FIELD_TYPES);
+export const fieldTypeEnum = v.picklist(FIELD_TYPES);
 
-export const setHeaderOp = z.object({
-  type: z.literal("set-header"),
-  title: z.string().optional(),
-  iconKeyword: z.string().optional(),
-  coverColor: z.string().optional(),
+export const setHeaderOp = v.object({
+  type: v.literal("set-header"),
+  title: v.optional(v.string()),
+  iconKeyword: v.optional(v.string()),
+  coverColor: v.optional(v.string()),
 });
 
-export const addFieldOp = z.object({
-  type: z.literal("add-field"),
+export const addFieldOp = v.object({
+  type: v.literal("add-field"),
   fieldType: fieldTypeEnum,
-  label: z.string(),
-  required: z.boolean().optional(),
-  placeholder: z.string().optional(),
-  options: z.array(z.string()).optional(),
+  label: v.string(),
+  required: v.optional(v.boolean()),
+  placeholder: v.optional(v.string()),
+  options: v.optional(v.array(v.string())),
 });
 
-export const addSectionOp = z.object({
-  type: z.literal("add-section"),
-  title: z.string(),
-  level: z.enum(["1", "2", "3"]).optional(),
+export const addSectionOp = v.object({
+  type: v.literal("add-section"),
+  title: v.string(),
+  level: v.optional(v.picklist(["1", "2", "3"])),
 });
 
 // TOKEN_NAMES subset the AI emits. Card/popover excluded — derived from base/accent.
@@ -59,13 +59,13 @@ export const AI_THEME_TOKEN_KEYS = [
   "ring",
 ] as const;
 
-const themeTokensShape: Record<string, z.ZodString> = {};
+const themeTokensShape: Record<string, v.StringSchema<undefined>> = {};
 for (const base of AI_THEME_TOKEN_KEYS) {
-  themeTokensShape[`light:${base}`] = z.string();
-  themeTokensShape[`dark:${base}`] = z.string();
+  themeTokensShape[`light:${base}`] = v.string();
+  themeTokensShape[`dark:${base}`] = v.string();
 }
 
-export const themeTokensSchema = z.object(themeTokensShape);
+export const themeTokensSchema = v.object(themeTokensShape);
 
 export const RADIUS_OPTIONS = ["none", "small", "medium", "large"] as const;
 
@@ -92,39 +92,39 @@ export const FREE_DEFAULT_MODE_OPTIONS = ["light", "dark", "system"] as const;
 
 // Free-plan schema — only FREE_CUSTOMIZATION_KEYS (gate). No light/dark tokens,
 // no custom CSS.
-export const freeThemeSchema = z.object({
-  themeColor: z.enum(FREE_THEME_COLOR_OPTIONS),
-  baseColor: z.enum(FREE_BASE_COLOR_OPTIONS),
-  font: z.string(),
-  radius: z.enum(RADIUS_OPTIONS),
-  defaultMode: z.enum(FREE_DEFAULT_MODE_OPTIONS),
+export const freeThemeSchema = v.object({
+  themeColor: v.picklist(FREE_THEME_COLOR_OPTIONS),
+  baseColor: v.picklist(FREE_BASE_COLOR_OPTIONS),
+  font: v.string(),
+  radius: v.picklist(RADIUS_OPTIONS),
+  defaultMode: v.picklist(FREE_DEFAULT_MODE_OPTIONS),
 });
 
-export type FreeThemeArgs = z.infer<typeof freeThemeSchema>;
+export type FreeThemeArgs = v.InferOutput<typeof freeThemeSchema>;
 
-export const setThemeOp = z.object({
-  type: z.literal("set-theme"),
+export const setThemeOp = v.object({
+  type: v.literal("set-theme"),
   // Optional, but if present all 30 keys required — forces a complete theme,
   // not tokens: null.
-  tokens: themeTokensSchema.optional(),
-  font: z.string().optional(),
-  radius: z.enum(RADIUS_OPTIONS).optional(),
+  tokens: v.optional(themeTokensSchema),
+  font: v.optional(v.string()),
+  radius: v.optional(v.picklist(RADIUS_OPTIONS)),
 });
 
-export const replaceFieldOp = z.object({
-  type: z.literal("replace-field"),
-  label: z.string().optional(),
-  fieldType: fieldTypeEnum.optional(),
-  placeholder: z.string().optional(),
-  options: z.array(z.string()).optional(),
+export const replaceFieldOp = v.object({
+  type: v.literal("replace-field"),
+  label: v.optional(v.string()),
+  fieldType: v.optional(fieldTypeEnum),
+  placeholder: v.optional(v.string()),
+  options: v.optional(v.array(v.string())),
 });
 
-export const addPageBreakOp = z.object({
-  type: z.literal("add-page-break"),
-  isThankYou: z.boolean().optional(),
+export const addPageBreakOp = v.object({
+  type: v.literal("add-page-break"),
+  isThankYou: v.optional(v.boolean()),
 });
 
-export const opSchema = z.discriminatedUnion("type", [
+export const opSchema = v.variant("type", [
   setHeaderOp,
   addFieldOp,
   addSectionOp,
@@ -133,18 +133,18 @@ export const opSchema = z.discriminatedUnion("type", [
   addPageBreakOp,
 ]);
 
-export const formGenSchema = z.object({
-  ops: z.array(opSchema),
+export const formGenSchema = v.object({
+  ops: v.array(opSchema),
 });
 
-export type SetHeaderOp = z.infer<typeof setHeaderOp>;
-export type AddFieldOp = z.infer<typeof addFieldOp>;
-export type AddSectionOp = z.infer<typeof addSectionOp>;
-export type SetThemeOp = z.infer<typeof setThemeOp>;
-export type ReplaceFieldOp = z.infer<typeof replaceFieldOp>;
-export type AddPageBreakOp = z.infer<typeof addPageBreakOp>;
-export type Op = z.infer<typeof opSchema>;
-export type FormGenResult = z.infer<typeof formGenSchema>;
+export type SetHeaderOp = v.InferOutput<typeof setHeaderOp>;
+export type AddFieldOp = v.InferOutput<typeof addFieldOp>;
+export type AddSectionOp = v.InferOutput<typeof addSectionOp>;
+export type SetThemeOp = v.InferOutput<typeof setThemeOp>;
+export type ReplaceFieldOp = v.InferOutput<typeof replaceFieldOp>;
+export type AddPageBreakOp = v.InferOutput<typeof addPageBreakOp>;
+export type Op = v.InferOutput<typeof opSchema>;
+export type FormGenResult = v.InferOutput<typeof formGenSchema>;
 
 export type PartialOp = Partial<Op> & { type?: Op["type"] };
 

--- a/src/lib/form-schema/generate-preview-schema.test.ts
+++ b/src/lib/form-schema/generate-preview-schema.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import * as v from "valibot";
 
 import type { PlateFormField } from "@/lib/editor/transform-plate-to-form";
 import { generateZodSchemaFromFields } from "./generate-preview-schema";
@@ -7,21 +8,21 @@ describe("generateZodSchemaFromFields - Date / Time required", () => {
   it("rejects empty Date when required", () => {
     const fields: PlateFormField[] = [{ id: "d", name: "d", fieldType: "Date", required: true }];
     const schema = generateZodSchemaFromFields(fields);
-    const result = schema.safeParse({ d: "" });
+    const result = v.safeParse(schema, { d: "" });
     expect(result.success).toBe(false);
   });
 
   it("rejects empty Time when required", () => {
     const fields: PlateFormField[] = [{ id: "t", name: "t", fieldType: "Time", required: true }];
     const schema = generateZodSchemaFromFields(fields);
-    const result = schema.safeParse({ t: "" });
+    const result = v.safeParse(schema, { t: "" });
     expect(result.success).toBe(false);
   });
 
   it("accepts empty Date when not required", () => {
     const fields: PlateFormField[] = [{ id: "d", name: "d", fieldType: "Date", required: false }];
     const schema = generateZodSchemaFromFields(fields);
-    const result = schema.safeParse({ d: "" });
+    const result = v.safeParse(schema, { d: "" });
     expect(result.success).toBe(true);
   });
 
@@ -30,9 +31,9 @@ describe("generateZodSchemaFromFields - Date / Time required", () => {
       { id: "n", name: "n", fieldType: "Number", required: true, min: 3, max: 4 },
     ];
     const schema = generateZodSchemaFromFields(fields);
-    expect(schema.safeParse({ n: 2 }).success).toBe(false);
-    expect(schema.safeParse({ n: 3 }).success).toBe(true);
-    expect(schema.safeParse({ n: 5 }).success).toBe(false);
+    expect(v.safeParse(schema, { n: 2 }).success).toBe(false);
+    expect(v.safeParse(schema, { n: 3 }).success).toBe(true);
+    expect(v.safeParse(schema, { n: 5 }).success).toBe(false);
   });
 
   it("rejects empty string for required Number (regression: Number('') is 0)", () => {
@@ -40,8 +41,8 @@ describe("generateZodSchemaFromFields - Date / Time required", () => {
       { id: "n", name: "n", fieldType: "Number", required: true, min: 3, max: 12 },
     ];
     const schema = generateZodSchemaFromFields(fields);
-    expect(schema.safeParse({ n: "" }).success).toBe(false);
-    expect(schema.safeParse({ n: "5" }).success).toBe(true);
-    expect(schema.safeParse({ n: "20" }).success).toBe(false);
+    expect(v.safeParse(schema, { n: "" }).success).toBe(false);
+    expect(v.safeParse(schema, { n: "5" }).success).toBe(true);
+    expect(v.safeParse(schema, { n: "20" }).success).toBe(false);
   });
 });

--- a/src/lib/form-schema/generate-preview-schema.ts
+++ b/src/lib/form-schema/generate-preview-schema.ts
@@ -1,16 +1,20 @@
-/** Build a Zod schema from Plate-node validation props for preview-mode validation. */
+/** Build a valibot schema from Plate-node validation props for preview-mode validation. */
 import { isValidPhoneNumber } from "react-phone-number-input";
-import { z } from "zod";
-import type { ZodType } from "zod";
+import * as v from "valibot";
 import type { PlateFormField } from "@/lib/editor/transform-plate-to-form";
 
+// Re-export alias kept for callers — name stays stable even though impl is valibot.
+type AnyValibotSchema = v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>;
+
 /**
- * Zod schema from PlateFormField[].
+ * Valibot schema from PlateFormField[].
  * @param fields - form fields w/ validation props
- * @returns Zod object schema
+ * @returns valibot object schema
  */
-export const generateZodSchemaFromFields = (fields: PlateFormField[]): z.ZodObject => {
-  const schemaShape: Record<string, ZodType> = {};
+export const generateZodSchemaFromFields = (
+  fields: PlateFormField[],
+): v.ObjectSchema<v.ObjectEntries, undefined> => {
+  const schemaShape: v.ObjectEntries = {};
 
   for (const field of fields) {
     // Skip Button fields - they don't have validation
@@ -18,134 +22,221 @@ export const generateZodSchemaFromFields = (fields: PlateFormField[]): z.ZodObje
       continue;
     }
 
-    let fieldSchema: ZodType;
+    let fieldSchema: AnyValibotSchema;
+    let isAlreadyOptional = false;
 
     switch (field.fieldType) {
       case "Email":
         fieldSchema = field.required
-          ? z
-              .email({ error: "Please enter a valid email address" })
-              .min(1, "This field is required")
-          : z.union([z.literal(""), z.email({ error: "Please enter a valid email address" })]);
+          ? v.pipe(
+              v.string(),
+              v.nonEmpty("This field is required"),
+              v.email("Please enter a valid email address"),
+            )
+          : v.union([
+              v.literal(""),
+              v.pipe(v.string(), v.email("Please enter a valid email address")),
+            ]);
         break;
       case "Link": {
         const urlRegex = /^(https?:\/\/)?[\w.-]+\.\w{2,}(\/\S*)?$/;
         fieldSchema = field.required
-          ? z
-              .string({ error: "This field is required" })
-              .min(1, "This field is required")
-              .regex(urlRegex, "Please enter a valid URL")
-          : z.union([z.literal(""), z.string().regex(urlRegex, "Please enter a valid URL")]);
+          ? v.pipe(
+              v.string(),
+              v.nonEmpty("This field is required"),
+              v.regex(urlRegex, "Please enter a valid URL"),
+            )
+          : v.union([
+              v.literal(""),
+              v.pipe(v.string(), v.regex(urlRegex, "Please enter a valid URL")),
+            ]);
         break;
       }
       case "Number": {
-        let numberSchema = z.coerce.number({ error: "Please enter a valid number" });
-        if (field.allowDecimals === false) {
-          numberSchema = numberSchema.int("Decimals are not allowed");
-        }
-        if (typeof field.min === "number") {
-          numberSchema = numberSchema.min(field.min, `Value must be at least ${field.min}`);
-        }
-        if (typeof field.max === "number") {
-          numberSchema = numberSchema.max(field.max, `Value must be at most ${field.max}`);
-        }
-        // `Number("") === 0` → a required empty input would pass. Preprocess
-        // "" → undefined so the number schema rejects it as required.
+        // Coerce string/number → number, guard "" → undefined (Number("")===0 would pass without this).
+        const coerceNum = (val: unknown): number | undefined => {
+          if (val === "" || val === null || val === undefined) return undefined;
+          return Number(val);
+        };
+        // Build number schema with optional int/min/max validations.
+        const buildNumSchema = (): AnyValibotSchema => {
+          const base = v.pipe(
+            v.unknown(),
+            v.transform(coerceNum),
+            // Cast: transform output is number|undefined; number() rejects undefined — correct behavior.
+            v.number("Please enter a valid number") as unknown as v.TransformAction<
+              unknown,
+              number
+            >,
+          );
+          if (
+            field.allowDecimals === false &&
+            typeof field.min === "number" &&
+            typeof field.max === "number"
+          ) {
+            return v.pipe(
+              base,
+              v.integer("Decimals are not allowed"),
+              v.minValue(field.min, `Value must be at least ${field.min}`),
+              v.maxValue(field.max, `Value must be at most ${field.max}`),
+            );
+          }
+          if (field.allowDecimals === false && typeof field.min === "number") {
+            return v.pipe(
+              base,
+              v.integer("Decimals are not allowed"),
+              v.minValue(field.min, `Value must be at least ${field.min}`),
+            );
+          }
+          if (field.allowDecimals === false && typeof field.max === "number") {
+            return v.pipe(
+              base,
+              v.integer("Decimals are not allowed"),
+              v.maxValue(field.max, `Value must be at most ${field.max}`),
+            );
+          }
+          if (field.allowDecimals === false) {
+            return v.pipe(base, v.integer("Decimals are not allowed"));
+          }
+          if (typeof field.min === "number" && typeof field.max === "number") {
+            return v.pipe(
+              base,
+              v.minValue(field.min, `Value must be at least ${field.min}`),
+              v.maxValue(field.max, `Value must be at most ${field.max}`),
+            );
+          }
+          if (typeof field.min === "number") {
+            return v.pipe(base, v.minValue(field.min, `Value must be at least ${field.min}`));
+          }
+          if (typeof field.max === "number") {
+            return v.pipe(base, v.maxValue(field.max, `Value must be at most ${field.max}`));
+          }
+          return base;
+        };
+        const numSchema = buildNumSchema();
         fieldSchema = field.required
-          ? z.preprocess(
-              (val) => (val === "" || val === null || val === undefined ? undefined : val),
-              numberSchema,
-            )
-          : z.union([z.literal(""), numberSchema]);
+          ? numSchema
+          : // Accept "" as literal pass-through; otherwise coerce+validate.
+            v.union([v.literal(""), numSchema]);
         break;
       }
       case "Phone": {
         // PhoneInput emits E.164 (e.g. "+919360992440"). Validate format via
         // libphonenumber, not stale char-count limits from the old text UI.
-        const phoneSchema = z
-          .string()
-          .refine((v) => isValidPhoneNumber(v), "Please enter a valid phone number");
+        const phoneSchema = v.pipe(
+          v.string(),
+          v.check((val) => isValidPhoneNumber(val), "Please enter a valid phone number"),
+        );
         fieldSchema = field.required
-          ? z.string().min(1, "This field is required").pipe(phoneSchema)
-          : z.union([z.literal(""), phoneSchema]);
+          ? v.pipe(
+              v.string(),
+              v.nonEmpty("This field is required"),
+              v.check((val) => isValidPhoneNumber(val), "Please enter a valid phone number"),
+            )
+          : v.union([v.literal(""), phoneSchema]);
         break;
       }
       case "Date":
         fieldSchema = field.required
-          ? z.string({ error: "This field is required" }).nonempty("Please select a date")
-          : z.string().optional();
+          ? v.pipe(v.string(), v.nonEmpty("Please select a date"))
+          : v.optional(v.string());
+        if (!field.required) isAlreadyOptional = true;
         break;
       case "Time":
         fieldSchema = field.required
-          ? z.string({ error: "This field is required" }).nonempty("Please select a time")
-          : z.string().optional();
+          ? v.pipe(v.string(), v.nonEmpty("Please select a time"))
+          : v.optional(v.string());
+        if (!field.required) isAlreadyOptional = true;
         break;
       case "FileUpload": {
-        const uploadedFileSchema = z.object({
-          url: z.string(),
-          name: z.string(),
-          size: z.number(),
-          type: z.string(),
+        const uploadedFileSchema = v.object({
+          url: v.string(),
+          name: v.string(),
+          size: v.number(),
+          type: v.string(),
         });
         fieldSchema = field.required
-          ? uploadedFileSchema.refine((v) => v && v.url.length > 0, {
-              message: "Please upload a file",
-            })
-          : z.union([z.literal(""), uploadedFileSchema]).optional();
+          ? v.pipe(
+              uploadedFileSchema,
+              v.check((val) => Boolean(val?.url && val.url.length > 0), "Please upload a file"),
+            )
+          : v.optional(v.union([v.literal(""), uploadedFileSchema]));
+        if (!field.required) isAlreadyOptional = true;
         break;
       }
       case "Checkbox":
       case "MultiSelect":
         if (field.required) {
-          fieldSchema = z.array(z.string()).nonempty("Please select at least one option");
+          fieldSchema = v.pipe(
+            v.array(v.string()),
+            v.nonEmpty("Please select at least one option"),
+          );
         } else {
-          fieldSchema = z.array(z.string()).default([]);
+          fieldSchema = v.optional(v.array(v.string()), []);
+          isAlreadyOptional = true;
         }
         break;
       case "MultiChoice":
         if (field.required) {
-          fieldSchema = z.string().min(1, "Please select an option");
+          fieldSchema = v.pipe(v.string(), v.minLength(1, "Please select an option"));
         } else {
-          fieldSchema = z.string().default("");
+          fieldSchema = v.optional(v.string(), "");
+          isAlreadyOptional = true;
         }
         break;
       case "Ranking":
         if (field.required) {
-          fieldSchema = z.array(z.string()).nonempty("Please rank the options");
+          fieldSchema = v.pipe(v.array(v.string()), v.nonEmpty("Please rank the options"));
         } else {
-          fieldSchema = z.array(z.string()).default([]);
+          fieldSchema = v.optional(v.array(v.string()), []);
+          isAlreadyOptional = true;
         }
         break;
       default: {
         // Input, Textarea, Phone, and other string-based types
-        let schema: z.ZodString = z.string();
+        const pipes: v.MinLengthAction<string, number, string>[] = [];
 
         if ("minLength" in field && field.minLength !== undefined && field.minLength > 0) {
-          schema = schema.min(field.minLength, `Minimum ${field.minLength} characters required`);
-        }
-
-        if ("maxLength" in field && field.maxLength !== undefined && field.maxLength > 0) {
-          schema = schema.max(field.maxLength, `Maximum ${field.maxLength} characters allowed`);
+          pipes.push(
+            v.minLength(field.minLength, `Minimum ${field.minLength} characters required`),
+          );
         }
 
         // Required fields must have at least 1 character
         if (field.required && !("minLength" in field && field.minLength !== undefined)) {
-          schema = schema.min(1, "This field is required");
+          pipes.push(v.minLength(1, "This field is required"));
         }
 
-        fieldSchema = schema;
+        const maxPipes: v.MaxLengthAction<string, number, string>[] = [];
+        if ("maxLength" in field && field.maxLength !== undefined && field.maxLength > 0) {
+          maxPipes.push(
+            v.maxLength(field.maxLength, `Maximum ${field.maxLength} characters allowed`),
+          );
+        }
+
+        if (pipes.length > 0 && maxPipes.length > 0) {
+          fieldSchema = v.pipe(v.string(), pipes[0], maxPipes[0]);
+        } else if (pipes.length > 0) {
+          fieldSchema = v.pipe(v.string(), pipes[0]);
+        } else if (maxPipes.length > 0) {
+          fieldSchema = v.pipe(v.string(), maxPipes[0]);
+        } else {
+          fieldSchema = v.string();
+        }
         break;
       }
     }
 
-    if (field.required) {
-      schemaShape[field.name] = fieldSchema;
+    if (field.required || isAlreadyOptional) {
+      schemaShape[field.name] = fieldSchema as v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>;
     } else {
-      schemaShape[field.name] = fieldSchema.optional();
+      schemaShape[field.name] = v.optional(
+        fieldSchema as v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+      );
     }
   }
 
-  return z.object(schemaShape);
+  return v.object(schemaShape);
 };
 
 /**

--- a/src/lib/server-fn/analytics.ts
+++ b/src/lib/server-fn/analytics.ts
@@ -1,5 +1,5 @@
 import { createServerFn } from "@tanstack/react-start";
-import { z } from "zod";
+import * as v from "valibot";
 import { authMiddleware } from "@/lib/auth/middleware";
 import { getActiveOrgId } from "@/lib/server-fn/auth-helpers";
 import type {
@@ -15,14 +15,14 @@ import type {
 // DB logic lives in analytics.server.ts, dynamically imported in each handler so Start strips it
 // from the client bundle — @/db + postgres driver never reach the browser via this file.
 
-const recordVisitInputSchema = z.object({
-  formId: z.uuid(),
-  visitorHash: z.string().min(1).max(128),
-  sessionId: z.string().min(1).max(128),
-  referrer: z.string().nullish(),
-  utmSource: z.string().nullish(),
-  utmMedium: z.string().nullish(),
-  utmCampaign: z.string().nullish(),
+const recordVisitInputSchema = v.object({
+  formId: v.pipe(v.string(), v.uuid()),
+  visitorHash: v.pipe(v.string(), v.minLength(1), v.maxLength(128)),
+  sessionId: v.pipe(v.string(), v.minLength(1), v.maxLength(128)),
+  referrer: v.nullish(v.string()),
+  utmSource: v.nullish(v.string()),
+  utmMedium: v.nullish(v.string()),
+  utmCampaign: v.nullish(v.string()),
 });
 
 export const recordFormVisit = createServerFn({ method: "POST" })
@@ -37,16 +37,18 @@ const MAX_DURATION_MS = 86_400_000; // 24h cap as a spam guard for client-suppli
 const MAX_VITAL_MS = 3_600_000; // 1h — generous spam guard for client-reported vitals
 const MAX_CLS = 100;
 
-const updateVisitInputSchema = z.object({
-  visitId: z.uuid(),
-  didStartForm: z.boolean().optional(),
-  didSubmit: z.boolean().optional(),
-  submissionId: z.uuid().nullish(),
-  visitEndedAt: z.iso.datetime().nullish(),
-  durationMs: z.number().int().nonnegative().max(MAX_DURATION_MS).nullish(),
-  lcpMs: z.number().int().nonnegative().max(MAX_VITAL_MS).nullish(),
-  inpMs: z.number().int().nonnegative().max(MAX_VITAL_MS).nullish(),
-  cls: z.number().nonnegative().max(MAX_CLS).nullish(),
+const updateVisitInputSchema = v.object({
+  visitId: v.pipe(v.string(), v.uuid()),
+  didStartForm: v.optional(v.boolean()),
+  didSubmit: v.optional(v.boolean()),
+  submissionId: v.nullish(v.pipe(v.string(), v.uuid())),
+  visitEndedAt: v.nullish(v.pipe(v.string(), v.isoTimestamp())),
+  durationMs: v.nullish(
+    v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(MAX_DURATION_MS)),
+  ),
+  lcpMs: v.nullish(v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(MAX_VITAL_MS))),
+  inpMs: v.nullish(v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(MAX_VITAL_MS))),
+  cls: v.nullish(v.pipe(v.number(), v.minValue(0), v.maxValue(MAX_CLS))),
 });
 
 export const updateFormVisit = createServerFn({ method: "POST" })
@@ -56,17 +58,17 @@ export const updateFormVisit = createServerFn({ method: "POST" })
     return updateFormVisitImpl(data);
   });
 
-const questionProgressInputSchema = z.object({
-  visitId: z.uuid(),
-  formId: z.uuid(),
-  visitorHash: z.string().min(1).max(128),
-  questionId: z.string().min(1).max(256),
-  questionType: z.string().max(64).nullish(),
-  questionIndex: z.number().int().nonnegative(),
-  stepId: z.string().max(256).nullish(),
-  stepIndex: z.number().int().nonnegative().nullish(),
-  event: z.enum(["view", "start", "complete"]),
-  wasLastQuestion: z.boolean().optional(),
+const questionProgressInputSchema = v.object({
+  visitId: v.pipe(v.string(), v.uuid()),
+  formId: v.pipe(v.string(), v.uuid()),
+  visitorHash: v.pipe(v.string(), v.minLength(1), v.maxLength(128)),
+  questionId: v.pipe(v.string(), v.minLength(1), v.maxLength(256)),
+  questionType: v.nullish(v.pipe(v.string(), v.maxLength(64))),
+  questionIndex: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  stepId: v.nullish(v.pipe(v.string(), v.maxLength(256))),
+  stepIndex: v.nullish(v.pipe(v.number(), v.integer(), v.minValue(0))),
+  event: v.picklist(["view", "start", "complete"]),
+  wasLastQuestion: v.optional(v.boolean()),
 });
 
 export const recordQuestionProgress = createServerFn({ method: "POST" })
@@ -78,8 +80,12 @@ export const recordQuestionProgress = createServerFn({ method: "POST" })
 
 const MAX_QUESTION_PROGRESS_BATCH = 20;
 
-const questionProgressBatchInputSchema = z.object({
-  items: z.array(questionProgressInputSchema).min(1).max(MAX_QUESTION_PROGRESS_BATCH),
+const questionProgressBatchInputSchema = v.object({
+  items: v.pipe(
+    v.array(questionProgressInputSchema),
+    v.minLength(1),
+    v.maxLength(MAX_QUESTION_PROGRESS_BATCH),
+  ),
 });
 
 export const recordQuestionProgressBatch = createServerFn({ method: "POST" })
@@ -100,11 +106,11 @@ export const recordQuestionProgressBatch = createServerFn({ method: "POST" })
 
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
-const insightsFilterInputSchema = z.object({
-  formId: z.uuid(),
-  filter: z.enum(["last_24_hours", "last_7_days", "last_30_days", "last_90_days", "custom"]),
-  startDate: z.string().regex(DATE_KEY_PATTERN).optional(),
-  endDate: z.string().regex(DATE_KEY_PATTERN).optional(),
+const insightsFilterInputSchema = v.object({
+  formId: v.pipe(v.string(), v.uuid()),
+  filter: v.picklist(["last_24_hours", "last_7_days", "last_30_days", "last_90_days", "custom"]),
+  startDate: v.optional(v.pipe(v.string(), v.regex(DATE_KEY_PATTERN))),
+  endDate: v.optional(v.pipe(v.string(), v.regex(DATE_KEY_PATTERN))),
 });
 
 export const getFormInsights = createServerFn({ method: "POST" })
@@ -133,14 +139,14 @@ export const getFormVitals = createServerFn({ method: "POST" })
 
 export const getInsightsAvailability = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ formId: z.uuid() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }): Promise<InsightsAvailability> => {
     const { getInsightsAvailabilityImpl } = await import("./analytics.server");
     return getInsightsAvailabilityImpl(data, context, getActiveOrgId(context.session));
   });
 
-const aggregateInputSchema = z.object({
-  date: z.string().regex(DATE_KEY_PATTERN),
+const aggregateInputSchema = v.object({
+  date: v.pipe(v.string(), v.regex(DATE_KEY_PATTERN)),
 });
 
 export const aggregateAnalyticsDaily = createServerFn({ method: "POST" })

--- a/src/lib/server-fn/billing.ts
+++ b/src/lib/server-fn/billing.ts
@@ -1,7 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { and, eq } from "drizzle-orm";
 import { createError } from "@/lib/errors/create";
-import { z } from "zod";
+import * as v from "valibot";
 import { db } from "@/db";
 import { member } from "@/db/schema";
 import { authMiddleware } from "@/lib/auth/middleware";
@@ -12,7 +12,7 @@ import type { ErrorCode } from "@/lib/errors/codes";
  * keyed by org. Bypass the adapter and create a customer session via the SDK directly. */
 export const openOrgBillingPortal = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ orgId: z.string() }))
+  .inputValidator(v.object({ orgId: v.string() }))
   .handler(async ({ data, context }) => {
     const [membership] = await db
       .select()

--- a/src/lib/server-fn/custom-domain-view-rsc.tsx
+++ b/src/lib/server-fn/custom-domain-view-rsc.tsx
@@ -1,12 +1,12 @@
 import { createServerFn } from "@tanstack/react-start";
 import { getRequestHost } from "@tanstack/react-start/server";
-import { z } from "zod";
+import * as v from "valibot";
 
 // Thin stubs: dynamically import ./custom-domain-view-rsc.impl so platejs/BaseEditorKit/EditorStatic
 // never reach the client bundle. Mirrors public-form-view-rsc.tsx on the app-domain route.
 
 export const getCustomDomainFormByIdRSC = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ formId: z.uuid() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data }) => {
     const host = getRequestHost({ xForwardedHost: true });
     const { runCustomDomainByIdRSC } = await import("./custom-domain-view-rsc.impl");
@@ -14,7 +14,7 @@ export const getCustomDomainFormByIdRSC = createServerFn({ method: "GET" })
   });
 
 export const getCustomDomainFormBySlugRSC = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ slug: z.string() }))
+  .inputValidator(v.object({ slug: v.string() }))
   .handler(async ({ data }) => {
     const host = getRequestHost({ xForwardedHost: true });
     const { runCustomDomainBySlugRSC } = await import("./custom-domain-view-rsc.impl");

--- a/src/lib/server-fn/custom-domains.ts
+++ b/src/lib/server-fn/custom-domains.ts
@@ -2,7 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import { and, eq, isNotNull } from "drizzle-orm";
 import { createError } from "@/lib/errors/create";
-import { z } from "zod";
+import * as v from "valibot";
 import { customDomains, forms, member } from "@/db/schema";
 import { db } from "@/db";
 import { authMiddleware } from "@/lib/auth/middleware";
@@ -25,7 +25,7 @@ const serializeDomain = (domain: typeof customDomains.$inferSelect) => ({
 
 export const listOrgDomains = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ orgId: z.string() }))
+  .inputValidator(v.object({ orgId: v.string() }))
   .handler(async ({ data, context }) => {
     const [membership] = await db
       .select()
@@ -56,9 +56,9 @@ export const listOrgDomains = createServerFn({ method: "POST" })
 export const addDomain = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      orgId: z.string(),
-      domain: z.string(),
+    v.object({
+      orgId: v.string(),
+      domain: v.string(),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -149,7 +149,7 @@ export const addDomain = createServerFn({ method: "POST" })
 
 export const removeDomain = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ domainId: z.string() }))
+  .inputValidator(v.object({ domainId: v.string() }))
   .handler(async ({ data, context }) => {
     const [domain] = await db
       .select()
@@ -244,7 +244,7 @@ const assertCanReadDomain = async (domainId: string, userId: string) => {
 
 export const checkDomainStatus = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ domainId: z.string() }))
+  .inputValidator(v.object({ domainId: v.string() }))
   .handler(async ({ data, context }) => {
     await assertCanReadDomain(data.domainId, context.session.user.id);
     return refreshDomainStatusFromVercel(data.domainId);
@@ -252,7 +252,7 @@ export const checkDomainStatus = createServerFn({ method: "POST" })
 
 export const recheckDomainStatus = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ domainId: z.string() }))
+  .inputValidator(v.object({ domainId: v.string() }))
   .handler(async ({ data, context }) => {
     await assertCanReadDomain(data.domainId, context.session.user.id);
     return triggerDomainVerification(data.domainId);
@@ -261,11 +261,11 @@ export const recheckDomainStatus = createServerFn({ method: "POST" })
 export const updateDomainMeta = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      domainId: z.string(),
-      siteTitle: z.string().optional(),
-      faviconUrl: z.string().optional(),
-      ogImageUrl: z.string().optional(),
+    v.object({
+      domainId: v.string(),
+      siteTitle: v.optional(v.string()),
+      faviconUrl: v.optional(v.string()),
+      ogImageUrl: v.optional(v.string()),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -329,7 +329,7 @@ export const updateDomainMeta = createServerFn({ method: "POST" })
   });
 
 export const getDomainByHost = createServerFn({ method: "POST" })
-  .inputValidator(z.object({ host: z.string() }))
+  .inputValidator(v.object({ host: v.string() }))
   .handler(async ({ data }) => {
     const [domain] = await db
       .select({

--- a/src/lib/server-fn/favorites.ts
+++ b/src/lib/server-fn/favorites.ts
@@ -1,6 +1,6 @@
 import { createServerFn } from "@tanstack/react-start";
 import { and, eq } from "drizzle-orm";
-import { z } from "zod";
+import * as v from "valibot";
 import { formFavorites } from "@/db/schema";
 import { db } from "@/db";
 import { authMiddleware } from "@/lib/auth/middleware";
@@ -26,9 +26,9 @@ export const getFavorites = createServerFn({ method: "GET" })
 export const addFavorite = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      formId: z.uuid(),
-      sortIndex: z.string().nullable().optional(),
+    v.object({
+      formId: v.pipe(v.string(), v.uuid()),
+      sortIndex: v.nullish(v.string()),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -51,7 +51,7 @@ export const addFavorite = createServerFn({ method: "POST" })
 
 export const removeFavorite = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ formId: z.uuid() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }) => {
     const userId = context.session.user.id;
     await authForm(data.formId, userId, getActiveOrgId(context.session));
@@ -64,9 +64,9 @@ export const removeFavorite = createServerFn({ method: "POST" })
 export const reorderFavorite = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      formId: z.uuid(),
-      sortIndex: z.string(),
+    v.object({
+      formId: v.pipe(v.string(), v.uuid()),
+      sortIndex: v.string(),
     }),
   )
   .handler(async ({ data, context }) => {

--- a/src/lib/server-fn/form-versions.ts
+++ b/src/lib/server-fn/form-versions.ts
@@ -3,7 +3,7 @@ import { queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import { createError } from "@/lib/errors/create";
-import { z } from "zod";
+import * as v from "valibot";
 import { formSettings, forms, formVersions, user } from "@/db/schema";
 import { db } from "@/db";
 import { authMiddleware } from "@/lib/auth/middleware";
@@ -29,8 +29,8 @@ const serializeVersion = (version: typeof formVersions.$inferSelect) => ({
 export const publishFormVersion = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      formId: z.uuid(),
+    v.object({
+      formId: v.pipe(v.string(), v.uuid()),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -195,7 +195,7 @@ export const publishFormVersion = createServerFn({ method: "POST" })
 
 export const getFormVersions = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ formId: z.uuid() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     const [_, versions] = await Promise.all([
@@ -245,7 +245,7 @@ export const getFormVersionsQueryOption = (formId: string) =>
 
 export const getFormVersionContent = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ versionId: z.uuid() }))
+  .inputValidator(v.object({ versionId: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }) => {
     const [version] = await db
       .select()
@@ -273,9 +273,9 @@ export const getFormVersionContent = createServerFn({ method: "GET" })
 export const restoreFormVersion = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      formId: z.uuid(),
-      versionId: z.uuid(),
+    v.object({
+      formId: v.pipe(v.string(), v.uuid()),
+      versionId: v.pipe(v.string(), v.uuid()),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -322,7 +322,7 @@ export const restoreFormVersion = createServerFn({ method: "POST" })
 
 export const discardFormChanges = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ formId: z.uuid() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     await authForm(data.formId, context.session.user.id, orgId);

--- a/src/lib/server-fn/forms.ts
+++ b/src/lib/server-fn/forms.ts
@@ -1,7 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { and, count, eq, inArray, ne, sql } from "drizzle-orm";
 import { createError } from "@/lib/errors/create";
-import { z } from "zod";
+import * as v from "valibot";
 import { customDomains, formSettings, forms, member, submissions, workspaces } from "@/db/schema";
 import { RESERVED_SLUGS } from "@/lib/config/plan-config";
 import { planUnlocks } from "@/lib/config/plan-gates";
@@ -45,19 +45,19 @@ export const mergeFormSettings = (patch: Partial<FormSettings>) =>
 export const createForm = createServerFn({ method: "POST" })
   .middleware([authMiddleware, formProSettingsMiddleware])
   .inputValidator(
-    z.object({
-      id: z.uuid(),
-      workspaceId: z.uuid(),
-      title: z.string().optional(),
-      formName: z.string().optional(),
-      schemaName: z.string().optional(),
-      content: z.array(z.unknown()).optional(),
-      icon: z.string().nullable().optional(),
-      cover: z.string().nullable().optional(),
-      status: z.enum(["draft", "published", "archived"]).optional(),
-      draftSettings: z.custom<FormSettings>().optional(),
-      customization: z.record(z.string(), z.unknown()).optional(),
-      sortIndex: z.string().nullable().optional(),
+    v.object({
+      id: v.pipe(v.string(), v.uuid()),
+      workspaceId: v.pipe(v.string(), v.uuid()),
+      title: v.optional(v.string()),
+      formName: v.optional(v.string()),
+      schemaName: v.optional(v.string()),
+      content: v.optional(v.array(v.any())),
+      icon: v.optional(v.nullable(v.string())),
+      cover: v.optional(v.nullable(v.string())),
+      status: v.optional(v.picklist(["draft", "published", "archived"])),
+      draftSettings: v.optional(v.custom<FormSettings>(() => true)),
+      customization: v.optional(v.record(v.string(), v.any())),
+      sortIndex: v.optional(v.nullable(v.string())),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -106,20 +106,20 @@ export const createForm = createServerFn({ method: "POST" })
 export const updateForm = createServerFn({ method: "POST" })
   .middleware([authMiddleware, formProSettingsMiddleware])
   .inputValidator(
-    z.object({
-      id: z.uuid(),
-      workspaceId: z.uuid().optional(),
-      title: z.string().optional(),
-      formName: z.string().optional(),
-      schemaName: z.string().optional(),
-      content: z.array(z.unknown()).optional(),
-      icon: z.string().nullable().optional(),
-      cover: z.string().nullable().optional(),
-      status: z.enum(["draft", "published", "archived"]).optional(),
-      updatedAt: z.string().optional(),
-      draftSettings: z.custom<Partial<FormSettings>>().optional(),
-      customization: z.record(z.string(), z.unknown()).optional(),
-      sortIndex: z.string().nullable().optional(),
+    v.object({
+      id: v.pipe(v.string(), v.uuid()),
+      workspaceId: v.optional(v.pipe(v.string(), v.uuid())),
+      title: v.optional(v.string()),
+      formName: v.optional(v.string()),
+      schemaName: v.optional(v.string()),
+      content: v.optional(v.array(v.any())),
+      icon: v.optional(v.nullable(v.string())),
+      cover: v.optional(v.nullable(v.string())),
+      status: v.optional(v.picklist(["draft", "published", "archived"])),
+      updatedAt: v.optional(v.string()),
+      draftSettings: v.optional(v.custom<Partial<FormSettings>>(() => true)),
+      customization: v.optional(v.record(v.string(), v.any())),
+      sortIndex: v.optional(v.nullable(v.string())),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -152,7 +152,7 @@ export const updateForm = createServerFn({ method: "POST" })
  * updated too so share sidebar reflects it without a form-listings-sync roundtrip. */
 export const setFormAnalytics = createServerFn({ method: "POST" })
   .middleware([authMiddleware, formProSettingsMiddleware])
-  .inputValidator(z.object({ formId: z.uuid(), enabled: z.boolean() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()), enabled: v.boolean() }))
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     await authForm(data.formId, context.session.user.id, orgId);
@@ -207,7 +207,7 @@ export const setFormAnalytics = createServerFn({ method: "POST" })
 
 export const deleteForm = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ id: z.uuid() }))
+  .inputValidator(v.object({ id: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     await authForm(data.id, context.session.user.id, orgId);
@@ -221,7 +221,11 @@ export const deleteForm = createServerFn({ method: "POST" })
 // Bulk soft-delete (move to trash). Capped at 200 to keep statements bounded.
 export const bulkArchiveForms = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ ids: z.array(z.uuid()).min(1).max(200) }))
+  .inputValidator(
+    v.object({
+      ids: v.pipe(v.array(v.pipe(v.string(), v.uuid())), v.minLength(1), v.maxLength(200)),
+    }),
+  )
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     await authFormsBulk(data.ids, context.session.user.id, orgId);
@@ -241,7 +245,11 @@ export const bulkArchiveForms = createServerFn({ method: "POST" })
 // Bulk hard-delete from trash.
 export const bulkDeleteForms = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ ids: z.array(z.uuid()).min(1).max(200) }))
+  .inputValidator(
+    v.object({
+      ids: v.pipe(v.array(v.pipe(v.string(), v.uuid())), v.minLength(1), v.maxLength(200)),
+    }),
+  )
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     await authFormsBulk(data.ids, context.session.user.id, orgId);
@@ -331,7 +339,7 @@ export const getArchivedFormListings = createServerFn({ method: "GET" })
 
 export const _getFormById = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ id: z.uuid() }))
+  .inputValidator(v.object({ id: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     const [_, [form]] = await Promise.all([
@@ -367,7 +375,7 @@ const generateSlug = (title: string): string =>
 /** @public - consumed by upcoming domain settings UI */
 export const updateFormSlug = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ formId: z.uuid(), slug: z.string() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()), slug: v.string() }))
   .handler(async ({ data, context }) => {
     const { formId, slug } = data;
     const orgId = getActiveOrgId(context.session);
@@ -479,9 +487,9 @@ export const updateFormSlug = createServerFn({ method: "POST" })
 export const assignFormDomain = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      formId: z.uuid(),
-      customDomainId: z.string().nullable(),
+    v.object({
+      formId: v.pipe(v.string(), v.uuid()),
+      customDomainId: v.nullable(v.string()),
     }),
   )
   .handler(async ({ data, context }) => {

--- a/src/lib/server-fn/notifications.ts
+++ b/src/lib/server-fn/notifications.ts
@@ -2,7 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import { and, asc, desc, eq, ne } from "drizzle-orm";
 import { createError } from "@/lib/errors/create";
-import { z } from "zod";
+import * as v from "valibot";
 import {
   formNotificationPreferences,
   formSubmissionNotifications,
@@ -90,7 +90,7 @@ export const getSubmissionNotificationsQueryOptions = () =>
 
 export const getFormInAppNotificationPreference = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ formId: z.uuid() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     const userId = context.session.user.id;
@@ -145,9 +145,9 @@ export const getFormInAppNotificationPreferenceQueryOptions = (formId: string) =
 export const setFormInAppNotificationPreference = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      formId: z.uuid(),
-      enabled: z.boolean(),
+    v.object({
+      formId: v.pipe(v.string(), v.uuid()),
+      enabled: v.boolean(),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -212,7 +212,7 @@ export const setFormInAppNotificationPreference = createServerFn({ method: "POST
 
 export const markSubmissionNotificationRead = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ formId: z.uuid() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }) => {
     const userId = context.session.user.id;
     const now = new Date();
@@ -237,7 +237,7 @@ export const markSubmissionNotificationRead = createServerFn({ method: "POST" })
 
 export const clearSubmissionNotification = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ formId: z.uuid() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }) => {
     const userId = context.session.user.id;
 

--- a/src/lib/server-fn/public-file-uploads.ts
+++ b/src/lib/server-fn/public-file-uploads.ts
@@ -4,7 +4,7 @@ import { getRequestIP } from "@tanstack/react-start/server";
 import { and, eq, sql } from "drizzle-orm";
 import { createError } from "@/lib/errors/create";
 import type { Value } from "platejs";
-import { z } from "zod";
+import * as v from "valibot";
 import { forms, formVersions, uploadRateLimits } from "@/db/schema";
 import { db } from "@/db";
 import type { ErrorCode } from "@/lib/errors/codes";
@@ -186,13 +186,13 @@ const decodeBase64 = (dataUrl: string): Buffer => {
 
 export const uploadFormFile = createServerFn({ method: "POST" })
   .inputValidator(
-    z.object({
-      formId: z.uuid(),
-      draftId: z.uuid(),
-      fieldName: z.string().min(1),
-      filename: z.string().min(1).max(255),
-      contentType: z.string().min(1).max(127),
-      base64: z.string().min(1),
+    v.object({
+      formId: v.pipe(v.string(), v.uuid()),
+      draftId: v.pipe(v.string(), v.uuid()),
+      fieldName: v.pipe(v.string(), v.minLength(1)),
+      filename: v.pipe(v.string(), v.minLength(1), v.maxLength(255)),
+      contentType: v.pipe(v.string(), v.minLength(1), v.maxLength(127)),
+      base64: v.pipe(v.string(), v.minLength(1)),
     }),
   )
   .handler(async ({ data }) => {

--- a/src/lib/server-fn/public-form-view-rsc.tsx
+++ b/src/lib/server-fn/public-form-view-rsc.tsx
@@ -1,12 +1,12 @@
 import { createServerFn } from "@tanstack/react-start";
-import { z } from "zod";
+import * as v from "valibot";
 import { shortIdSchema } from "@/lib/short-id";
 
 // IMPORTANT: imported by $shortId.tsx on the client. Keep top-level imports free of
 // platejs/BaseEditorKit/EditorStatic — they drag the editor chunk (361 kB + KaTeX CSS) into the
 // client entry. Heavy work lives behind a dynamic import in the handler, which Start strips.
 export const getPublicFormViewRSC = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ shortId: shortIdSchema }))
+  .inputValidator(v.object({ shortId: shortIdSchema }))
   .handler(async ({ data }) => {
     const { runPublicFormViewRSC } = await import("./public-form-view-rsc.impl");
     return runPublicFormViewRSC(data);

--- a/src/lib/server-fn/public-form-view.ts
+++ b/src/lib/server-fn/public-form-view.ts
@@ -1,7 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { notFound } from "@tanstack/react-router";
 import { and, count, eq } from "drizzle-orm";
-import { z } from "zod";
+import * as v from "valibot";
 import {
   customDomains,
   formSettings,
@@ -24,7 +24,7 @@ import { buildPublicFormSettings } from "@/types/form-settings";
 /** Get a published form by public short id. Returns published version content (not draft);
  * only status === "published" forms. */
 export const getPublishedFormByShortId = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ shortId: shortIdSchema }))
+  .inputValidator(v.object({ shortId: shortIdSchema }))
   .handler(async ({ data }) => {
     // Settings live in form_settings now (split from versioning; see
     // docs/plans/2026-05-04-settings-version-split.md). Editor content still comes from the
@@ -176,7 +176,7 @@ export const getPublishedFormByShortId = createServerFn({ method: "GET" })
 
 /** Verify a password for a password-protected form. */
 export const verifyFormPassword = createServerFn({ method: "POST" })
-  .inputValidator(z.object({ formId: z.uuid(), password: z.string() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()), password: v.string() }))
   .handler(async ({ data }) => {
     // Password is a live setting — read from form_settings, not the draft.
     const [formRow] = await db

--- a/src/lib/server-fn/public-submissions.ts
+++ b/src/lib/server-fn/public-submissions.ts
@@ -1,7 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { and, count, eq, sql } from "drizzle-orm";
 import { createError } from "@/lib/errors/create";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Value } from "platejs";
 import {
   formVisits,
@@ -92,13 +92,13 @@ const getAllowedFieldNames = (versionId: string | null, content: Value): Set<str
  */
 export const createPublicSubmission = createServerFn({ method: "POST" })
   .inputValidator(
-    z.object({
-      formId: z.uuid(),
-      data: z.record(z.string(), z.any()),
-      isCompleted: z.boolean().default(true),
-      draftId: z.uuid().optional(),
-      lastStepReached: z.number().int().min(0).optional(),
-      visitId: z.uuid().nullish(),
+    v.object({
+      formId: v.pipe(v.string(), v.uuid()),
+      data: v.record(v.string(), v.any()),
+      isCompleted: v.optional(v.boolean(), true),
+      draftId: v.optional(v.pipe(v.string(), v.uuid())),
+      lastStepReached: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
+      visitId: v.nullish(v.pipe(v.string(), v.uuid())),
     }),
   )
   .handler(async ({ data }) => {

--- a/src/lib/server-fn/submissions.ts
+++ b/src/lib/server-fn/submissions.ts
@@ -1,6 +1,6 @@
 import { createServerFn } from "@tanstack/react-start";
 import { and, count, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Value } from "platejs";
 import { formSettings, forms, formVersions, submissions } from "@/db/schema";
 import { db } from "@/db";
@@ -49,7 +49,9 @@ const maybePurgeAfterSubmissionDelete = async (formId: string) => {
 
 export const deleteSubmission = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ id: z.uuid(), formId: z.uuid() }))
+  .inputValidator(
+    v.object({ id: v.pipe(v.string(), v.uuid()), formId: v.pipe(v.string(), v.uuid()) }),
+  )
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     await authForm(data.formId, context.session.user.id, orgId);
@@ -61,9 +63,9 @@ export const deleteSubmission = createServerFn({ method: "POST" })
 export const deleteSubmissionsBulk = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      formId: z.uuid(),
-      submissionIds: z.array(z.uuid()),
+    v.object({
+      formId: v.pipe(v.string(), v.uuid()),
+      submissionIds: v.array(v.pipe(v.string(), v.uuid())),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -83,11 +85,14 @@ export const SUBMISSIONS_PAGE_SIZE = 50;
 export const getSubmissionsByFormIdPaginated = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      formId: z.uuid(),
-      cursor: z.object({ createdAt: z.string(), id: z.string() }).optional(),
-      limit: z.number().int().min(1).max(100).default(SUBMISSIONS_PAGE_SIZE),
-      search: z.string().optional(),
+    v.object({
+      formId: v.pipe(v.string(), v.uuid()),
+      cursor: v.optional(v.object({ createdAt: v.string(), id: v.string() })),
+      limit: v.optional(
+        v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(100)),
+        SUBMISSIONS_PAGE_SIZE,
+      ),
+      search: v.optional(v.string()),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -139,7 +144,7 @@ export const getSubmissionsByFormIdPaginated = createServerFn({ method: "GET" })
 
 export const getSubmissionsCount = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ formId: z.uuid() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     await authForm(data.formId, context.session.user.id, orgId);
@@ -156,7 +161,7 @@ export const getSubmissionsCount = createServerFn({ method: "GET" })
  * historical versions. One round-trip replacing three queries; no orphan-detection waterfall. */
 export const getSubmissionsBootstrap = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ formId: z.uuid() }))
+  .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()) }))
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     await authForm(data.formId, context.session.user.id, orgId);

--- a/src/lib/server-fn/uploads.ts
+++ b/src/lib/server-fn/uploads.ts
@@ -1,6 +1,6 @@
 import { createServerFn } from "@tanstack/react-start";
 import { createError } from "@/lib/errors/create";
-import { z } from "zod";
+import * as v from "valibot";
 import { putBlob } from "@/integrations/blob";
 import { authMiddleware } from "@/lib/auth/middleware";
 import type { ErrorCode } from "@/lib/errors/codes";
@@ -9,9 +9,9 @@ import type { ErrorCode } from "@/lib/errors/codes";
 export const uploadAvatar = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      base64: z.string(),
-      filename: z.string().optional(),
+    v.object({
+      base64: v.string(),
+      filename: v.optional(v.string()),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -35,10 +35,10 @@ export const uploadAvatar = createServerFn({ method: "POST" })
 export const uploadEditorMedia = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      base64: z.string().min(1),
-      filename: z.string().min(1).max(255),
-      contentType: z.string().min(1).max(127),
+    v.object({
+      base64: v.pipe(v.string(), v.minLength(1)),
+      filename: v.pipe(v.string(), v.minLength(1), v.maxLength(255)),
+      contentType: v.pipe(v.string(), v.minLength(1), v.maxLength(127)),
     }),
   )
   .handler(async ({ data, context }) => {

--- a/src/lib/server-fn/workspaces.ts
+++ b/src/lib/server-fn/workspaces.ts
@@ -17,26 +17,27 @@ import { purgeFormCacheBatch } from "@/lib/server-fn/cdn-cache";
 import { createServerFn } from "@tanstack/react-start";
 import { and, count, eq, inArray } from "drizzle-orm";
 import { createError } from "@/lib/errors/create";
-import { z } from "zod";
+import * as v from "valibot";
 import type { ErrorCode } from "@/lib/errors/codes";
 import { getActiveOrgId } from "./auth-helpers";
 import { authWorkspace } from "./auth-helpers.server";
 
-const workspaceSchema = z.object({
-  id: z.uuid(),
-  organizationId: z.uuid(),
-  name: z.string().max(100),
-  createdAt: z.string().optional(),
-  updatedAt: z.string().optional(),
+const workspaceSchema = v.object({
+  id: v.pipe(v.string(), v.uuid()),
+  organizationId: v.pipe(v.string(), v.uuid()),
+  name: v.pipe(v.string(), v.maxLength(100)),
+  createdAt: v.optional(v.string()),
+  updatedAt: v.optional(v.string()),
 });
 
 export const createWorkspace = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    workspaceSchema.pick({ organizationId: true, name: true }).extend({
-      id: z.uuid().optional(),
-      name: workspaceSchema.shape.name.optional().default("Workspace"),
-      sortIndex: z.string().optional(),
+    v.object({
+      organizationId: v.pipe(v.string(), v.uuid()),
+      name: v.optional(v.pipe(v.string(), v.maxLength(100)), "Workspace"),
+      id: v.optional(v.pipe(v.string(), v.uuid())),
+      sortIndex: v.optional(v.string()),
     }),
   )
   .handler(async ({ data, context }) => {
@@ -84,7 +85,7 @@ export const createWorkspace = createServerFn({ method: "POST" })
 
 export const updateWorkspace = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(workspaceSchema.pick({ id: true, name: true }).partial({ name: true }))
+  .inputValidator(v.partial(v.pick(workspaceSchema, ["id", "name"]), ["name"]))
   .handler(async ({ data, context }) => {
     const { id, ...updateData } = data;
     const orgId = getActiveOrgId(context.session);
@@ -110,7 +111,7 @@ export const updateWorkspace = createServerFn({ method: "POST" })
 
 export const deleteWorkspace = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
-  .inputValidator(workspaceSchema.pick({ id: true }))
+  .inputValidator(v.pick(workspaceSchema, ["id"]))
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     await authWorkspace(data.id, context.session.user.id, orgId);
@@ -208,9 +209,9 @@ export const getWorkspaces = createServerFn({ method: "GET" })
 export const reorderWorkspace = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(
-    z.object({
-      workspaceId: z.uuid(),
-      sortIndex: z.string(),
+    v.object({
+      workspaceId: v.pipe(v.string(), v.uuid()),
+      sortIndex: v.string(),
     }),
   )
   .handler(async ({ data, context }) => {

--- a/src/lib/short-id.ts
+++ b/src/lib/short-id.ts
@@ -1,5 +1,5 @@
 import { customAlphabet } from "nanoid";
-import { z } from "zod";
+import * as v from "valibot";
 
 export const SHORT_ID_LENGTH = 7;
 export const SHORT_ID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
@@ -10,4 +10,4 @@ const SHORT_ID_REGEX = new RegExp(`^[${SHORT_ID_ALPHABET}]{${SHORT_ID_LENGTH}}$`
 
 export const isValidShortId = (value: string): boolean => SHORT_ID_REGEX.test(value);
 
-export const shortIdSchema = z.string().refine(isValidShortId, "Invalid Form Short ID");
+export const shortIdSchema = v.pipe(v.string(), v.check(isValidShortId, "Invalid Form Short ID"));

--- a/src/lib/valibot-search.ts
+++ b/src/lib/valibot-search.ts
@@ -1,0 +1,24 @@
+import * as v from "valibot";
+
+// zod->valibot parity helpers for search-param validators. Valibot has no
+// `coerce`, so we replicate `z.coerce.*` with an unknown-input transform.
+
+// z.coerce.boolean(): any present value -> Boolean(value); absent key -> undefined.
+const coercedBoolean = v.pipe(
+  v.unknown(),
+  v.transform((input) => Boolean(input)),
+);
+
+/** z.coerce.boolean().optional() */
+export const optionalCoercedBoolean = v.optional(coercedBoolean);
+
+/** z.coerce.boolean().optional().default(value) */
+export const coercedBooleanWithDefault = (value: boolean) => v.optional(coercedBoolean, value);
+
+/** z.coerce.boolean().catch(value).optional() — catch is inert for Boolean() coercion; kept for parity. */
+export const coercedBooleanWithCatch = (value: boolean) =>
+  v.optional(v.fallback(coercedBoolean, value));
+
+/** z.coerce.number().catch(fallbackValue).optional() — invalid/NaN -> fallback. */
+export const coercedNumberWithCatch = (fallbackValue: number) =>
+  v.optional(v.fallback(v.pipe(v.unknown(), v.transform(Number), v.number()), fallbackValue));

--- a/src/routes/$slug.tsx
+++ b/src/routes/$slug.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, isNotFound, notFound } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { z } from "zod";
-import { zodValidator } from "@tanstack/zod-adapter";
+import * as v from "valibot";
+import { coercedBooleanWithDefault, optionalCoercedBoolean } from "@/lib/valibot-search";
 import { PublicFormPage } from "@/routes/forms/-components/public-form-page";
 import type { PublicFormEmbedConfig } from "@/routes/forms/-components/public-form-page";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
@@ -126,18 +126,16 @@ const CustomDomainSlugRoute = () => {
 };
 
 export const Route = createFileRoute("/$slug")({
-  validateSearch: zodValidator(
-    z.object({
-      transparentBackground: z.boolean().optional().default(false),
-      transparent: z.coerce.boolean().optional(),
-      popup: z.coerce.boolean().optional().default(false),
-      hideTitle: z.coerce.boolean().optional().default(false),
-      alignLeft: z.coerce.boolean().optional().default(false),
-      originPage: z.string().optional(),
-      dynamicHeight: z.coerce.boolean().optional().default(false),
-      dynamicWidth: z.coerce.boolean().optional().default(false),
-    }),
-  ),
+  validateSearch: v.object({
+    transparentBackground: v.optional(v.boolean(), false),
+    transparent: optionalCoercedBoolean,
+    popup: coercedBooleanWithDefault(false),
+    hideTitle: coercedBooleanWithDefault(false),
+    alignLeft: coercedBooleanWithDefault(false),
+    originPage: v.optional(v.string()),
+    dynamicHeight: coercedBooleanWithDefault(false),
+    dynamicWidth: coercedBooleanWithDefault(false),
+  }),
   loader: async ({ params }) => {
     try {
       return await getCustomDomainFormBySlugRSC({ data: { slug: params.slug } });

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/$formId/edit.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/$formId/edit.tsx
@@ -13,8 +13,8 @@ import { format } from "date-fns";
 import { Loader2Icon } from "@/components/ui/icons";
 import type { Value } from "platejs";
 import { Activity, Suspense, lazy } from "react";
-import { z } from "zod";
-import { zodValidator } from "@tanstack/zod-adapter";
+import * as v from "valibot";
+import { coercedBooleanWithCatch, coercedNumberWithCatch } from "@/lib/valibot-search";
 
 const EditorApp = lazy(() => import("../-components/editor-app"));
 const PreviewMode = lazy(() =>
@@ -110,31 +110,28 @@ const DesignPage = () => {
 export const Route = createFileRoute(
   "/_authenticated/workspace/$workspaceId/form-builder/$formId/edit",
 )({
-  validateSearch: zodValidator(
-    z.object({
-      force: z.boolean().optional(),
-      embedType: z.enum(["standard", "popup", "fullpage"]).catch("standard").optional(),
-      embedHeight: z.coerce.number().catch(558).optional(),
-      embedDynamicHeight: z.coerce.boolean().catch(true).optional(),
-      embedDynamicWidth: z.coerce.boolean().catch(false).optional(),
-      embedHideTitle: z.coerce.boolean().catch(false).optional(),
-      embedAlignLeft: z.coerce.boolean().catch(false).optional(),
-      embedTransparent: z.coerce.boolean().catch(false).optional(),
-      embedBranding: z.coerce.boolean().catch(true).optional(),
-      embedPopupPosition: z
-        .enum(["bottom-right", "bottom-left", "center"])
-        .catch("bottom-right")
-        .optional(),
-      embedPopupWidth: z.coerce.number().catch(376).optional(),
-      embedDarkOverlay: z.coerce.boolean().catch(false).optional(),
-      embedEmoji: z.coerce.boolean().catch(true).optional(),
-      embedEmojiIcon: z.string().catch("\uD83D\uDC4B").optional(),
-      embedEmojiAnimation: z.enum(["wave", "bounce", "pulse"]).catch("wave").optional(),
-      embedPopupTrigger: z.enum(["button", "auto", "scroll"]).catch("button").optional(),
-      embedHideOnSubmit: z.coerce.boolean().catch(false).optional(),
-      embedHideOnSubmitDelay: z.coerce.number().catch(0).optional(),
-    }),
-  ),
+  validateSearch: v.object({
+    force: v.optional(v.boolean()),
+    embedType: v.optional(v.fallback(v.picklist(["standard", "popup", "fullpage"]), "standard")),
+    embedHeight: coercedNumberWithCatch(558),
+    embedDynamicHeight: coercedBooleanWithCatch(true),
+    embedDynamicWidth: coercedBooleanWithCatch(false),
+    embedHideTitle: coercedBooleanWithCatch(false),
+    embedAlignLeft: coercedBooleanWithCatch(false),
+    embedTransparent: coercedBooleanWithCatch(false),
+    embedBranding: coercedBooleanWithCatch(true),
+    embedPopupPosition: v.optional(
+      v.fallback(v.picklist(["bottom-right", "bottom-left", "center"]), "bottom-right"),
+    ),
+    embedPopupWidth: coercedNumberWithCatch(376),
+    embedDarkOverlay: coercedBooleanWithCatch(false),
+    embedEmoji: coercedBooleanWithCatch(true),
+    embedEmojiIcon: v.optional(v.fallback(v.string(), "\uD83D\uDC4B")),
+    embedEmojiAnimation: v.optional(v.fallback(v.picklist(["wave", "bounce", "pulse"]), "wave")),
+    embedPopupTrigger: v.optional(v.fallback(v.picklist(["button", "auto", "scroll"]), "button")),
+    embedHideOnSubmit: coercedBooleanWithCatch(false),
+    embedHideOnSubmitDelay: coercedNumberWithCatch(0),
+  }),
   ssr: "data-only",
   // Redirect published forms to submissions (prevents flash of editor)
   beforeLoad: async ({ context, params, search }) => {

--- a/src/routes/api/ai/form-generate.ts
+++ b/src/routes/api/ai/form-generate.ts
@@ -2,12 +2,13 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createFileRoute } from "@tanstack/react-router";
 import { convertToModelMessages, generateText, streamObject, tool } from "ai";
 import type { UIMessage } from "ai";
+import { valibotSchema } from "@ai-sdk/valibot";
 import { getRequestHeaders } from "@tanstack/react-start/server";
 import type { RequestLogger } from "evlog";
 import { createAILogger } from "evlog/ai";
 import { identifyUser } from "evlog/better-auth";
 import { useRequest as getNitroRequest } from "nitro/context";
-import { z } from "zod";
+import * as v from "valibot";
 import { apiAuthMiddleware } from "@/lib/auth/middleware";
 import {
   formGenSchema,
@@ -227,13 +228,13 @@ export const Route = createFileRoute("/api/ai/form-generate")({
         // Theme atomic — no streaming benefit; tool-call gives clear contract. Pro: full tool (30 light:/dark: tokens). Free: limited tool, output stays in gate-allowed keys.
         if (mode === "theme") {
           if (themePick.isPro) {
-            const setFormThemeArgs = z.object({
+            const setFormThemeArgs = v.object({
               tokens: themeTokensSchema,
-              font: z.string(),
-              radius: z.enum(RADIUS_OPTIONS),
+              font: v.string(),
+              radius: v.picklist(RADIUS_OPTIONS),
             });
 
-            let captured: z.infer<typeof setFormThemeArgs> | null = null;
+            let captured: v.InferOutput<typeof setFormThemeArgs> | null = null;
 
             await generateText({
               model,
@@ -244,8 +245,8 @@ export const Route = createFileRoute("/api/ai/form-generate")({
                 [themePick.toolName]: tool({
                   description:
                     "Apply a complete visual theme to the form (colors, font, radius). Call exactly once with all 30 token values, font, and radius.",
-                  inputSchema: setFormThemeArgs,
-                  execute: async (args) => {
+                  inputSchema: valibotSchema(setFormThemeArgs),
+                  execute: async (args: v.InferOutput<typeof setFormThemeArgs>) => {
                     captured = args;
                     return { ok: true };
                   },
@@ -254,7 +255,7 @@ export const Route = createFileRoute("/api/ai/form-generate")({
             });
 
             // Re-bind to const so TS narrows past null check — assignment in closure, flow analysis can't reach via the `let`.
-            const captured2 = captured as z.infer<typeof setFormThemeArgs> | null;
+            const captured2 = captured as v.InferOutput<typeof setFormThemeArgs> | null;
             if (!captured2) {
               return new Response(JSON.stringify({ error: "model_did_not_emit_theme" }), {
                 status: 502,
@@ -274,7 +275,7 @@ export const Route = createFileRoute("/api/ai/form-generate")({
           }
 
           // Free plan: limited tool — themeColor + baseColor + font + radius + defaultMode.
-          let captured: z.infer<typeof freeThemeSchema> | null = null;
+          let captured: v.InferOutput<typeof freeThemeSchema> | null = null;
 
           await generateText({
             model,
@@ -285,8 +286,8 @@ export const Route = createFileRoute("/api/ai/form-generate")({
               [themePick.toolName]: tool({
                 description:
                   "Apply a basic theme available on the free plan. Call exactly once with themeColor, baseColor, font, radius, and defaultMode — each value must be from the allowed list in the system prompt.",
-                inputSchema: freeThemeSchema,
-                execute: async (args) => {
+                inputSchema: valibotSchema(freeThemeSchema),
+                execute: async (args: v.InferOutput<typeof freeThemeSchema>) => {
                   captured = args;
                   return { ok: true };
                 },
@@ -294,7 +295,7 @@ export const Route = createFileRoute("/api/ai/form-generate")({
             },
           });
 
-          const capturedFree = captured as z.infer<typeof freeThemeSchema> | null;
+          const capturedFree = captured as v.InferOutput<typeof freeThemeSchema> | null;
           if (!capturedFree) {
             return new Response(JSON.stringify({ error: "model_did_not_emit_theme" }), {
               status: 502,
@@ -316,7 +317,7 @@ export const Route = createFileRoute("/api/ai/form-generate")({
         // ── All other modes: structured-output streaming ────────────────────
         const result = streamObject({
           model,
-          schema: formGenSchema,
+          schema: valibotSchema(formGenSchema),
           system: systemWithContext,
           messages: modelMessages,
         });

--- a/src/routes/api/track/visit-end.ts
+++ b/src/routes/api/track/visit-end.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
+import * as v from "valibot";
 
 const MAX_DURATION_MS = 86_400_000;
 // Spam guards for client-reported vitals — reject absurd payloads only. LCP/INP ms, CLS unitless.
@@ -7,13 +7,13 @@ const MAX_VITAL_MS = 3_600_000; // 1h
 const MAX_CLS = 100;
 
 /** Unload beacon payload: timing + optional vitals from beforeunload/pagehide. Local mirror of serverFn schema — decoupled from broader updateFormVisit (admin-only fields). */
-const visitEndBeaconSchema = z.object({
-  visitId: z.uuid(),
-  visitEndedAt: z.iso.datetime(),
-  durationMs: z.number().int().nonnegative().max(MAX_DURATION_MS),
-  lcpMs: z.number().int().nonnegative().max(MAX_VITAL_MS).nullish(),
-  inpMs: z.number().int().nonnegative().max(MAX_VITAL_MS).nullish(),
-  cls: z.number().nonnegative().max(MAX_CLS).nullish(),
+const visitEndBeaconSchema = v.object({
+  visitId: v.pipe(v.string(), v.uuid()),
+  visitEndedAt: v.pipe(v.string(), v.isoTimestamp()),
+  durationMs: v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(MAX_DURATION_MS)),
+  lcpMs: v.nullish(v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(MAX_VITAL_MS))),
+  inpMs: v.nullish(v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(MAX_VITAL_MS))),
+  cls: v.nullish(v.pipe(v.number(), v.minValue(0), v.maxValue(MAX_CLS))),
 });
 
 export const Route = createFileRoute("/api/track/visit-end")({
@@ -27,12 +27,12 @@ export const Route = createFileRoute("/api/track/visit-end")({
         } catch {
           return new Response(null, { status: 400 });
         }
-        const parsed = visitEndBeaconSchema.safeParse(body);
+        const parsed = v.safeParse(visitEndBeaconSchema, body);
         if (!parsed.success) {
           return new Response(null, { status: 400 });
         }
         const { updateFormVisitImpl } = await import("@/lib/server-fn/analytics.server");
-        await updateFormVisitImpl(parsed.data);
+        await updateFormVisitImpl(parsed.output);
         return new Response(null, { status: 204 });
       },
     },

--- a/src/routes/f/$formId.tsx
+++ b/src/routes/f/$formId.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, isNotFound, notFound } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { z } from "zod";
-import { zodValidator } from "@tanstack/zod-adapter";
+import * as v from "valibot";
+import { optionalCoercedBoolean } from "@/lib/valibot-search";
 import { PublicFormPage } from "@/routes/forms/-components/public-form-page";
 import type { PublicFormEmbedConfig } from "@/routes/forms/-components/public-form-page";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
@@ -133,19 +133,17 @@ const CustomDomainFormIdRoute = () => {
 };
 
 export const Route = createFileRoute("/f/$formId")({
-  validateSearch: zodValidator(
-    z.object({
-      // No `.default()` — would 307-redirect bare URLs to defaults-appended canonical, breaking link-preview crawlers.
-      transparentBackground: z.boolean().optional(),
-      transparent: z.coerce.boolean().optional(),
-      popup: z.coerce.boolean().optional(),
-      hideTitle: z.coerce.boolean().optional(),
-      alignLeft: z.coerce.boolean().optional(),
-      originPage: z.string().optional(),
-      dynamicHeight: z.coerce.boolean().optional(),
-      dynamicWidth: z.coerce.boolean().optional(),
-    }),
-  ),
+  // No `.default()` — would 307-redirect bare URLs to defaults-appended canonical, breaking link-preview crawlers.
+  validateSearch: v.object({
+    transparentBackground: v.optional(v.boolean()),
+    transparent: optionalCoercedBoolean,
+    popup: optionalCoercedBoolean,
+    hideTitle: optionalCoercedBoolean,
+    alignLeft: optionalCoercedBoolean,
+    originPage: v.optional(v.string()),
+    dynamicHeight: optionalCoercedBoolean,
+    dynamicWidth: optionalCoercedBoolean,
+  }),
   loader: async ({ params }) => {
     try {
       return await getCustomDomainFormByIdRSC({ data: { formId: params.formId } });

--- a/src/routes/forms/$shortId.tsx
+++ b/src/routes/forms/$shortId.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { z } from "zod";
-import { zodValidator } from "@tanstack/zod-adapter";
+import * as v from "valibot";
 import { PublicFormPage } from "@/routes/forms/-components/public-form-page";
 import type { PublicFormEmbedConfig } from "@/routes/forms/-components/public-form-page";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
@@ -17,6 +16,14 @@ import {
 import { seo } from "@/lib/seo";
 import { APP_WEBSITE_URL } from "@/lib/config/app-config";
 import { getCoverPreloadLinks } from "@/lib/vercel-image";
+
+// z.coerce.boolean() parity: any present value → Boolean(value); absent key → undefined.
+const optionalCoercedBoolean = v.optional(
+  v.pipe(
+    v.unknown(),
+    v.transform((input) => Boolean(input)),
+  ),
+);
 
 type PublicTheme = "light" | "dark" | "system";
 
@@ -149,19 +156,17 @@ const PublicFormRoute = () => {
 };
 
 export const Route = createFileRoute("/forms/$shortId")({
-  validateSearch: zodValidator(
-    z.object({
-      // No `.default()` — Router would 307-canonicalize to ?popup=false&…, stripping link-preview bots that don't follow redirects.
-      transparentBackground: z.boolean().optional(),
-      transparent: z.coerce.boolean().optional(),
-      popup: z.coerce.boolean().optional(),
-      hideTitle: z.coerce.boolean().optional(),
-      alignLeft: z.coerce.boolean().optional(),
-      originPage: z.string().optional(),
-      dynamicHeight: z.coerce.boolean().optional(),
-      dynamicWidth: z.coerce.boolean().optional(),
-    }),
-  ),
+  // No `.default()` — Router would 307-canonicalize to ?popup=false&…, stripping link-preview bots that don't follow redirects.
+  validateSearch: v.object({
+    transparentBackground: v.optional(v.boolean()),
+    transparent: optionalCoercedBoolean,
+    popup: optionalCoercedBoolean,
+    hideTitle: optionalCoercedBoolean,
+    alignLeft: optionalCoercedBoolean,
+    originPage: v.optional(v.string()),
+    dynamicHeight: optionalCoercedBoolean,
+    dynamicWidth: optionalCoercedBoolean,
+  }),
   loader: async ({ params }) => getPublicFormViewRSC({ data: { shortId: params.shortId } }),
   head: ({ loaderData, params }) => {
     const defaultMode = loaderData?.form?.customization?.defaultMode || "system";

--- a/src/routes/forms/$shortId.tsx
+++ b/src/routes/forms/$shortId.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import * as v from "valibot";
+import { optionalCoercedBoolean } from "@/lib/valibot-search";
 import { PublicFormPage } from "@/routes/forms/-components/public-form-page";
 import type { PublicFormEmbedConfig } from "@/routes/forms/-components/public-form-page";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
@@ -16,14 +17,6 @@ import {
 import { seo } from "@/lib/seo";
 import { APP_WEBSITE_URL } from "@/lib/config/app-config";
 import { getCoverPreloadLinks } from "@/lib/vercel-image";
-
-// z.coerce.boolean() parity: any present value → Boolean(value); absent key → undefined.
-const optionalCoercedBoolean = v.optional(
-  v.pipe(
-    v.unknown(),
-    v.transform((input) => Boolean(input)),
-  ),
-);
 
 type PublicTheme = "light" | "dark" | "system";
 

--- a/src/routes/login/email.tsx
+++ b/src/routes/login/email.tsx
@@ -1,9 +1,8 @@
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { zodValidator } from "@tanstack/zod-adapter";
 import { Loader2Icon } from "@/components/ui/icons";
 import * as React from "react";
-import * as z from "zod";
+import * as v from "valibot";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { revalidateLogic, useAppForm } from "@/components/ui/tanstack-form";
@@ -13,8 +12,8 @@ import { isSafeRedirect } from "@/lib/auth/safe-redirect";
 import { Logo } from "@/components/ui/logo";
 import { SuccessCheck } from "@/components/transitions/success-check";
 
-const emailSchema = z.object({
-  email: z.email({ error: "Please enter a valid email address" }),
+const emailSchema = v.object({
+  email: v.pipe(v.string(), v.email("Please enter a valid email address")),
 });
 
 const EmailLoginPage = () => {
@@ -51,7 +50,7 @@ const EmailLoginPage = () => {
   });
 
   const form = useAppForm({
-    defaultValues: { email: "" } as z.input<typeof emailSchema>,
+    defaultValues: { email: "" } as v.InferInput<typeof emailSchema>,
     validationLogic: revalidateLogic(),
     validators: { onDynamic: emailSchema, onDynamicAsyncDebounceMs: 500 },
     onSubmit: async ({ value }) => {
@@ -155,10 +154,8 @@ export const Route = createFileRoute("/login/email")({
   server: {
     middleware: [guestMiddleware],
   },
-  validateSearch: zodValidator(
-    z.object({
-      redirect: z.string().optional(),
-    }),
-  ),
+  validateSearch: v.object({
+    redirect: v.optional(v.string()),
+  }),
   component: EmailLoginPage,
 });

--- a/src/routes/login/index.tsx
+++ b/src/routes/login/index.tsx
@@ -1,8 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { zodValidator } from "@tanstack/zod-adapter";
 import { Loader2Icon } from "@/components/ui/icons";
-import * as z from "zod";
+import * as v from "valibot";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth/auth-client";
 import { guestMiddleware } from "@/lib/auth/middleware";
@@ -98,10 +97,8 @@ export const Route = createFileRoute("/login/")({
   server: {
     middleware: [guestMiddleware],
   },
-  validateSearch: zodValidator(
-    z.object({
-      redirect: z.string().optional(),
-    }),
-  ),
+  validateSearch: v.object({
+    redirect: v.optional(v.string()),
+  }),
   component: LoginPage,
 });

--- a/src/test/ai-theme-schemas.test.ts
+++ b/src/test/ai-theme-schemas.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import * as v from "valibot";
 import { freeThemeSchema, themeTokensSchema, AI_THEME_TOKEN_KEYS } from "@/lib/ai/ops-schema";
 
 describe("freeThemeSchema", () => {
@@ -11,26 +12,26 @@ describe("freeThemeSchema", () => {
   };
 
   it("accepts a fully valid payload", () => {
-    expect(freeThemeSchema.safeParse(valid).success).toBeTruthy();
+    expect(v.safeParse(freeThemeSchema, valid).success).toBeTruthy();
   });
 
   it("rejects an out-of-enum themeColor", () => {
-    const result = freeThemeSchema.safeParse({ ...valid, themeColor: "magenta" });
+    const result = v.safeParse(freeThemeSchema, { ...valid, themeColor: "magenta" });
     expect(result.success).toBeFalsy();
   });
 
   it("rejects an out-of-enum baseColor (e.g. a theme color slipping in)", () => {
-    const result = freeThemeSchema.safeParse({ ...valid, baseColor: "blue" });
+    const result = v.safeParse(freeThemeSchema, { ...valid, baseColor: "blue" });
     expect(result.success).toBeFalsy();
   });
 
   it("rejects an out-of-enum radius", () => {
-    const result = freeThemeSchema.safeParse({ ...valid, radius: "round" });
+    const result = v.safeParse(freeThemeSchema, { ...valid, radius: "round" });
     expect(result.success).toBeFalsy();
   });
 
   it("rejects an out-of-enum defaultMode", () => {
-    const result = freeThemeSchema.safeParse({ ...valid, defaultMode: "auto" });
+    const result = v.safeParse(freeThemeSchema, { ...valid, defaultMode: "auto" });
     expect(result.success).toBeFalsy();
   });
 
@@ -38,13 +39,15 @@ describe("freeThemeSchema", () => {
     for (const key of Object.keys(valid)) {
       const partial = { ...valid } as Record<string, unknown>;
       delete partial[key];
-      expect(freeThemeSchema.safeParse(partial).success).toBeFalsy();
+      expect(v.safeParse(freeThemeSchema, partial).success).toBeFalsy();
     }
   });
 
   it("accepts any non-empty string for font (Google Fonts catalog is open)", () => {
-    expect(freeThemeSchema.safeParse({ ...valid, font: "Playfair Display" }).success).toBeTruthy();
-    expect(freeThemeSchema.safeParse({ ...valid, font: "JetBrains Mono" }).success).toBeTruthy();
+    expect(
+      v.safeParse(freeThemeSchema, { ...valid, font: "Playfair Display" }).success,
+    ).toBeTruthy();
+    expect(v.safeParse(freeThemeSchema, { ...valid, font: "JetBrains Mono" }).success).toBeTruthy();
   });
 });
 
@@ -59,7 +62,7 @@ describe("themeTokensSchema", () => {
   })();
 
   it("accepts a fully populated 30-key payload", () => {
-    expect(themeTokensSchema.safeParse(fullTokens).success).toBeTruthy();
+    expect(v.safeParse(themeTokensSchema, fullTokens).success).toBeTruthy();
   });
 
   it("rejects a partial payload (15 keys missing)", () => {
@@ -67,17 +70,17 @@ describe("themeTokensSchema", () => {
     for (const key of AI_THEME_TOKEN_KEYS) {
       half[`light:${key}`] = "#ffffff";
     }
-    expect(themeTokensSchema.safeParse(half).success).toBeFalsy();
+    expect(v.safeParse(themeTokensSchema, half).success).toBeFalsy();
   });
 
   it("rejects a payload missing a single required key", () => {
     const missingOne = { ...fullTokens };
     delete (missingOne as Record<string, unknown>)["light:primary"];
-    expect(themeTokensSchema.safeParse(missingOne).success).toBeFalsy();
+    expect(v.safeParse(themeTokensSchema, missingOne).success).toBeFalsy();
   });
 
   it("rejects a payload with non-string token values", () => {
     const badType = { ...fullTokens, "light:primary": 123 } as unknown;
-    expect(themeTokensSchema.safeParse(badType).success).toBeFalsy();
+    expect(v.safeParse(themeTokensSchema, badType).success).toBeFalsy();
   });
 });


### PR DESCRIPTION
## What

Migrates validation from **zod → valibot** across the entire app. zod was the single largest dependency in the public-form client bundle, and valibot's modular/tree-shakeable Standard Schema plugs directly into TanStack Router `validateSearch`, Start `createServerFn().inputValidator`, TanStack DB collection schemas, and TanStack Form — no adapter needed.

## Result — public-form `index` chunk

| | Baseline (zod) | After (valibot) | Δ |
|---|---|---|---|
| **gzip** | 280.87 kB | **262.99 kB** | **−17.88 kB (−6.4%)** |
| raw | 1,106.79 kB | 1,041.03 kB | −65.76 kB |
| zod in index | 23.59 kB gz | **0** | eliminated |
| valibot in index | 0 | 3.02 kB gz | +3.02 |

zod is **fully removed from the public-form critical path** and from our direct dependencies (it remains only as a transitive dep of the AI SDK packages, in the lazy editor chunk).

## Scope

- **Client routes** (`$shortId`, `$slug`, `f/$formId`, `login`, `login/email`, form-builder `edit`): `zodValidator` → valibot Standard Schema in `validateSearch`. Dropped `@tanstack/zod-adapter`.
- **Shared helpers** (`src/lib/valibot-search.ts`): verified zod-parity helpers for `coerce`/`.default`/`.catch`.
- **Local draft collection** (`collections/local/form.ts`): TanStack DB schema.
- **All server-fn `inputValidator`s** + dynamic preview-form schema.
- **AI schemas** (`ops-schema.ts`, `form-generate.ts`): valibot, wrapped with `valibotSchema()` from `@ai-sdk/valibot@2.0.28` (ai-v6 line; deps the `@ai-sdk/provider-utils@4.0.27` we already use) so the AI SDK gets JSON Schema via `@valibot/to-json-schema`. Raw valibot can't be passed to the AI SDK (its `~standard` lacks `jsonSchema`); `valibotSchema()` is required — conversion verified at runtime.

## Verification

- `pnpm exec tsc --noEmit`: 0 errors
- `pnpm exec vitest run --no-file-parallelism`: **422/422** pass (also green in pre-push)
- oxlint / oxfmt / knip: clean

## Deps

- Added: `valibot@1.4.0`, `@ai-sdk/valibot@2.0.28`, `@valibot/to-json-schema@1.7.0`
- Removed: `zod`, `@tanstack/zod-adapter`
