### PR TITLE
perf(bundle): evict drizzle-orm from client (−14 kB gz off public form)

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,3 +1,4 @@
+import "@tanstack/react-start/server-only";
 import { defineRelations, sql } from "drizzle-orm";
 import {
   boolean,
@@ -845,3 +846,12 @@ export const aiGenerationCounts = pgTable(
   },
   (t) => [index("idx_ai_generation_counts_org_day").on(t.organizationId, t.periodDay)],
 );
+
+// Row types — import these via `import type` from client-reachable server-fn modules
+// so a `typeof <table>.$inferSelect` annotation doesn't pull the table value (and
+// thus drizzle-orm) into the client bundle. Server-only marker above keeps values out.
+export type FormRow = typeof forms.$inferSelect;
+export type FormVersionRow = typeof formVersions.$inferSelect;
+export type SubmissionRow = typeof submissions.$inferSelect;
+export type CustomDomainRow = typeof customDomains.$inferSelect;
+export type FormSubmissionNotificationRow = typeof formSubmissionNotifications.$inferSelect;

--- a/src/integrations/email.ts
+++ b/src/integrations/email.ts
@@ -1,3 +1,4 @@
+import "@tanstack/react-start/server-only";
 import { Resend } from "resend";
 import { APP_NAME } from "@/lib/config/app-config";
 import { logger } from "@/lib/utils";

--- a/src/lib/server-fn/analytics.ts
+++ b/src/lib/server-fn/analytics.ts
@@ -2,6 +2,17 @@ import { createServerFn } from "@tanstack/react-start";
 import * as v from "valibot";
 import { authMiddleware } from "@/lib/auth/middleware";
 import { getActiveOrgId } from "@/lib/server-fn/auth-helpers";
+import {
+  aggregateAnalyticsDailyImpl,
+  getFormDropoffImpl,
+  getFormInsightsImpl,
+  getFormVitalsImpl,
+  getInsightsAvailabilityImpl,
+  recordFormVisitImpl,
+  recordQuestionProgressBatchImpl,
+  recordQuestionProgressImpl,
+  updateFormVisitImpl,
+} from "@/lib/server-fn/analytics.server";
 import type {
   InsightsAvailability,
   RecordQuestionProgressBatchInput,
@@ -12,8 +23,9 @@ import type {
   QuestionDropoffMetrics,
 } from "@/types/analytics";
 
-// DB logic lives in analytics.server.ts, dynamically imported in each handler so Start strips it
-// from the client bundle — @/db + postgres driver never reach the browser via this file.
+// DB logic lives in analytics.server.ts (server-only via the .server suffix). Imported
+// statically here but used only inside handlers, so Start prunes it from the client bundle —
+// @/db + postgres driver never reach the browser via this file.
 
 const recordVisitInputSchema = v.object({
   formId: v.pipe(v.string(), v.uuid()),
@@ -27,10 +39,7 @@ const recordVisitInputSchema = v.object({
 
 export const recordFormVisit = createServerFn({ method: "POST" })
   .inputValidator(recordVisitInputSchema)
-  .handler(async ({ data }): Promise<{ visitId: string | null }> => {
-    const { recordFormVisitImpl } = await import("./analytics.server");
-    return recordFormVisitImpl(data);
-  });
+  .handler(async ({ data }): Promise<{ visitId: string | null }> => recordFormVisitImpl(data));
 
 const MAX_DURATION_MS = 86_400_000; // 24h cap as a spam guard for client-supplied values
 
@@ -53,10 +62,7 @@ const updateVisitInputSchema = v.object({
 
 export const updateFormVisit = createServerFn({ method: "POST" })
   .inputValidator(updateVisitInputSchema)
-  .handler(async ({ data }): Promise<{ ok: true }> => {
-    const { updateFormVisitImpl } = await import("./analytics.server");
-    return updateFormVisitImpl(data);
-  });
+  .handler(async ({ data }): Promise<{ ok: true }> => updateFormVisitImpl(data));
 
 const questionProgressInputSchema = v.object({
   visitId: v.pipe(v.string(), v.uuid()),
@@ -73,10 +79,7 @@ const questionProgressInputSchema = v.object({
 
 export const recordQuestionProgress = createServerFn({ method: "POST" })
   .inputValidator(questionProgressInputSchema)
-  .handler(async ({ data }): Promise<{ ok: true }> => {
-    const { recordQuestionProgressImpl } = await import("./analytics.server");
-    return recordQuestionProgressImpl(data);
-  });
+  .handler(async ({ data }): Promise<{ ok: true }> => recordQuestionProgressImpl(data));
 
 const MAX_QUESTION_PROGRESS_BATCH = 20;
 
@@ -98,10 +101,7 @@ export const recordQuestionProgressBatch = createServerFn({ method: "POST" })
     }): Promise<{
       ok: true;
       processed: number;
-    }> => {
-      const { recordQuestionProgressBatchImpl } = await import("./analytics.server");
-      return recordQuestionProgressBatchImpl(data);
-    },
+    }> => recordQuestionProgressBatchImpl(data),
   );
 
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
@@ -116,34 +116,22 @@ const insightsFilterInputSchema = v.object({
 export const getFormInsights = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(insightsFilterInputSchema)
-  .handler(async ({ data, context }): Promise<FormInsightsMetrics> => {
-    const { getFormInsightsImpl } = await import("./analytics.server");
-    return getFormInsightsImpl(data, context, getActiveOrgId(context.session));
-  });
+  .handler(async ({ data, context }): Promise<FormInsightsMetrics> => getFormInsightsImpl(data, context, getActiveOrgId(context.session)));
 
 export const getFormDropoff = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(insightsFilterInputSchema)
-  .handler(async ({ data, context }): Promise<QuestionDropoffMetrics> => {
-    const { getFormDropoffImpl } = await import("./analytics.server");
-    return getFormDropoffImpl(data, context, getActiveOrgId(context.session));
-  });
+  .handler(async ({ data, context }): Promise<QuestionDropoffMetrics> => getFormDropoffImpl(data, context, getActiveOrgId(context.session)));
 
 export const getFormVitals = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(insightsFilterInputSchema)
-  .handler(async ({ data, context }): Promise<FormVitalsMetrics> => {
-    const { getFormVitalsImpl } = await import("./analytics.server");
-    return getFormVitalsImpl(data, context, getActiveOrgId(context.session));
-  });
+  .handler(async ({ data, context }): Promise<FormVitalsMetrics> => getFormVitalsImpl(data, context, getActiveOrgId(context.session)));
 
 export const getInsightsAvailability = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(v.object({ formId: v.pipe(v.string(), v.uuid()) }))
-  .handler(async ({ data, context }): Promise<InsightsAvailability> => {
-    const { getInsightsAvailabilityImpl } = await import("./analytics.server");
-    return getInsightsAvailabilityImpl(data, context, getActiveOrgId(context.session));
-  });
+  .handler(async ({ data, context }): Promise<InsightsAvailability> => getInsightsAvailabilityImpl(data, context, getActiveOrgId(context.session)));
 
 const aggregateInputSchema = v.object({
   date: v.pipe(v.string(), v.regex(DATE_KEY_PATTERN)),
@@ -151,7 +139,4 @@ const aggregateInputSchema = v.object({
 
 export const aggregateAnalyticsDaily = createServerFn({ method: "POST" })
   .inputValidator(aggregateInputSchema)
-  .handler(async ({ data }) => {
-    const { aggregateAnalyticsDailyImpl } = await import("./analytics.server");
-    return aggregateAnalyticsDailyImpl(data);
-  });
+  .handler(async ({ data }) => aggregateAnalyticsDailyImpl(data));

--- a/src/lib/server-fn/billing.ts
+++ b/src/lib/server-fn/billing.ts
@@ -5,6 +5,7 @@ import * as v from "valibot";
 import { db } from "@/db";
 import { member } from "@/db/schema";
 import { authMiddleware } from "@/lib/auth/middleware";
+import { polarClient } from "@/lib/auth/auth";
 import type { ErrorCode } from "@/lib/errors/codes";
 
 /** Opens Polar's hosted portal for an org-scoped customer. Better Auth's customer.portal() looks
@@ -32,7 +33,6 @@ export const openOrgBillingPortal = createServerFn({ method: "POST" })
       });
     }
 
-    const { polarClient } = await import("@/lib/auth/auth");
     const email = context.session.user.email;
 
     // Customer has no externalId (checkout created it with email only; referenceId lives on the

--- a/src/lib/server-fn/custom-domains.ts
+++ b/src/lib/server-fn/custom-domains.ts
@@ -4,6 +4,7 @@ import { and, eq, isNotNull } from "drizzle-orm";
 import { createError } from "@/lib/errors/create";
 import * as v from "valibot";
 import { customDomains, forms, member } from "@/db/schema";
+import type { CustomDomainRow } from "@/db/schema";
 import { db } from "@/db";
 import { authMiddleware } from "@/lib/auth/middleware";
 import type { ErrorCode } from "@/lib/errors/codes";
@@ -17,7 +18,7 @@ import {
 import { DOMAIN_LIMITS } from "@/lib/config/plan-config";
 import { isSubdomain } from "@/lib/dns-instructions";
 
-const serializeDomain = (domain: typeof customDomains.$inferSelect) => ({
+const serializeDomain = (domain: CustomDomainRow) => ({
   ...domain,
   createdAt: domain.createdAt.toISOString(),
   updatedAt: domain.updatedAt.toISOString(),

--- a/src/lib/server-fn/form-versions.ts
+++ b/src/lib/server-fn/form-versions.ts
@@ -5,6 +5,7 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 import { createError } from "@/lib/errors/create";
 import * as v from "valibot";
 import { formSettings, forms, formVersions, user } from "@/db/schema";
+import type { FormVersionRow } from "@/db/schema";
 import { db } from "@/db";
 import { authMiddleware } from "@/lib/auth/middleware";
 import { canonicalJSON, computeContentHash } from "@/lib/content-hash";
@@ -18,7 +19,7 @@ import { authForm } from "./auth-helpers.server";
 // TODO: make plan-based
 const MAX_VERSIONS_PER_FORM = 20;
 
-const serializeVersion = (version: typeof formVersions.$inferSelect) => ({
+const serializeVersion = (version: FormVersionRow) => ({
   ...version,
   publishedAt: version.publishedAt.toISOString(),
   createdAt: version.createdAt.toISOString(),
@@ -93,7 +94,7 @@ export const publishFormVersion = createServerFn({ method: "POST" })
         willInsertVersion: versionedDirty || isFirstPublish,
       });
 
-      let newVersion: typeof formVersions.$inferSelect | undefined;
+      let newVersion: FormVersionRow | undefined;
       let versionId = form.lastPublishedVersionId ?? null;
 
       if (versionedDirty || isFirstPublish) {

--- a/src/lib/server-fn/forms.ts
+++ b/src/lib/server-fn/forms.ts
@@ -3,6 +3,7 @@ import { and, count, eq, inArray, ne, sql } from "drizzle-orm";
 import { createError } from "@/lib/errors/create";
 import * as v from "valibot";
 import { customDomains, formSettings, forms, member, submissions, workspaces } from "@/db/schema";
+import type { FormRow } from "@/db/schema";
 import { RESERVED_SLUGS } from "@/lib/config/plan-config";
 import { planUnlocks } from "@/lib/config/plan-gates";
 import { db } from "@/db";
@@ -13,6 +14,7 @@ import { defaultFormSettings } from "@/types/form-settings";
 import type { FormSettings } from "@/types/form-settings";
 import { getActiveOrgId } from "./auth-helpers";
 import { authForm, authFormsBulk } from "./auth-helpers.server";
+import { mergeFormSettings } from "./merge-form-settings.server";
 import { getOrgPlan, getOrgPlanWithPolarSync } from "./plan-helpers.server";
 import { generateShortId } from "@/lib/short-id";
 
@@ -29,18 +31,13 @@ const isShortIdCollision = (err: unknown): boolean =>
   "constraint_name" in err &&
   (err as { constraint_name: unknown }).constraint_name === SHORT_ID_CONSTRAINT;
 
-const serializeForm = (form: typeof forms.$inferSelect) => ({
+const serializeForm = (form: FormRow) => ({
   ...form,
   createdAt: form.createdAt.toISOString(),
   updatedAt: form.updatedAt.toISOString(),
   content: form.content as object[],
   customization: (form.customization ?? {}) as Record<string, object>,
 });
-
-/** Shallow-merge settings patch into forms.draftSettings JSONB (working draft only;
- * live settings served to public renderers live in form_settings). */
-export const mergeFormSettings = (patch: Partial<FormSettings>) =>
-  sql`${forms.draftSettings} || ${JSON.stringify(patch)}::jsonb`;
 
 export const createForm = createServerFn({ method: "POST" })
   .middleware([authMiddleware, formProSettingsMiddleware])

--- a/src/lib/server-fn/merge-form-settings.server.ts
+++ b/src/lib/server-fn/merge-form-settings.server.ts
@@ -1,0 +1,12 @@
+import { sql } from "drizzle-orm";
+import { forms } from "@/db/schema";
+import type { FormSettings } from "@/types/form-settings";
+
+// Server-only: references the `forms` table value + drizzle `sql`. Kept out of forms.ts
+// (a client-reachable server-fn module) so its module-level schema reference doesn't pin
+// drizzle-orm into the client bundle. The `.server.ts` suffix strips it from the client.
+
+/** Shallow-merge settings patch into forms.draftSettings JSONB (working draft only;
+ * live settings served to public renderers live in form_settings). */
+export const mergeFormSettings = (patch: Partial<FormSettings>) =>
+  sql`${forms.draftSettings} || ${JSON.stringify(patch)}::jsonb`;

--- a/src/lib/server-fn/notifications.ts
+++ b/src/lib/server-fn/notifications.ts
@@ -9,13 +9,14 @@ import {
   forms,
   workspaces,
 } from "@/db/schema";
+import type { FormSubmissionNotificationRow } from "@/db/schema";
 import { db } from "@/db";
 import { authMiddleware } from "@/lib/auth/middleware";
 import type { ErrorCode } from "@/lib/errors/codes";
 import { getActiveOrgId } from "./auth-helpers";
 import { authForm } from "./auth-helpers.server";
 
-type NotificationRow = typeof formSubmissionNotifications.$inferSelect;
+type NotificationRow = FormSubmissionNotificationRow;
 
 const serializeSubmissionNotification = (
   row: NotificationRow & {

--- a/src/lib/server-fn/org.ts
+++ b/src/lib/server-fn/org.ts
@@ -1,12 +1,13 @@
 import { queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
+import { auth } from "@/lib/auth/auth";
 
 /** Server-only org data for SSR (_authenticated loader). Auth handled by route's authMiddleware.
- * auth lazy-imported in handler: static import would drag @polar-sh/sdk + @/db + pg into the
- * client bundle (this file is statically imported by _authenticated.tsx). */
+ * `auth` (server-only marker) is used only in the handler, so Start prunes it + its @polar-sh/sdk
+ * + @/db + pg deps from the client bundle even though this file is statically imported by
+ * _authenticated.tsx. */
 export const getOrgDataForLayout = createServerFn({ method: "GET" }).handler(async () => {
-  const { auth } = await import("@/lib/auth/auth");
   const headers = getRequestHeaders();
   const [activeOrg, orgsData] = await Promise.all([
     auth.api.getFullOrganization({ headers }),

--- a/src/lib/server-fn/plan-cleanup.server.ts
+++ b/src/lib/server-fn/plan-cleanup.server.ts
@@ -1,7 +1,7 @@
 import { and, eq, inArray, ne, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { customDomains, formSettings, forms, organization, workspaces } from "@/db/schema";
-import { mergeFormSettings } from "@/lib/server-fn/forms";
+import { mergeFormSettings } from "@/lib/server-fn/merge-form-settings.server";
 import { vercelDomains } from "@/lib/vercel-domains.server";
 
 type DbExecutor = typeof db;

--- a/src/lib/server-fn/public-submissions.ts
+++ b/src/lib/server-fn/public-submissions.ts
@@ -21,6 +21,7 @@ import {
 import type { ErrorCode } from "@/lib/errors/codes";
 import { isServerPlan } from "./plan-helpers";
 import { recordOwnerSubmissionNotification } from "./notifications-helpers.server";
+import { sendFormSubmissionNotification, sendRespondentConfirmation } from "@/integrations/email";
 
 type VersionSettings = {
   closeForm?: boolean;
@@ -381,9 +382,6 @@ const sendEmailNotifications = async (
   submissionId: string,
   submissionData: Record<string, unknown>,
 ) => {
-  const { sendFormSubmissionNotification, sendRespondentConfirmation } =
-    await import("@/integrations/email");
-
   if (settings.selfEmailNotifications) {
     let toEmail = settings.notificationEmail;
 

--- a/src/lib/server-fn/submissions.ts
+++ b/src/lib/server-fn/submissions.ts
@@ -3,6 +3,7 @@ import { and, count, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
 import * as v from "valibot";
 import type { Value } from "platejs";
 import { formSettings, forms, formVersions, submissions } from "@/db/schema";
+import type { SubmissionRow } from "@/db/schema";
 import { db } from "@/db";
 import {
   getEditableFields,
@@ -23,7 +24,7 @@ export type SerializedSubmission = {
   updatedAt: string;
 };
 
-const serializeSubmission = (s: typeof submissions.$inferSelect) => ({
+const serializeSubmission = (s: SubmissionRow) => ({
   ...s,
   createdAt: s.createdAt.toISOString(),
   updatedAt: s.updatedAt.toISOString(),

--- a/src/test/plan-cleanup.test.ts
+++ b/src/test/plan-cleanup.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { customDomains, forms, organization } from "@/db/schema";
-import { mergeFormSettings } from "@/lib/server-fn/forms";
+import { mergeFormSettings } from "@/lib/server-fn/merge-form-settings.server";
 import { applyDowngradeCleanup, applyUpgradeRestore } from "@/lib/server-fn/plan-cleanup.server";
 import {
   cleanupTestOrg,


### PR DESCRIPTION
## What

Stacks on #91 (now merged). Evicts `drizzle-orm` + `src/db/schema.ts` from the client bundle and cleans up the server-eviction `await import()` workarounds they were forcing in server-fn modules — using TanStack Start's **server-only marker** + **import-protection** as the declarative mechanism instead.

## Result — public-form `index` chunk

| | Post-valibot (PR #91) | After this PR | Δ this PR |
|---|---|---|---|
| **gzip** | 262.99 kB | **248.93 kB** | **−14.06 kB** |
| raw | 1,041.03 kB | 981.70 kB | −59.33 kB |
| drizzle-orm | 18.5 kB gz | **0** (gone from ALL client chunks) | eliminated |
| `src/db/schema.ts` | 3.1 kB gz | 0 | eliminated |

Cumulative from the original (pre-valibot) baseline: **280.87 → 248.93 kB gz = −31.94 kB (−11.4%)**.

## How (in 3 commits)

### `6abe868` — evict drizzle-orm + schema from the client
- Marked `src/db/schema.ts` server-only (`import "@tanstack/react-start/server-only"`). The Start compiler prunes handler-only schema imports from client-reachable server-fn modules; import-protection now fails the build with an exact import-trace if anything references schema *values* outside a server boundary.
- Two pre-existing leaks surfaced and fixed:
  - **Module-level `mergeFormSettings`** (`export const ... = sql\`${forms.draftSettings} ...\``) moved to `merge-form-settings.server.ts` — its `.server.ts` suffix strips it from the client. Two consumers (`plan-cleanup.server.ts`, the plan-cleanup test) updated to import from the new location.
  - **`typeof <table>.$inferSelect` annotations** in forms/form-versions/submissions/custom-domains/notifications were pinning the table value binding. Added exported row types to `schema.ts` (`FormRow`, `FormVersionRow`, `SubmissionRow`, `CustomDomainRow`, `FormSubmissionNotificationRow`) and switched annotations to `import type { ... } from "@/db/schema"` — type-only imports are erased and **don't** trip import-protection.

### `fcfaa17` — replace server-eviction `await import()` with static imports
Now that the targets are server-only-marked (or `.server.ts`) and the compiler prunes handler-only imports, the dynamic-import workarounds are unnecessary:
- `analytics.ts`: **9** dynamic imports of `./analytics.server` → 1 static import
- `org.ts`: `@/lib/auth/auth` (auth instance) → static
- `billing.ts`: `@/lib/auth/auth` (polarClient) → static

Bundle size unchanged (the deps were already evicted via dynamic import) — the win is the code style. import-protection confirms pruning.

### `52e2614` — same pattern for the email integration
- Marked `@/integrations/email` server-only (it constructs a `Resend` client with the API key at module scope; only non-test importer is `auth.ts`).
- `public-submissions.ts`: `await import("@/integrations/email")` inside `sendEmailNotifications` (non-exported, handler-reachable-only) → static import. Resend SDK prunes from the client.

## What still uses `await import()` (intentional)
- **Client lazy/circular-dep**: editor hooks, route loaders importing `@/collections`, `merge-theme`, `forms-queries` (not server-eviction; targets aren't server-only).
- **Already inside `.server.ts` or API routes**: whole module already server-only; not a bundle concern.
- **RSC `.impl` files** (`public-form-view-rsc.tsx`, `custom-domain-view-rsc.tsx`): load-bearing for public-form rendering; pull the heavy Plate editor. Too risky to touch for style.

## Verification
- `pnpm exec tsc --noEmit`: 0 errors
- `pnpm exec vitest run --no-file-parallelism`: **422/422** pass (also green in pre-push)
- `vite build`: 0 import-protection denials
- oxfmt/oxlint/knip: clean
