### PR TITLE
feat(logic): conditional form logic (Wave 1)

### DIFF
--- a/src/components/editor/plugins/form-blocks-kit.tsx
+++ b/src/components/editor/plugins/form-blocks-kit.tsx
@@ -6,6 +6,7 @@ import { FormButtonElement } from "@/components/ui/form-button-node";
 import { FormFieldElement } from "@/components/ui/form-field-node";
 import { FormLabelElement } from "@/components/ui/form-label-node";
 import { FormTextareaElement } from "@/components/ui/form-textarea-node";
+import { LogicBlockElement } from "@/components/ui/logic-block-node";
 import { PageBreakElement } from "@/components/ui/page-break-node";
 import { FormFileUploadElement } from "@/components/ui/form-file-upload-node";
 import { FormMultiSelectInputElement } from "@/components/ui/form-multi-select-input-node";
@@ -768,6 +769,19 @@ export const PageBreakPlugin = createPlatePlugin({
   },
 });
 
+export const LogicBlockPlugin = createPlatePlugin({
+  key: "logicBlock",
+  node: {
+    isElement: true,
+    isVoid: true,
+    isSelectable: true,
+    component: LogicBlockElement,
+  },
+  handlers: {
+    onKeyDown: ({ editor, event }) => handleBackspace(editor, event),
+  },
+});
+
 export const FormEmailPlugin = createPlatePlugin({
   key: "formEmail",
   node: { isElement: true, component: FormFieldElement },
@@ -943,4 +957,5 @@ export const FormBlocksKit = [
   FormOptionItemPlugin,
   FormMultiSelectInputPlugin,
   PageBreakPlugin,
+  LogicBlockPlugin,
 ];

--- a/src/components/editor/transforms.ts
+++ b/src/components/editor/transforms.ts
@@ -9,6 +9,7 @@ import {
   insertVideoPlaceholder,
 } from "@platejs/media";
 import { insertToc } from "@platejs/toc";
+import { createLogicBlockNode } from "@/components/ui/logic-block-node";
 import { KEYS, PathApi } from "platejs";
 import type { NodeEntry, Path, TElement } from "platejs";
 import type { PlateEditor } from "platejs/react";
@@ -35,6 +36,14 @@ const insertList = (editor: PlateEditor, type: string) => {
 };
 
 const insertBlockMap: Record<string, (editor: PlateEditor, type: string) => void> = {
+  logicBlock: (editor) => {
+    const block = editor.api.block();
+    if (!block) return;
+    editor.tf.insertNodes(createLogicBlockNode() as unknown as TElement, {
+      at: PathApi.next(block[1]),
+      select: true,
+    });
+  },
   [KEYS.listTodo]: insertList,
   [KEYS.ol]: insertList,
   [KEYS.ul]: insertList,

--- a/src/components/form-components/form-preview-from-plate.tsx
+++ b/src/components/form-components/form-preview-from-plate.tsx
@@ -13,6 +13,8 @@ import {
   transformPlateForPreview,
 } from "@/lib/editor/transform-plate-for-preview";
 import type { PreviewSegment } from "@/lib/editor/transform-plate-for-preview";
+import { FormLogicProvider } from "@/contexts/form-logic-context";
+import { buildFormLogic } from "@/lib/logic/build-form-logic";
 import { extractQuestionsForStep } from "@/lib/forms/extract-questions";
 import type { QuestionRef } from "@/lib/forms/extract-questions";
 import { DEFAULT_ICON } from "@/lib/config/app-config";
@@ -396,6 +398,15 @@ export const FormPreviewFromPlate = ({
     [steps],
   );
 
+  const isFieldByFieldMode = settings?.presentationMode === "field-by-field";
+
+  // Conditional-logic runtime context. Card mode aligns step ids with the ruleset
+  // extractor; field-by-field uses synthetic ids (step-level jumps degrade to fall-through).
+  const formLogic = useMemo(
+    () => buildFormLogic(content, steps, isFieldByFieldMode),
+    [content, steps, isFieldByFieldMode],
+  );
+
   if (steps.length === 0 || steps.flat().length === 0) {
     return (
       <div className="flex min-h-[300px] flex-col items-center justify-center p-8 text-center">
@@ -431,22 +442,24 @@ export const FormPreviewFromPlate = ({
       initialCurrentStep={initialCurrentStep}
       tracking={tracking}
     >
-      <FormPreviewContent
-        shortId={shortId}
-        steps={steps}
-        stepQuestions={stepQuestions}
-        thankYouNodes={thankYouNodes}
-        title={title}
-        icon={icon}
-        iconColor={iconColor}
-        cover={cover}
-        hideTitle={hideTitle}
-        layout={layout}
-        settings={settings}
-        customization={customization}
-        isPopup={isPopup}
-        boundToParent={boundToParent}
-      />
+      <FormLogicProvider value={formLogic}>
+        <FormPreviewContent
+          shortId={shortId}
+          steps={steps}
+          stepQuestions={stepQuestions}
+          thankYouNodes={thankYouNodes}
+          title={title}
+          icon={icon}
+          iconColor={iconColor}
+          cover={cover}
+          hideTitle={hideTitle}
+          layout={layout}
+          settings={settings}
+          customization={customization}
+          isPopup={isPopup}
+          boundToParent={boundToParent}
+        />
+      </FormLogicProvider>
     </StepFormProvider>
   );
 };

--- a/src/components/form-components/form-preview-rsc.tsx
+++ b/src/components/form-components/form-preview-rsc.tsx
@@ -10,6 +10,8 @@ import { ChevronLeftIcon, ChevronRightIcon } from "@/components/ui/icons";
 import { ProgressBar } from "@/routes/forms/-components/progress-bar";
 import { StepFormProvider, useStepForm } from "@/contexts/step-form-context";
 import type { PublicFormTracking, TrackingBase } from "@/contexts/step-form-context";
+import { FormLogicProvider } from "@/contexts/form-logic-context";
+import type { FormLogicValue } from "@/lib/logic/build-form-logic";
 import { useTranslation } from "@/contexts/translation-context";
 import { useFocusFirstField } from "@/hooks/use-focus-first-field";
 import { useMountEffect } from "@/hooks/use-mount-effect";
@@ -55,6 +57,8 @@ interface FormPreviewRSCProps {
   initialCurrentStep?: number;
   /** Analytics base ({ visitId, visitorHash }). Public route only; undefined in builder previews disables tracking. */
   trackingBase?: TrackingBase;
+  /** Conditional-logic payload (plain JSON from the RSC server fn). null = no logic. */
+  logic?: FormLogicValue | null;
   /** Field-by-field meta. Required when presentationMode="field-by-field" — client renders icon+title+cover-as-bg instead of pre-rendered card header. iconColor = picker bg (from server-side formHeader node). */
   fieldByFieldMeta?: {
     title?: string;
@@ -205,17 +209,18 @@ const StepFormRSC = ({
   /** Field-by-field: server strips Button fields, so render an auto Submit/Next here w/ Enter/Esc shortcuts. */
   autoActionButton?: boolean;
 }) => {
-  const { currentStep, totalSteps, goToPrevStep, isSubmitting } = useStepForm();
+  const { totalSteps, goToPrevStep, canGoBack, isSubmitting } = useStepForm();
   const { t } = useTranslation();
   const fields = stepRSC.fields;
 
-  const { form, formName, handleFieldFocus } = useStepPreviewForm({
-    fields,
-    stepIndex,
-    isLastStep,
-    formName: `stepForm-${stepIndex}`,
-    questions,
-  });
+  const { form, formName, handleFieldFocus, visibleFieldNames, lockedFieldNames, hideSubmit } =
+    useStepPreviewForm({
+      fields,
+      stepIndex,
+      isLastStep,
+      formName: `stepForm-${stepIndex}`,
+      questions,
+    });
 
   const formRef = useRef<HTMLFormElement>(null);
   const [isTextareaFocused, setIsTextareaFocused] = useState(false);
@@ -227,7 +232,7 @@ const StepFormRSC = ({
     if (target && formRef.current && !formRef.current.contains(target)) return;
 
     if (event.key === "Escape") {
-      if (currentStep === 0) return;
+      if (!canGoBack) return;
       if (formRef.current?.querySelector('[aria-expanded="true"]')) return;
       event.preventDefault();
       event.stopPropagation();
@@ -295,6 +300,8 @@ const StepFormRSC = ({
           buttonRole?: "next" | "previous" | "submit";
         };
         const role = btn.buttonRole ?? "submit";
+        // Conditional "hide submit button" action suppresses the completion control.
+        if (hideSubmit && role === "submit") return null;
         const defaultText =
           role === "next" ? t("next") : role === "previous" ? t("previous") : t("submit");
         return (
@@ -304,18 +311,36 @@ const StepFormRSC = ({
             }
             buttonRole={role}
             isSubmitting={isSubmitting}
-            onPrevious={currentStep > 0 ? goToPrevStep : undefined}
+            onPrevious={canGoBack ? goToPrevStep : undefined}
             totalSteps={totalSteps}
           />
         );
       }
+      // Conditional logic: skip hidden fields; lock (non-interactive) auto-filled ones.
+      if (visibleFieldNames && !visibleFieldNames.has(field.name)) return null;
+      const locked = lockedFieldNames.has(field.name);
       return (
-        <div data-bf-question-id={field.id} className="w-full">
+        <div
+          data-bf-question-id={field.id}
+          className={`w-full${locked ? " opacity-75" : ""}`}
+          inert={locked || undefined}
+          aria-disabled={locked || undefined}
+        >
           <RenderFieldComponent key={fieldId} element={field} form={form} />
         </div>
       );
     },
-    [form, isSubmitting, currentStep, goToPrevStep, totalSteps, t],
+    [
+      form,
+      isSubmitting,
+      canGoBack,
+      goToPrevStep,
+      totalSteps,
+      t,
+      visibleFieldNames,
+      lockedFieldNames,
+      hideSubmit,
+    ],
   );
 
   const ButtonGroupSlot = useCallback(
@@ -335,12 +360,12 @@ const StepFormRSC = ({
           className="flex w-full flex-row-reverse items-center justify-between"
           style={{ maxWidth: "var(--bf-input-width)" }}
         >
-          {action && (
+          {action && !(hideSubmit && actionRole === "submit") && (
             <StepButton
               buttonText={actionText}
               buttonRole={actionRole}
               isSubmitting={isSubmitting}
-              onPrevious={currentStep > 0 ? goToPrevStep : undefined}
+              onPrevious={canGoBack ? goToPrevStep : undefined}
               grouped
               totalSteps={totalSteps}
             />
@@ -350,7 +375,7 @@ const StepFormRSC = ({
               buttonText={prev.buttonText || t("previous")}
               buttonRole="previous"
               isSubmitting={isSubmitting}
-              onPrevious={currentStep > 0 ? goToPrevStep : undefined}
+              onPrevious={canGoBack ? goToPrevStep : undefined}
               grouped
             />
           ) : (
@@ -359,7 +384,7 @@ const StepFormRSC = ({
         </div>
       );
     },
-    [t, isSubmitting, currentStep, goToPrevStep, totalSteps],
+    [t, isSubmitting, canGoBack, goToPrevStep, totalSteps, hideSubmit],
   );
 
   return (
@@ -380,14 +405,16 @@ const StepFormRSC = ({
             className="flex w-full items-center gap-3 pt-2"
             style={{ maxWidth: "var(--bf-input-width)" }}
           >
-            <Button
-              type="submit"
-              style={{ fontSize: "13px" }}
-              className="h-9 gap-1.5 rounded-lg px-4"
-              disabled={isSubmitting}
-            >
-              {isSubmitting ? t("submitting") : isLastStep ? t("submit") : t("next")}
-            </Button>
+            {!(hideSubmit && isLastStep) && (
+              <Button
+                type="submit"
+                style={{ fontSize: "13px" }}
+                className="h-9 gap-1.5 rounded-lg px-4"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? t("submitting") : isLastStep ? t("submit") : t("next")}
+              </Button>
+            )}
             <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
               press{" "}
               {isTextareaFocused && (
@@ -403,7 +430,7 @@ const StepFormRSC = ({
               </kbd>
               <span aria-hidden="true">↵</span>
             </span>
-            {currentStep > 0 && (
+            {canGoBack && (
               <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
                 <kbd className="rounded border border-border bg-muted/50 px-1.5 py-0.5 font-medium text-foreground">
                   Esc
@@ -801,6 +828,7 @@ export const FormPreviewRSC = ({
   initialCurrentStep,
   trackingBase,
   fieldByFieldMeta,
+  logic,
 }: FormPreviewRSCProps) => {
   if (steps.length === 0 || stepCount === 0) {
     return (
@@ -828,7 +856,7 @@ export const FormPreviewRSC = ({
         }
       : null;
 
-  return (
+  const content = (
     <StepFormProvider
       totalSteps={stepCount}
       onSubmit={onSubmit}
@@ -855,4 +883,8 @@ export const FormPreviewRSC = ({
       )}
     </StepFormProvider>
   );
+
+  // Provide the conditional-logic payload so the public form runs the same engine
+  // (visibility/jumps/set-value/hide-submit) the builder preview does.
+  return logic ? <FormLogicProvider value={logic}>{content}</FormLogicProvider> : content;
 };

--- a/src/components/form-components/step-form.tsx
+++ b/src/components/form-components/step-form.tsx
@@ -31,7 +31,7 @@ export const StepForm = ({
   isLastStep,
   autoActionButton = false,
 }: StepFormProps) => {
-  const { currentStep, totalSteps, goToPrevStep, isSubmitting, tracking } = useStepForm();
+  const { totalSteps, goToPrevStep, canGoBack, isSubmitting, tracking } = useStepForm();
   const { t } = useTranslation();
   const Renderer = use(PreviewRendererContext) ?? RenderStepPreviewInput;
   const fields = useMemo(() => getFieldsFromSegments(segments), [segments]);
@@ -42,13 +42,14 @@ export const StepForm = ({
   );
   const showAutoActionButton = autoActionButton && !hasAuthoredButton;
 
-  const { form, formName, handleFieldFocus } = useStepPreviewForm({
-    fields,
-    questions: stepQuestions,
-    stepIndex,
-    isLastStep,
-    formName: `stepForm-${stepIndex}`,
-  });
+  const { form, formName, handleFieldFocus, visibleFieldNames, lockedFieldNames, hideSubmit } =
+    useStepPreviewForm({
+      fields,
+      questions: stepQuestions,
+      stepIndex,
+      isLastStep,
+      formName: `stepForm-${stepIndex}`,
+    });
 
   const groupedItems = useMemo(() => groupSegmentsForRendering(segments), [segments]);
 
@@ -64,7 +65,7 @@ export const StepForm = ({
     if (target && formRef.current && !formRef.current.contains(target)) return;
 
     if (event.key === "Escape") {
-      if (currentStep === 0) return;
+      if (!canGoBack) return;
       // Defensive: bail if an in-form popover trigger is open — Esc shouldn't navigate away if focus stayed on trigger.
       if (formRef.current?.querySelector('[aria-expanded="true"]')) return;
       event.preventDefault();
@@ -159,7 +160,8 @@ export const StepForm = ({
                   <RenderStepButton
                     field={actionButton}
                     isSubmitting={isSubmitting}
-                    onPrevious={currentStep > 0 ? goToPrevStep : undefined}
+                    onPrevious={canGoBack ? goToPrevStep : undefined}
+                    hideSubmit={hideSubmit}
                     grouped
                   />
                 )}
@@ -167,7 +169,7 @@ export const StepForm = ({
                   <RenderStepButton
                     field={prevButton}
                     isSubmitting={isSubmitting}
-                    onPrevious={currentStep > 0 ? goToPrevStep : undefined}
+                    onPrevious={canGoBack ? goToPrevStep : undefined}
                     grouped
                   />
                 ) : (
@@ -189,20 +191,40 @@ export const StepForm = ({
           if (item.type === "field") {
             const { field } = item;
 
+            // Conditional logic: skip fields the engine has hidden (value retained in form state).
+            if (
+              field.fieldType !== "Button" &&
+              visibleFieldNames &&
+              !visibleFieldNames.has(field.name)
+            ) {
+              return null;
+            }
+
             if (field.fieldType === "Button") {
               return (
                 <RenderStepButton
                   key={field.id}
                   field={field}
                   isSubmitting={isSubmitting}
-                  onPrevious={currentStep > 0 ? goToPrevStep : undefined}
+                  onPrevious={canGoBack ? goToPrevStep : undefined}
+                  hideSubmit={hideSubmit}
                   totalSteps={totalSteps}
                 />
               );
             }
 
+            // Fields auto-filled by a "Set value" action are locked (non-interactive)
+            // while the controlling logic is active; the value still submits.
+            const locked = lockedFieldNames.has(field.name);
             return (
-              <div key={field.id} className="w-full" data-bf-input data-bf-question-id={field.id}>
+              <div
+                key={field.id}
+                className={`w-full${locked ? " opacity-75" : ""}`}
+                data-bf-input
+                data-bf-question-id={field.id}
+                inert={locked || undefined}
+                aria-disabled={locked || undefined}
+              >
                 <Renderer element={field} form={form} />
               </div>
             );
@@ -211,7 +233,7 @@ export const StepForm = ({
           return null;
         })}
 
-        {showAutoActionButton && (
+        {showAutoActionButton && !(hideSubmit && isLastStep) && (
           <div
             className="flex w-full items-center gap-3 pt-2"
             style={{ maxWidth: "var(--bf-input-width)" }}
@@ -242,7 +264,7 @@ export const StepForm = ({
               </kbd>
               <span aria-hidden="true">↵</span>
             </span>
-            {currentStep > 0 && (
+            {canGoBack && (
               <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
                 <kbd className="rounded border border-border bg-muted/50 px-1.5 py-0.5 font-medium text-foreground">
                   Esc
@@ -296,15 +318,20 @@ const RenderStepButton = ({
   onPrevious,
   grouped = false,
   totalSteps = 1,
+  hideSubmit = false,
 }: {
   field: ButtonField;
   isSubmitting: boolean;
   onPrevious?: () => void;
   grouped?: boolean;
   totalSteps?: number;
+  hideSubmit?: boolean;
 }) => {
   const { t } = useTranslation();
   const buttonRole = field.buttonRole || "submit";
+
+  // Conditional "hide submit button" action suppresses the completion control.
+  if (hideSubmit && buttonRole === "submit") return null;
   const defaultText =
     buttonRole === "next" ? t("next") : buttonRole === "previous" ? t("previous") : t("submit");
   const buttonText = field.buttonText || defaultText;

--- a/src/components/ui/block-menu.tsx
+++ b/src/components/ui/block-menu.tsx
@@ -4,7 +4,8 @@ import {
   BlockMenuPlugin,
   BlockSelectionPlugin,
 } from "@platejs/selection/react";
-import { KEYS } from "platejs";
+import { KEYS, PathApi } from "platejs";
+import type { TElement } from "platejs";
 import { useEditorPlugin, useEditorSelector, useHotkeys, usePluginOption } from "platejs/react";
 import * as React from "react";
 
@@ -38,6 +39,7 @@ import {
 import type { FileTypeCategory } from "@/lib/form-schema/file-upload-types";
 import { ALLOWED_LABEL_TYPES, FORM_INPUT_NODE_TYPES } from "@/lib/form-schema/form-field-constants";
 import { cn } from "@/lib/utils";
+import { createLogicBlockNode } from "@/components/ui/logic-block-node";
 
 type BlockFieldType =
   | "textLike" // formInput, formTextarea, formEmail, formLink
@@ -265,6 +267,16 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
     api.blockMenu.hide();
   }, [editor, api.blockMenu]);
 
+  const handleAddLogic = React.useCallback(() => {
+    if (!firstPath) return;
+    // Insert the logic block as the next sibling of the selected block.
+    editor.tf.insertNodes(createLogicBlockNode() as unknown as TElement, {
+      at: PathApi.next(firstPath),
+      select: false,
+    });
+    api.blockMenu.hide();
+  }, [editor, firstPath, api.blockMenu]);
+
   const handleTurnInto = React.useCallback(
     (type: string) => {
       editor
@@ -290,6 +302,7 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
     isEditingName,
     onDelete: handleDelete,
     onDuplicate: handleDuplicate,
+    onAddLogic: handleAddLogic,
   });
 
   // Close on scroll — virtual anchor is pinned to the click (x,y), so the menu would float in
@@ -467,6 +480,7 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
           <BlockMenuActions
             onDelete={handleDelete}
             onDuplicate={handleDuplicate}
+            onAddLogic={handleAddLogic}
             onHide={handleHideMenu}
             turnIntoOpen={turnIntoOpen}
             onTurnIntoPointerEnter={handleTurnIntoPointerEnter}
@@ -1060,6 +1074,7 @@ const ButtonFieldSettings = ({ buttonText, handlers }: FieldTypeSettingsProps) =
 interface BlockMenuActionsProps {
   onDelete: () => void;
   onDuplicate: () => void;
+  onAddLogic: () => void;
   onHide: () => void;
   turnIntoOpen: boolean;
   onTurnIntoPointerEnter: () => void;
@@ -1074,6 +1089,7 @@ interface BlockMenuActionsProps {
 const BlockMenuActions = ({
   onDelete,
   onDuplicate,
+  onAddLogic,
   onHide,
   turnIntoOpen,
   onTurnIntoPointerEnter,
@@ -1100,7 +1116,7 @@ const BlockMenuActions = ({
       <span className="flex-1 text-left">Hide</span>
       <DropdownMenuShortcut>⌘⌥H</DropdownMenuShortcut>
     </DropdownMenuItem>
-    <DropdownMenuItem className="text-foreground/80" onClick={onHide}>
+    <DropdownMenuItem className="text-foreground/80" onClick={onAddLogic}>
       <PlusIcon />
       <span className="flex-1 text-left">Add conditional logic</span>
       <DropdownMenuShortcut>⌘⌥L</DropdownMenuShortcut>
@@ -1137,6 +1153,7 @@ interface UseBlockMenuContextMenuAndHotkeysOptions {
   isEditingName: boolean;
   onDelete: () => void;
   onDuplicate: () => void;
+  onAddLogic: () => void;
 }
 
 const useBlockMenuContextMenuAndHotkeys = ({
@@ -1146,6 +1163,7 @@ const useBlockMenuContextMenuAndHotkeys = ({
   isEditingName,
   onDelete,
   onDuplicate,
+  onAddLogic,
 }: UseBlockMenuContextMenuAndHotkeysOptions) => {
   React.useEffect(() => {
     const node = triggerRef.current;
@@ -1185,12 +1203,11 @@ const useBlockMenuContextMenuAndHotkeys = ({
     [isOpen, isEditingName, api.blockMenu],
   );
 
-  useHotkeys(
-    "mod+alt+l",
-    () => api.blockMenu.hide(),
-    { enabled: isOpen && !isEditingName, preventDefault: true },
-    [isOpen, isEditingName, api.blockMenu],
-  );
+  useHotkeys("mod+alt+l", onAddLogic, { enabled: isOpen && !isEditingName, preventDefault: true }, [
+    isOpen,
+    isEditingName,
+    onAddLogic,
+  ]);
 };
 
 interface BlockMenuFirstNode {

--- a/src/components/ui/logic-block-node.tsx
+++ b/src/components/ui/logic-block-node.tsx
@@ -1,0 +1,605 @@
+import { GitBranch, Zap } from "lucide-react";
+import * as React from "react";
+import type { PlateElementProps } from "platejs/react";
+import {
+  PlateElement,
+  useEditorRef,
+  useEditorVersion,
+  useFocused,
+  useSelected,
+} from "platejs/react";
+
+import { MinusIcon, PlusIcon } from "@/components/ui/icons";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { transformPlateForPreview } from "@/lib/editor/transform-plate-for-preview";
+import { operatorNeedsOperand, operatorsForFieldType, OPERATOR_LABELS } from "@/lib/logic/labels";
+import { THANK_YOU_STEP } from "@/lib/logic/types";
+import type {
+  Action,
+  Condition,
+  ConditionGroup,
+  LogicBlockNode,
+  OperatorId,
+} from "@/lib/logic/types";
+import { cn } from "@/lib/utils";
+
+export const createLogicBlockNode = (): LogicBlockNode => ({
+  type: "logicBlock",
+  id: crypto.randomUUID(),
+  when: { combinator: "all", children: [] },
+  actions: [],
+  elseActions: [],
+  children: [{ text: "" }],
+});
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface FieldInfo {
+  name: string;
+  label: string;
+  fieldType: string;
+  isFieldArray: boolean;
+  /** Defined choices, for choice-type fields (Checkbox/Radio/MultiSelect/Ranking). */
+  options?: Option[];
+}
+
+const FIRST_STEP_ID = "step-0";
+
+const collectFields = (editor: ReturnType<typeof useEditorRef>): FieldInfo[] => {
+  const out: FieldInfo[] = [];
+  const { steps } = transformPlateForPreview(editor.children);
+  for (const segments of steps) {
+    for (const seg of segments) {
+      if (seg.type !== "field" || seg.field.fieldType === "Button") continue;
+      out.push({
+        name: seg.field.name,
+        label: seg.field.label ?? seg.field.name,
+        fieldType: seg.field.fieldType,
+        isFieldArray: (seg.field as { isFieldArray?: boolean }).isFieldArray === true,
+        options: (seg.field as { options?: Option[] }).options,
+      });
+    }
+  }
+  return out;
+};
+
+const collectStepOptions = (editor: ReturnType<typeof useEditorRef>): Option[] => {
+  const options: Option[] = [{ value: FIRST_STEP_ID, label: "Step 1" }];
+  let stepNumber = 2;
+  for (const node of editor.children as Array<Record<string, unknown>>) {
+    if (node.type !== "pageBreak") continue;
+    if (node.isThankYouPage === true) continue;
+    const value = typeof node.id === "string" ? node.id : `${FIRST_STEP_ID}-${stepNumber}`;
+    options.push({ value, label: `Step ${stepNumber}` });
+    stepNumber++;
+  }
+  options.push({ value: THANK_YOU_STEP, label: "Thank You page" });
+  return options;
+};
+
+// ── Token primitives (Figma: white pill, elevation-sm, 8px radius, 32px tall) ──
+
+/** Pill-shaped dropdown built on the shared Select component, sized to its content. */
+const TokenSelect = ({
+  value,
+  onChange,
+  ariaLabel,
+  options,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel: string;
+  options: Option[];
+}) => (
+  <Select value={value} onValueChange={(next) => onChange(String(next))}>
+    <SelectTrigger
+      aria-label={ariaLabel}
+      className="gap-1 rounded-lg border-0 bg-[var(--form-input-bg,var(--color-gray-50))] ps-2.5 pe-2 text-foreground elevation-sm"
+    >
+      <SelectValue className="font-normal">
+        {(selected: string) => options.find((o) => o.value === selected)?.label ?? ""}
+      </SelectValue>
+    </SelectTrigger>
+    <SelectContent>
+      {options.map((o) => (
+        <SelectItem key={o.value} value={o.value}>
+          {o.label}
+        </SelectItem>
+      ))}
+    </SelectContent>
+  </Select>
+);
+
+const TokenInput = ({
+  value,
+  onChange,
+  ariaLabel,
+  placeholder,
+  widthClass = "w-28",
+  type = "text",
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel: string;
+  placeholder?: string;
+  widthClass?: string;
+  type?: "text" | "date" | "time";
+}) => (
+  <input
+    aria-label={ariaLabel}
+    type={type}
+    value={value}
+    placeholder={placeholder}
+    onChange={(e) => onChange(e.target.value)}
+    className={cn(
+      "h-8 rounded-lg border-0 bg-[var(--form-input-bg,var(--color-gray-50))] pr-2 pl-2.5 text-[13px] text-foreground elevation-sm outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring",
+      widthClass,
+    )}
+  />
+);
+
+/** Allow only a (partial) number: optional leading minus, digits, one decimal point. */
+const NUMERIC_PATTERN = /^-?\d*\.?\d*$/;
+
+/** Numeric operand as a − value + stepper (Figma "− 5 +"). Typeable but digits-only,
+ * since it only renders for Number-typed fields. */
+const TokenStepper = ({
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel: string;
+}) => {
+  const parsed = Number(value);
+  const current = Number.isFinite(parsed) ? parsed : 0;
+  return (
+    <span className="flex h-8 items-center gap-1.5 rounded-lg bg-[var(--form-input-bg,var(--color-gray-50))] px-1.5 elevation-sm">
+      <button
+        type="button"
+        aria-label={`Decrease ${ariaLabel}`}
+        onClick={() => onChange(String(current - 1))}
+        className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-secondary hover:text-foreground"
+      >
+        <MinusIcon className="size-3.5" />
+      </button>
+      <input
+        aria-label={ariaLabel}
+        type="text"
+        inputMode="numeric"
+        value={value}
+        placeholder="0"
+        onChange={(e) => {
+          // Reject non-numeric input — this control is tied to a Number field.
+          if (NUMERIC_PATTERN.test(e.target.value)) onChange(e.target.value);
+        }}
+        className="w-12 bg-transparent text-center text-[13px] text-foreground tabular-nums outline-none placeholder:text-muted-foreground"
+      />
+      <button
+        type="button"
+        aria-label={`Increase ${ariaLabel}`}
+        onClick={() => onChange(String(current + 1))}
+        className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-secondary hover:text-foreground"
+      >
+        <PlusIcon className="size-3.5" />
+      </button>
+    </span>
+  );
+};
+
+/** Scalar field types — the only ones a "Set value" action can sensibly target. */
+const SCALAR_FIELD_TYPES = new Set([
+  "Input",
+  "Textarea",
+  "Email",
+  "Phone",
+  "Number",
+  "Link",
+  "Date",
+  "Time",
+]);
+
+/** Operand/value control matched to the field type: stepper for numbers, native
+ * date/time pickers for Date/Time, plain text otherwise. */
+const ValueControl = ({
+  fieldType,
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  fieldType: string | undefined;
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel: string;
+}) => {
+  if (fieldType === "Number")
+    return <TokenStepper value={value} onChange={onChange} ariaLabel={ariaLabel} />;
+  if (fieldType === "Date")
+    return (
+      <TokenInput
+        type="date"
+        widthClass="w-36"
+        value={value}
+        onChange={onChange}
+        ariaLabel={ariaLabel}
+      />
+    );
+  if (fieldType === "Time")
+    return (
+      <TokenInput
+        type="time"
+        widthClass="w-28"
+        value={value}
+        onChange={onChange}
+        ariaLabel={ariaLabel}
+      />
+    );
+  return <TokenInput placeholder="value" value={value} onChange={onChange} ariaLabel={ariaLabel} />;
+};
+
+const AddToken = ({ onClick, label }: { onClick: () => void; label: string }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="flex h-8 w-fit items-center gap-1 rounded-lg border border-dashed border-border px-2.5 text-[13px] text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
+  >
+    <PlusIcon className="size-3.5" />
+    {label}
+  </button>
+);
+
+const RemoveToken = ({ onClick, label }: { onClick: () => void; label: string }) => (
+  <button
+    type="button"
+    aria-label={label}
+    onClick={onClick}
+    className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-secondary hover:text-foreground"
+  >
+    <span className="text-base leading-none">×</span>
+  </button>
+);
+
+/** One labelled section ("If" / "Do" / "Else Do"): leading icon+label column,
+ * then a vertical stack of token rows. */
+const RowShell = ({
+  icon,
+  label,
+  children,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex gap-2 px-2 py-1.5">
+    <div className="flex h-8 shrink-0 items-center gap-2">
+      {icon}
+      <span className="text-[13px] text-muted-foreground">{label}</span>
+    </div>
+    <div className="flex flex-1 flex-col items-start gap-1.5">{children}</div>
+  </div>
+);
+
+const isCondition = (node: Condition | ConditionGroup): node is Condition =>
+  !("combinator" in node);
+
+const ACTION_KIND_OPTIONS: Option[] = [
+  { value: "show", label: "Show field" },
+  { value: "hide", label: "Hide field" },
+  { value: "require", label: "Require field" },
+  { value: "setValue", label: "Set value" },
+  { value: "jump", label: "Jump to step" },
+  { value: "hideSubmit", label: "Hide submit" },
+  { value: "redirect", label: "Redirect to URL" },
+];
+
+const COMBINATOR_OPTIONS: Option[] = [
+  { value: "all", label: "all of" },
+  { value: "any", label: "any of" },
+];
+
+const defaultActionForKind = (
+  kind: Action["kind"],
+  fields: FieldInfo[],
+  stepOptions: Option[],
+): Action => {
+  if (kind === "hideSubmit") return { kind };
+  if (kind === "jump") return { kind, toStep: stepOptions[0]?.value ?? THANK_YOU_STEP };
+  if (kind === "redirect") return { kind, url: "" };
+  if (kind === "setValue") {
+    const scalar = fields.find((f) => SCALAR_FIELD_TYPES.has(f.fieldType) && !f.isFieldArray);
+    return { kind, target: scalar?.name ?? "", value: "" };
+  }
+  return { kind, target: fields[0]?.name ?? "" };
+};
+
+/** One condition: field · operator · value (stepper for numbers). */
+const ConditionRow = ({
+  condition,
+  sourceOptions,
+  fieldTypeByName,
+  fieldChoicesByName,
+  onChange,
+  onRemove,
+}: {
+  condition: Condition;
+  sourceOptions: Option[];
+  fieldTypeByName: Map<string, string>;
+  fieldChoicesByName: Map<string, Option[]>;
+  onChange: (next: Condition) => void;
+  onRemove: () => void;
+}) => {
+  const operatorOptions = operatorsForFieldType(fieldTypeByName.get(condition.source)).map(
+    (op) => ({
+      value: op,
+      label: OPERATOR_LABELS[op],
+    }),
+  );
+  const choices = fieldChoicesByName.get(condition.source);
+  return (
+    <div className="flex w-full flex-wrap items-center gap-1.5">
+      <TokenSelect
+        ariaLabel="Field"
+        value={condition.source}
+        options={sourceOptions}
+        onChange={(source) => {
+          const valid = operatorsForFieldType(fieldTypeByName.get(source));
+          const operator = valid.includes(condition.operator) ? condition.operator : valid[0];
+          // Reset the operand when the field type changes; seed the first choice for choice fields.
+          const nextChoices = fieldChoicesByName.get(source);
+          const value = nextChoices?.[0]?.value ?? "";
+          onChange({ ...condition, source, operator, value });
+        }}
+      />
+      <TokenSelect
+        ariaLabel="Operator"
+        value={condition.operator}
+        options={operatorOptions}
+        onChange={(op) => onChange({ ...condition, operator: op as OperatorId })}
+      />
+      {operatorNeedsOperand(condition.operator) &&
+        (choices && choices.length > 0 ? (
+          <TokenSelect
+            ariaLabel="Value"
+            value={condition.value ?? ""}
+            options={choices}
+            onChange={(value) => onChange({ ...condition, value })}
+          />
+        ) : (
+          <ValueControl
+            ariaLabel="Value"
+            fieldType={fieldTypeByName.get(condition.source)}
+            value={condition.value ?? ""}
+            onChange={(value) => onChange({ ...condition, value })}
+          />
+        ))}
+      <RemoveToken onClick={onRemove} label="Remove condition" />
+    </div>
+  );
+};
+
+/** One action: kind · target/step/url. */
+const ActionRow = ({
+  action,
+  fields,
+  fieldOptions,
+  setTargetOptions,
+  fieldTypeByName,
+  stepOptions,
+  onChange,
+  onRemove,
+}: {
+  action: Action;
+  fields: FieldInfo[];
+  fieldOptions: Option[];
+  /** Scalar-only targets for "Set value" (multi/file/repeatable can't be set). */
+  setTargetOptions: Option[];
+  fieldTypeByName: Map<string, string>;
+  stepOptions: Option[];
+  onChange: (next: Action) => void;
+  onRemove: () => void;
+}) => (
+  <div className="flex w-full flex-wrap items-center gap-1.5">
+    <TokenSelect
+      ariaLabel="Action"
+      value={action.kind}
+      options={ACTION_KIND_OPTIONS}
+      onChange={(kind) =>
+        onChange(defaultActionForKind(kind as Action["kind"], fields, stepOptions))
+      }
+    />
+    {(action.kind === "show" || action.kind === "hide" || action.kind === "require") && (
+      <TokenSelect
+        ariaLabel="Target field"
+        value={action.target}
+        options={fieldOptions}
+        onChange={(target) => onChange({ ...action, target })}
+      />
+    )}
+    {action.kind === "setValue" && (
+      <>
+        <TokenSelect
+          ariaLabel="Target field"
+          value={action.target}
+          options={setTargetOptions}
+          onChange={(target) => onChange({ ...action, target })}
+        />
+        <ValueControl
+          ariaLabel="Set value"
+          fieldType={fieldTypeByName.get(action.target)}
+          value={action.value}
+          onChange={(value) => onChange({ ...action, value })}
+        />
+      </>
+    )}
+    {action.kind === "jump" && (
+      <TokenSelect
+        ariaLabel="Target step"
+        value={action.toStep}
+        options={stepOptions}
+        onChange={(toStep) => onChange({ ...action, toStep })}
+      />
+    )}
+    {action.kind === "redirect" && (
+      <TokenInput
+        ariaLabel="Redirect URL"
+        placeholder="https://…"
+        widthClass="w-48"
+        value={action.url}
+        onChange={(url) => onChange({ ...action, url })}
+      />
+    )}
+    <RemoveToken onClick={onRemove} label="Remove action" />
+  </div>
+);
+
+export const LogicBlockElement = (props: PlateElementProps) => {
+  const { element, children } = props;
+  const editor = useEditorRef();
+  const selected = useSelected();
+  const focused = useFocused();
+
+  // Re-render on editor edits so renamed fields / new steps update pickers.
+  useEditorVersion();
+
+  const when = (element.when as ConditionGroup | undefined) ?? { combinator: "all", children: [] };
+  const actions = (element.actions as Action[] | undefined) ?? [];
+  const elseActions = (element.elseActions as Action[] | undefined) ?? [];
+  const conditions = when.children;
+
+  const fields = collectFields(editor);
+  const sources = fields.filter((f) => !f.isFieldArray); // Wave 1: repeatable can't be a source
+  const sourceOptions = sources.map((f) => ({ value: f.name, label: f.label }));
+  const fieldOptions = fields.map((f) => ({ value: f.name, label: f.label }));
+  const setTargetOptions = fields
+    .filter((f) => SCALAR_FIELD_TYPES.has(f.fieldType) && !f.isFieldArray)
+    .map((f) => ({ value: f.name, label: f.label }));
+  const stepOptions = collectStepOptions(editor);
+  const fieldTypeByName = new Map(fields.map((f) => [f.name, f.fieldType]));
+  const fieldChoicesByName = new Map(fields.map((f) => [f.name, f.options ?? []]));
+
+  const patch = React.useCallback(
+    (updates: Partial<Pick<LogicBlockNode, "when" | "actions" | "elseActions">>) => {
+      const path = editor.api.findPath(element);
+      if (path) editor.tf.setNodes(updates, { at: path });
+    },
+    [editor, element],
+  );
+
+  // Conditions
+  const updateCondition = (index: number, next: Condition) =>
+    patch({ when: { ...when, children: conditions.map((c, i) => (i === index ? next : c)) } });
+  const removeCondition = (index: number) =>
+    patch({ when: { ...when, children: conditions.filter((_, i) => i !== index) } });
+  const addCondition = () => {
+    const source = sources[0]?.name ?? "";
+    const operator = operatorsForFieldType(fieldTypeByName.get(source))[0];
+    patch({ when: { ...when, children: [...conditions, { source, operator, value: "" }] } });
+  };
+  const setCombinator = (combinator: string) =>
+    patch({ when: { ...when, combinator: combinator === "any" ? "any" : "all" } });
+
+  // Actions (Do) + else actions (Else Do) share helpers via a setter.
+  const makeActionHandlers = (
+    list: Action[],
+    key: "actions" | "elseActions",
+  ): {
+    update: (index: number, next: Action) => void;
+    remove: (index: number) => void;
+    add: () => void;
+  } => ({
+    update: (index, next) => patch({ [key]: list.map((a, i) => (i === index ? next : a)) }),
+    remove: (index) => patch({ [key]: list.filter((_, i) => i !== index) }),
+    add: () => patch({ [key]: [...list, { kind: "show", target: fields[0]?.name ?? "" }] }),
+  });
+  const doHandlers = makeActionHandlers(actions, "actions");
+  const elseHandlers = makeActionHandlers(elseActions, "elseActions");
+
+  const renderActionRows = (list: Action[], handlers: ReturnType<typeof makeActionHandlers>) => (
+    <>
+      {list.map((action, i) => (
+        <ActionRow
+          // eslint-disable-next-line @eslint-react/no-array-index-key
+          key={i}
+          action={action}
+          fields={fields}
+          fieldOptions={fieldOptions}
+          setTargetOptions={setTargetOptions}
+          fieldTypeByName={fieldTypeByName}
+          stepOptions={stepOptions}
+          onChange={(next) => handlers.update(i, next)}
+          onRemove={() => handlers.remove(i)}
+        />
+      ))}
+      <AddToken onClick={handlers.add} label="Add action" />
+    </>
+  );
+
+  return (
+    <PlateElement {...props} className="clear-both my-3">
+      <div
+        contentEditable={false}
+        role="presentation"
+        className={cn(
+          "flex flex-col gap-0.5 rounded-xl bg-muted/50 p-1.5",
+          selected && focused && "ring-2 ring-ring ring-offset-2",
+        )}
+      >
+        {/* IF — conditions */}
+        <RowShell icon={<GitBranch className="size-4 text-[#7757ee]" />} label="If">
+          {sources.length === 0 ? (
+            <span className="flex h-8 items-center text-[13px] text-muted-foreground">
+              Add a field to the form first.
+            </span>
+          ) : (
+            <>
+              {conditions.length > 1 && (
+                <TokenSelect
+                  value={when.combinator}
+                  onChange={setCombinator}
+                  ariaLabel="Match"
+                  options={COMBINATOR_OPTIONS}
+                />
+              )}
+              {conditions.map((node, i) =>
+                isCondition(node) ? (
+                  <ConditionRow
+                    // eslint-disable-next-line @eslint-react/no-array-index-key
+                    key={i}
+                    condition={node}
+                    sourceOptions={sourceOptions}
+                    fieldTypeByName={fieldTypeByName}
+                    fieldChoicesByName={fieldChoicesByName}
+                    onChange={(next) => updateCondition(i, next)}
+                    onRemove={() => removeCondition(i)}
+                  />
+                ) : null,
+              )}
+              <AddToken onClick={addCondition} label="Add condition" />
+            </>
+          )}
+        </RowShell>
+
+        {/* DO — actions when conditions pass */}
+        <RowShell icon={<Zap className="size-4 text-[#278f5e]" />} label="Do">
+          {renderActionRows(actions, doHandlers)}
+        </RowShell>
+
+        {/* ELSE DO — actions when conditions fail */}
+        <RowShell icon={<Zap className="size-4 text-muted-foreground" />} label="Else Do">
+          {renderActionRows(elseActions, elseHandlers)}
+        </RowShell>
+      </div>
+      {children}
+    </PlateElement>
+  );
+};

--- a/src/components/ui/slash-node.tsx
+++ b/src/components/ui/slash-node.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/icons";
 import {
   BadgeIcon,
+  GitBranch,
   Heading1Icon,
   Heading2Icon,
   Heading3Icon,
@@ -274,6 +275,33 @@ const groups: Group[] = [
         keywords: ["form", "multi", "select", "dropdown", "tag", "option"],
         label: "Multi Select",
         value: "formMultiSelect",
+      },
+    ].map((item) => ({
+      ...item,
+      onSelect: (editor, value) => {
+        insertBlock(editor, value, { upsert: true });
+      },
+    })),
+  },
+  {
+    group: "Logic",
+    items: [
+      {
+        description: "Show, hide, require, or branch based on answers",
+        icon: <GitBranch />,
+        keywords: [
+          "logic",
+          "conditional",
+          "condition",
+          "if",
+          "rule",
+          "branch",
+          "show",
+          "hide",
+          "jump",
+        ],
+        label: "Conditional logic",
+        value: "logicBlock",
       },
     ].map((item) => ({
       ...item,

--- a/src/contexts/form-logic-context.tsx
+++ b/src/contexts/form-logic-context.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+import type { FormLogicValue } from "@/lib/logic/build-form-logic";
+
+export type { FormLogicValue };
+
+const FormLogicContext = React.createContext<FormLogicValue | null>(null);
+
+export const FormLogicProvider = FormLogicContext.Provider;
+
+/** Null when no logic context is mounted (e.g. RSC preview) — callers treat as "no logic". */
+export const useFormLogic = (): FormLogicValue | null => React.use(FormLogicContext);

--- a/src/contexts/step-form-context.test.ts
+++ b/src/contexts/step-form-context.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { stepFormReducer } from "./step-form-context";
+
+const base = {
+  history: [0],
+  direction: 0,
+  formData: {},
+  isSubmitting: false,
+  isSubmitted: false,
+};
+
+describe("stepFormReducer history stack", () => {
+  it("push-step appends the resolved target index and merges formData", () => {
+    const next = stepFormReducer(base, { type: "push-step", target: 2, formData: { a: 1 } });
+    expect(next.history).toEqual([0, 2]);
+    expect(next.direction).toBe(1);
+    expect(next.formData).toEqual({ a: 1 });
+  });
+
+  it("prev-step pops to the previously visited step (origin, not current-1)", () => {
+    const state = { ...base, history: [0, 2, 3] };
+    const next = stepFormReducer(state, { type: "prev-step" });
+    expect(next.history).toEqual([0, 2]);
+    expect(next.direction).toBe(-1);
+  });
+
+  it("prev-step at the first step is a no-op", () => {
+    expect(stepFormReducer(base, { type: "prev-step" })).toBe(base);
+  });
+
+  it("reset returns to a single-entry history", () => {
+    const state = { ...base, history: [0, 1, 2], isSubmitted: true };
+    expect(stepFormReducer(state, { type: "reset" }).history).toEqual([0]);
+  });
+});

--- a/src/contexts/step-form-context.tsx
+++ b/src/contexts/step-form-context.tsx
@@ -23,8 +23,13 @@ type StepFormContextValue = {
   formData: Record<string, unknown>;
   isSubmitting: boolean;
   isSubmitted: boolean;
+  /** Commit step data and advance to the next sequential step (no logic). */
   goToNextStep: (stepData: Record<string, unknown>) => void;
+  /** Commit step data and jump to an explicit target step index (logic-resolved). */
+  goToStep: (stepData: Record<string, unknown>, target: number) => void;
   goToPrevStep: () => void;
+  /** False at the first visited step — drives Back affordances. */
+  canGoBack: boolean;
   direction: number;
   submitForm: (finalStepData: Record<string, unknown>) => Promise<void>;
   reset: () => void;
@@ -35,7 +40,9 @@ type StepFormContextValue = {
 };
 
 type StepFormState = {
-  currentStep: number;
+  /** Visited-step stack. `currentStep` is the last entry. Back pops it, so the
+   * respondent returns to the step they actually came from after a jump. */
+  history: number[];
   direction: number;
   formData: Record<string, unknown>;
   isSubmitting: boolean;
@@ -43,28 +50,27 @@ type StepFormState = {
 };
 
 type StepFormAction =
-  | { type: "next-step"; formData: Record<string, unknown>; totalSteps: number }
+  | { type: "push-step"; formData: Record<string, unknown>; target: number }
   | { type: "prev-step" }
   | { type: "submit-start" }
   | { type: "submit-success" }
   | { type: "submit-end" }
   | { type: "reset" };
 
-const stepFormReducer = (state: StepFormState, action: StepFormAction): StepFormState => {
+export const stepFormReducer = (state: StepFormState, action: StepFormAction): StepFormState => {
   switch (action.type) {
-    case "next-step":
+    case "push-step":
       return {
         ...state,
         formData: action.formData,
         direction: 1,
-        currentStep: Math.min(state.currentStep + 1, action.totalSteps - 1),
+        history: [...state.history, action.target],
       };
     case "prev-step":
-      return {
-        ...state,
-        direction: -1,
-        currentStep: Math.max(state.currentStep - 1, 0),
-      };
+      // Pop to the previously visited step; no-op at the first step.
+      return state.history.length > 1
+        ? { ...state, direction: -1, history: state.history.slice(0, -1) }
+        : state;
     case "submit-start":
       return { ...state, isSubmitting: true };
     case "submit-success":
@@ -73,7 +79,7 @@ const stepFormReducer = (state: StepFormState, action: StepFormAction): StepForm
       return { ...state, isSubmitting: false };
     case "reset":
       return {
-        currentStep: 0,
+        history: [0],
         direction: 0,
         formData: {},
         isSubmitting: false,
@@ -125,24 +131,35 @@ export const StepFormProvider = ({
   );
 
   const [state, dispatch] = React.useReducer(stepFormReducer, undefined, () => ({
-    currentStep: initialCurrentStep ?? 0,
+    // Resuming a draft at step N: seed a linear 0..N history so Back still works
+    // (the real visited path isn't persisted; linear is the sensible default).
+    history: Array.from({ length: (initialCurrentStep ?? 0) + 1 }, (_, i) => i),
     direction: 0,
     formData: initialFormData ?? (saveAnswersForLater ? (loadSavedData() ?? {}) : {}),
     isSubmitting: false,
     isSubmitted: false,
   }));
-  const { currentStep, direction, formData, isSubmitting, isSubmitted } = state;
+  const { history, direction, formData, isSubmitting, isSubmitted } = state;
+  const currentStep = history[history.length - 1];
+  const canGoBack = history.length > 1;
 
   const formDataRef = useAsRef(formData);
 
-  const goToNextStep = React.useCallback(
-    (stepData: Record<string, unknown>) => {
+  const goToStep = React.useCallback(
+    (stepData: Record<string, unknown>, target: number) => {
       const next = { ...formDataRef.current, ...stepData };
       if (Object.keys(next).length > 0) saveData(next);
-      dispatch({ type: "next-step", formData: next, totalSteps });
+      dispatch({ type: "push-step", formData: next, target: Math.max(0, target) });
     },
     // eslint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps -- formDataRef is a stable ref
-    [totalSteps, saveData],
+    [saveData],
+  );
+
+  const goToNextStep = React.useCallback(
+    (stepData: Record<string, unknown>) => {
+      goToStep(stepData, Math.min(currentStep + 1, totalSteps - 1));
+    },
+    [goToStep, currentStep, totalSteps],
   );
 
   const goToPrevStep = React.useCallback(() => {
@@ -179,7 +196,9 @@ export const StepFormProvider = ({
       isSubmitting,
       isSubmitted,
       goToNextStep,
+      goToStep,
       goToPrevStep,
+      canGoBack,
       direction,
       submitForm,
       reset,
@@ -193,7 +212,9 @@ export const StepFormProvider = ({
       isSubmitting,
       isSubmitted,
       goToNextStep,
+      goToStep,
       goToPrevStep,
+      canGoBack,
       direction,
       submitForm,
       reset,

--- a/src/hooks/use-preview-form.ts
+++ b/src/hooks/use-preview-form.ts
@@ -1,6 +1,10 @@
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useStore } from "@tanstack/react-form";
 import { revalidateLogic, useAppForm } from "@/components/ui/tanstack-form";
 import { useStepForm } from "@/contexts/step-form-context";
+import { useFormLogic } from "@/contexts/form-logic-context";
+import { evaluate } from "@/lib/logic/engine";
+import { THANK_YOU_STEP } from "@/lib/logic/types";
 import {
   enqueueQuestionProgress,
   fireUpdateVisit,
@@ -19,6 +23,21 @@ import type { AppForm } from "./use-form-builder";
 
 /** Visits that already fired `didStartForm: true`. Module-scope survives re-renders/step changes; resets on reload (new visitId, no double-fire). */
 const didStartFiredVisits = new Set<string>();
+
+/** First step after `fromIndex` that has at least one visible field (or is static-only).
+ * Returns -1 when none remain → the form should finish. */
+const nextVisibleStepIndex = (
+  stepFieldNames: string[][],
+  visibility: Record<string, boolean>,
+  fromIndex: number,
+): number => {
+  for (let i = fromIndex + 1; i < stepFieldNames.length; i++) {
+    const names = stepFieldNames[i];
+    if (names.length === 0) return i; // static-only step stays in the flow
+    if (names.some((name) => visibility[name] !== false)) return i;
+  }
+  return -1;
+};
 
 interface UseStepPreviewFormOptions {
   fields: PlateFormField[];
@@ -41,14 +60,56 @@ export const useStepPreviewForm = ({
   formName: string;
   /** Form-level onFocus → per-Question `start` emitter, deduped per (visitId, questionId). */
   handleFieldFocus: (event: React.FocusEvent<HTMLFormElement>) => void;
+  /** Field names currently visible per conditional logic — step-form hides the rest.
+   * `null` when no logic context is mounted (render everything). */
+  visibleFieldNames: Set<string> | null;
+  /** Field names auto-filled by an active "Set value" action — rendered read-only. */
+  lockedFieldNames: Set<string>;
+  /** True when a passing hide-submit action should suppress the completion button. */
+  hideSubmit: boolean;
 } => {
-  const { formData, goToNextStep, submitForm, formId, tracking } = useStepForm();
+  const { formData, goToNextStep, goToStep, submitForm, currentStep, formId, tracking } =
+    useStepForm();
   const { saveDraft } = useDraftAutoSave(formId);
+  const logic = useFormLogic();
+
+  // Mirror of the live form values, used to recompute visibility/required reactively.
+  const [liveValues, setLiveValues] = useState<Record<string, unknown>>(() => ({}));
+  const mergedAnswers = useMemo<Record<string, unknown>>(
+    () => ({ ...formData, ...liveValues }),
+    [formData, liveValues],
+  );
+  const evaluation = useMemo(
+    () => (logic ? evaluate(logic.ruleset, mergedAnswers, logic.allFields) : null),
+    [logic, mergedAnswers],
+  );
+  const visibleFieldNames = useMemo<Set<string> | null>(() => {
+    if (!evaluation) return null;
+    return new Set(
+      fields.filter((f) => evaluation.visibility[f.name] !== false).map((f) => f.name),
+    );
+  }, [evaluation, fields]);
+  const lockedFieldNames = useMemo<Set<string>>(
+    () => new Set(evaluation ? Object.keys(evaluation.setValues) : []),
+    [evaluation],
+  );
 
   // `start` dedup latch keyed `visitId::questionId`, per Step mount. Cross-step idempotency via server upsert (coalesce on startedAt); StepForm remounts on back-nav, resetting this.
   const startFiredRef = useRef<Set<string>>(new Set());
 
-  const validationSchema = useMemo(() => generateZodSchemaFromFields(fields), [fields]);
+  // Validate only currently-visible fields, with logic-driven effective-required applied.
+  // Hidden fields are excluded so they never block submit; a passing require-action adds requiredness.
+  const effectiveFields = useMemo(() => {
+    if (!evaluation) return fields;
+    return fields
+      .filter((f) => evaluation.visibility[f.name] !== false)
+      .map((f) => ({ ...f, required: evaluation.effectiveRequired[f.name] === true }));
+  }, [fields, evaluation]);
+
+  const validationSchema = useMemo(
+    () => generateZodSchemaFromFields(effectiveFields),
+    [effectiveFields],
+  );
 
   // Question id → ref, keyed by Plate Block id (= data-bf-question-id), so focus on any descendant resolves even for fields without `name` (Phone, MultiSelect, etc.).
   const questionsById = useMemo<Map<string, QuestionRef>>(() => {
@@ -174,11 +235,34 @@ export const useStepPreviewForm = ({
         flushQuestionProgressBuffer();
       }
 
-      if (isLastStep) {
-        await submitForm(value);
-      } else {
-        goToNextStep(value);
+      // Resolve navigation against the *final* answers (avoids the one-render lag of the
+      // memoized evaluation). No logic context → fall back to sequential next/submit.
+      if (!logic) {
+        if (isLastStep) await submitForm(value);
+        else goToNextStep(value);
+        return;
       }
+
+      const finalAnswers = { ...formData, ...value };
+      const submitEval = evaluate(logic.ruleset, finalAnswers, logic.allFields);
+      const finish = async () => {
+        if (submitEval.hideSubmit) return; // completion blocked while the condition holds
+        await submitForm(value);
+        if (submitEval.redirectUrl) globalThis.location.href = submitEval.redirectUrl;
+      };
+
+      const currentStepId = logic.stepIds[currentStep];
+      const jumpTo = currentStepId ? submitEval.resolveJump(currentStepId) : null;
+      if (jumpTo === THANK_YOU_STEP) {
+        await finish();
+        return;
+      }
+      let target = jumpTo ? logic.stepIds.indexOf(jumpTo) : -1;
+      if (target < 0) {
+        target = nextVisibleStepIndex(logic.stepFieldNames, submitEval.visibility, currentStep);
+      }
+      if (target < 0) await finish();
+      else goToStep(value, target);
     },
     canSubmitWhenInvalid: false,
     onSubmitInvalid({ formApi }) {
@@ -202,5 +286,41 @@ export const useStepPreviewForm = ({
     },
   });
 
-  return { form: form as unknown as AppForm, formName, handleFieldFocus };
+  // Mirror live values into state so visibility/required (and thus the schema) recompute
+  // as the respondent types — enables same-step progressive disclosure. Only runs work
+  // when logic is present; otherwise the empty `liveValues` keeps everything visible.
+  const storeValues = useStore(form.store, (state) => state.values) as Record<string, unknown>;
+  useEffect(() => {
+    if (logic) setLiveValues(storeValues);
+  }, [logic, storeValues]);
+
+  // Auto-fill fields targeted by a "Set value" action. Apply only when the *computed*
+  // value changes (not every render) so the respondent can still edit in between.
+  const appliedSetValuesRef = useRef<Record<string, string>>({});
+  useEffect(() => {
+    if (!evaluation) return;
+    const prev = appliedSetValuesRef.current;
+    const next = evaluation.setValues;
+    const onThisStep = (name: string) => fields.some((f) => f.name === name);
+    // Apply changed set-values (only this step's fields live in this form instance;
+    // cross-step targets are applied by their own step when it mounts).
+    for (const [name, val] of Object.entries(next)) {
+      if (prev[name] !== val && onThisStep(name)) form.setFieldValue(name, val);
+    }
+    // Revert fields that were auto-filled but are no longer controlled, so a stale
+    // forced value doesn't persist after its condition stops matching.
+    for (const name of Object.keys(prev)) {
+      if (!(name in next) && onThisStep(name)) form.setFieldValue(name, "");
+    }
+    appliedSetValuesRef.current = { ...next };
+  }, [evaluation, fields, form]);
+
+  return {
+    form: form as unknown as AppForm,
+    formName,
+    handleFieldFocus,
+    visibleFieldNames,
+    lockedFieldNames,
+    hideSubmit: evaluation?.hideSubmit ?? false,
+  };
 };

--- a/src/lib/editor/transform-plate-for-preview.ts
+++ b/src/lib/editor/transform-plate-for-preview.ts
@@ -71,6 +71,36 @@ export const transformPlateForPreview = (value: Value): PreviewStepResult => {
   return { steps, thankYouNodes };
 };
 
+/** Step id per CARD step, aligned 1:1 with `transformPlateForPreview(...).steps`
+ * and with the ids the logic ruleset extractor assigns. First chunk = "step-0";
+ * subsequent chunks take the id of the pageBreak that opens them. Used to map a
+ * jump rule's target/source step id to a rendered step index. */
+export const getPreviewStepIds = (value: Value): string[] => {
+  let startIdx = 0;
+  if (value.length > 0 && value[0].type === "formHeader") startIdx = 1;
+  const remaining = value.slice(startIdx);
+
+  const ids: string[] = [];
+  let current = "step-0";
+  let chunkLen = 0;
+  let collectingThankYou = false;
+
+  for (const node of remaining) {
+    if (node.type === "pageBreak") {
+      if (chunkLen > 0 && !collectingThankYou) {
+        ids.push(current);
+        chunkLen = 0;
+      }
+      if (node.isThankYouPage) collectingThankYou = true;
+      else current = (node as { id?: string }).id ?? current;
+      continue;
+    }
+    if (!collectingThankYou) chunkLen++;
+  }
+  if (chunkLen > 0 && !collectingThankYou) ids.push(current);
+  return ids;
+};
+
 /** Plate nodes → ordered segments. Consecutive static nodes grouped into one
  * StaticSegment; form nodes (formLabel+formInput, formButton) → FieldSegments. */
 const createSegments = (nodes: Value): PreviewSegment[] => {
@@ -113,6 +143,13 @@ const createSegments = (nodes: Value): PreviewSegment[] => {
   while (i < nodes.length) {
     const node = nodes[i];
     const nodeType = node.type;
+
+    // Logic blocks are evaluation-only — never rendered. Skip before label look-back
+    // and the static-buffer default so they don't surface as content.
+    if (nodeType === "logicBlock") {
+      i++;
+      continue;
+    }
 
     if (INPUT_TYPE_TO_FIELD_TYPE[nodeType]) {
       const label = lookBackForLabel(i);

--- a/src/lib/errors/codes.ts
+++ b/src/lib/errors/codes.ts
@@ -52,6 +52,7 @@ export type ErrorCode =
   // --- Public submissions ----------------------------------------------
   | "submissions/draft-too-large"
   | "submissions/missing-draft-id"
+  | "submissions/invalid"
 
   // --- Notifications ---------------------------------------------------
   | "notifications/forbidden"

--- a/src/lib/logic/build-form-logic.ts
+++ b/src/lib/logic/build-form-logic.ts
@@ -1,0 +1,43 @@
+import type { Value } from "platejs";
+
+import { getFieldsFromSegments, getPreviewStepIds } from "@/lib/editor/transform-plate-for-preview";
+import type { PreviewSegment } from "@/lib/editor/transform-plate-for-preview";
+import { extractRuleset } from "./extract-ruleset";
+import type { EngineField, Ruleset } from "./types";
+
+/** Plain (serializable) conditional-logic payload — no functions, safe to ship
+ * across the RSC boundary. The runtime engine (`evaluate`) is built from it client-side. */
+export interface FormLogicValue {
+  ruleset: Ruleset;
+  /** All answerable fields (name + authored required), across every step. */
+  allFields: EngineField[];
+  /** Step id per rendered step index. Card mode aligns with the ruleset extractor's
+   * ids ("step-0" + page-break ids); field-by-field uses synthetic ids (jumps degrade). */
+  stepIds: string[];
+  /** Answerable field names per rendered step index — used to skip fully-hidden steps. */
+  stepFieldNames: string[][];
+}
+
+/** Derive the conditional-logic payload from published content + its rendered steps.
+ * Shared by the builder preview (FormPreviewFromPlate) and the public RSC renderer so
+ * both compute identical rulesets/step-ids/fields. */
+export const buildFormLogic = (
+  content: Value,
+  steps: PreviewSegment[][],
+  isFieldByField: boolean,
+): FormLogicValue => {
+  const stepFieldNames = steps.map((segs) =>
+    getFieldsFromSegments(segs)
+      .filter((f) => f.fieldType !== "Button")
+      .map((f) => f.name),
+  );
+  const allFields: EngineField[] = [];
+  for (const segs of steps) {
+    for (const field of getFieldsFromSegments(segs)) {
+      if (field.fieldType === "Button") continue;
+      allFields.push({ name: field.name, required: field.required === true });
+    }
+  }
+  const stepIds = isFieldByField ? steps.map((_, i) => `fbf-${i}`) : getPreviewStepIds(content);
+  return { ruleset: extractRuleset(content), allFields, stepIds, stepFieldNames };
+};

--- a/src/lib/logic/engine.test.ts
+++ b/src/lib/logic/engine.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vitest";
+import { evaluate } from "./engine";
+import { THANK_YOU_STEP } from "./types";
+import type { EngineField, Rule, Ruleset } from "./types";
+
+const ruleset = (rules: Rule[]): Ruleset => ({ rules, orphanedRefs: [] });
+
+const fields: EngineField[] = [
+  { name: "country" },
+  { name: "vat", required: true },
+  { name: "extra" },
+];
+
+describe("evaluate — visibility", () => {
+  it("show-targeted field is hidden by default and revealed when its condition passes", () => {
+    const rs = ruleset([
+      {
+        id: "r1",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "DE" }],
+        },
+        actions: [{ kind: "show", target: "vat" }],
+      },
+    ]);
+    expect(evaluate(rs, { country: "FR" }, fields).visibility.vat).toBe(false);
+    expect(evaluate(rs, { country: "DE" }, fields).visibility.vat).toBe(true);
+  });
+
+  it("hide action conceals an otherwise-visible field when its condition passes", () => {
+    const rs = ruleset([
+      {
+        id: "r1",
+        stepId: "s1",
+        when: {
+          combinator: "any",
+          children: [{ source: "country", operator: "equals", value: "US" }],
+        },
+        actions: [{ kind: "hide", target: "extra" }],
+      },
+    ]);
+    expect(evaluate(rs, { country: "DE" }, fields).visibility.extra).toBe(true);
+    expect(evaluate(rs, { country: "US" }, fields).visibility.extra).toBe(false);
+  });
+
+  it("hide wins over show deterministically, regardless of rule order", () => {
+    const show: Rule = {
+      id: "show",
+      stepId: "s1",
+      when: {
+        combinator: "all",
+        children: [{ source: "country", operator: "equals", value: "DE" }],
+      },
+      actions: [{ kind: "show", target: "vat" }],
+    };
+    const hide: Rule = {
+      id: "hide",
+      stepId: "s1",
+      when: {
+        combinator: "all",
+        children: [{ source: "country", operator: "equals", value: "DE" }],
+      },
+      actions: [{ kind: "hide", target: "vat" }],
+    };
+    // Both rules fire for country=DE; hide must win in either authoring order.
+    expect(evaluate(ruleset([show, hide]), { country: "DE" }, fields).visibility.vat).toBe(false);
+    expect(evaluate(ruleset([hide, show]), { country: "DE" }, fields).visibility.vat).toBe(false);
+  });
+
+  it("applies elseActions (Else Do) when the condition fails", () => {
+    const rs = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "DE" }],
+        },
+        actions: [{ kind: "show", target: "vat" }],
+        elseActions: [{ kind: "show", target: "extra" }],
+      },
+    ]);
+    // country=DE → Do branch: vat shown, extra (else-show-target) stays hidden-by-default
+    const pass = evaluate(rs, { country: "DE" }, fields);
+    expect(pass.visibility.vat).toBe(true);
+    expect(pass.visibility.extra).toBe(false);
+    // country=FR → Else Do branch: extra shown, vat stays hidden-by-default
+    const fail = evaluate(rs, { country: "FR" }, fields);
+    expect(fail.visibility.vat).toBe(false);
+    expect(fail.visibility.extra).toBe(true);
+  });
+
+  it("setValue auto-fills a target only on the active branch", () => {
+    const rs = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "DE" }],
+        },
+        actions: [{ kind: "setValue", target: "vat", value: "36" }],
+        elseActions: [{ kind: "setValue", target: "vat", value: "0" }],
+      },
+    ]);
+    expect(evaluate(rs, { country: "DE" }, fields).setValues.vat).toBe("36");
+    expect(evaluate(rs, { country: "FR" }, fields).setValues.vat).toBe("0");
+  });
+
+  it("ignores action targets that are not known fields (no stray visibility keys)", () => {
+    const rs = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "DE" }],
+        },
+        actions: [{ kind: "hide", target: "ghostField" }],
+      },
+    ]);
+    const result = evaluate(rs, { country: "DE" }, fields);
+    expect("ghostField" in result.visibility).toBe(false);
+  });
+});
+
+describe("evaluate — combinators & grouping", () => {
+  it("all requires every child; any requires one", () => {
+    const all: Rule = {
+      id: "r",
+      stepId: "s1",
+      when: {
+        combinator: "all",
+        children: [
+          { source: "country", operator: "equals", value: "DE" },
+          { source: "extra", operator: "isNotEmpty" },
+        ],
+      },
+      actions: [{ kind: "hide", target: "vat" }],
+    };
+    expect(evaluate(ruleset([all]), { country: "DE", extra: "x" }, fields).visibility.vat).toBe(
+      false,
+    );
+    expect(evaluate(ruleset([all]), { country: "DE", extra: "" }, fields).visibility.vat).toBe(
+      true,
+    );
+  });
+
+  it("nested group expresses (A and B) or C", () => {
+    const rule: Rule = {
+      id: "r",
+      stepId: "s1",
+      when: {
+        combinator: "any",
+        children: [
+          {
+            combinator: "all",
+            children: [
+              { source: "country", operator: "equals", value: "DE" },
+              { source: "extra", operator: "equals", value: "biz" },
+            ],
+          },
+          { source: "country", operator: "equals", value: "CH" },
+        ],
+      },
+      actions: [{ kind: "hide", target: "vat" }],
+    };
+    expect(evaluate(ruleset([rule]), { country: "CH" }, fields).visibility.vat).toBe(false);
+    expect(evaluate(ruleset([rule]), { country: "DE", extra: "biz" }, fields).visibility.vat).toBe(
+      false,
+    );
+    expect(evaluate(ruleset([rule]), { country: "DE", extra: "x" }, fields).visibility.vat).toBe(
+      true,
+    );
+  });
+});
+
+describe("evaluate — required, hideSubmit, redirect", () => {
+  it("authored-required but hidden field is not effectively required", () => {
+    const rs = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "US" }],
+        },
+        actions: [{ kind: "hide", target: "vat" }],
+      },
+    ]);
+    expect(evaluate(rs, { country: "DE" }, fields).effectiveRequired.vat).toBe(true);
+    expect(evaluate(rs, { country: "US" }, fields).effectiveRequired.vat).toBe(false);
+  });
+
+  it("require action makes a visible field required only when its condition passes", () => {
+    const rs = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "DE" }],
+        },
+        actions: [{ kind: "require", target: "extra" }],
+      },
+    ]);
+    expect(evaluate(rs, { country: "FR" }, fields).effectiveRequired.extra).toBe(false);
+    expect(evaluate(rs, { country: "DE" }, fields).effectiveRequired.extra).toBe(true);
+  });
+
+  it("hideSubmit and redirect react to conditions", () => {
+    const rs = ruleset([
+      {
+        id: "r1",
+        stepId: "s1",
+        when: { combinator: "all", children: [{ source: "country", operator: "isEmpty" }] },
+        actions: [{ kind: "hideSubmit" }],
+      },
+      {
+        id: "r2",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "DE" }],
+        },
+        actions: [{ kind: "redirect", url: "https://de.example.com" }],
+      },
+    ]);
+    expect(evaluate(rs, { country: "" }, fields).hideSubmit).toBe(true);
+    expect(evaluate(rs, { country: "DE" }, fields).hideSubmit).toBe(false);
+    expect(evaluate(rs, { country: "DE" }, fields).redirectUrl).toBe("https://de.example.com");
+    expect(evaluate(rs, { country: "FR" }, fields).redirectUrl).toBeNull();
+  });
+});
+
+describe("evaluate — resolveJump", () => {
+  it("first matching jump rule on the step wins; non-match falls through to null", () => {
+    const rs = ruleset([
+      {
+        id: "r1",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "US" }],
+        },
+        actions: [{ kind: "jump", toStep: "s3" }],
+      },
+      {
+        id: "r2",
+        stepId: "s1",
+        when: { combinator: "all", children: [{ source: "country", operator: "isEmpty" }] },
+        actions: [{ kind: "jump", toStep: THANK_YOU_STEP }],
+      },
+    ]);
+    expect(evaluate(rs, { country: "US" }, fields).resolveJump("s1")).toBe("s3");
+    expect(evaluate(rs, { country: "" }, fields).resolveJump("s1")).toBe(THANK_YOU_STEP);
+    expect(evaluate(rs, { country: "DE" }, fields).resolveJump("s1")).toBeNull();
+    expect(evaluate(rs, { country: "US" }, fields).resolveJump("s2")).toBeNull();
+  });
+});
+
+describe("evaluate — fail-closed orphans", () => {
+  it("condition on an unknown source evaluates false", () => {
+    const rs = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "ghost", operator: "equals", value: "x" }],
+        },
+        actions: [{ kind: "hide", target: "vat" }],
+      },
+    ]);
+    expect(evaluate(rs, { ghost: "x" }, fields).visibility.vat).toBe(true); // hide never fires
+  });
+});

--- a/src/lib/logic/engine.ts
+++ b/src/lib/logic/engine.ts
@@ -1,0 +1,127 @@
+import { applyOperator } from "./operators";
+import { THANK_YOU_STEP } from "./types";
+import type {
+  Action,
+  Condition,
+  ConditionGroup,
+  EngineField,
+  EvaluationResult,
+  Rule,
+  Ruleset,
+} from "./types";
+
+const isGroup = (node: Condition | ConditionGroup): node is ConditionGroup => "combinator" in node;
+
+const evalCondition = (
+  cond: Condition,
+  answers: Record<string, unknown>,
+  knownNames: Set<string>,
+): boolean => {
+  // Fail closed: a condition on an unknown source is false.
+  if (!knownNames.has(cond.source)) return false;
+  return applyOperator(cond.operator, answers[cond.source], cond.value);
+};
+
+const evalGroup = (
+  group: ConditionGroup,
+  answers: Record<string, unknown>,
+  knownNames: Set<string>,
+): boolean => {
+  const results = group.children.map((child) =>
+    isGroup(child)
+      ? evalGroup(child, answers, knownNames)
+      : evalCondition(child, answers, knownNames),
+  );
+  if (group.combinator === "all") return results.every(Boolean);
+  return results.some(Boolean);
+};
+
+const collectShowTargets = (rules: Rule[]): Set<string> => {
+  const set = new Set<string>();
+  for (const rule of rules) {
+    for (const action of [...rule.actions, ...(rule.elseActions ?? [])]) {
+      if (action.kind === "show") set.add(action.target);
+    }
+  }
+  return set;
+};
+
+/** The action list a rule contributes for the current answers: "Do" when it passes,
+ * "Else Do" when it doesn't. */
+const activeActions = (
+  rule: Rule,
+  answers: Record<string, unknown>,
+  knownNames: Set<string>,
+): Action[] =>
+  evalGroup(rule.when, answers, knownNames) ? rule.actions : (rule.elseActions ?? []);
+
+/** Pure, isomorphic evaluation of a ruleset against current answers. */
+export const evaluate = (
+  ruleset: Ruleset,
+  answers: Record<string, unknown>,
+  fields: ReadonlyArray<EngineField>,
+): EvaluationResult => {
+  const knownNames = new Set(fields.map((f) => f.name));
+  const showTargets = collectShowTargets(ruleset.rules);
+
+  // Collect which targets a *passing* rule shows/hides/requires. Only known fields
+  // are tracked, so orphaned action targets never leak stray keys into the result.
+  const passingShow = new Set<string>();
+  const passingHide = new Set<string>();
+  const requiredByAction = new Set<string>();
+  const setValues: Record<string, string> = {};
+  let hideSubmit = false;
+  let redirectUrl: string | null = null;
+
+  for (const rule of ruleset.rules) {
+    for (const action of activeActions(rule, answers, knownNames)) {
+      if (action.kind === "show" && knownNames.has(action.target)) passingShow.add(action.target);
+      else if (action.kind === "hide" && knownNames.has(action.target))
+        passingHide.add(action.target);
+      else if (action.kind === "require" && knownNames.has(action.target))
+        requiredByAction.add(action.target);
+      else if (action.kind === "setValue" && knownNames.has(action.target))
+        setValues[action.target] = action.value; // document order, last wins
+      else if (action.kind === "hideSubmit") hideSubmit = true;
+      else if (action.kind === "redirect") redirectUrl = action.url;
+    }
+  }
+
+  // Visibility precedence: a passing hide always wins over a passing show
+  // (deterministic, order-independent, fail-safe — hidden fields are stripped server-side).
+  // Default: show-targeted fields start hidden; everything else starts visible.
+  const visibility: Record<string, boolean> = {};
+  for (const field of fields) {
+    if (passingHide.has(field.name)) visibility[field.name] = false;
+    else if (passingShow.has(field.name)) visibility[field.name] = true;
+    else visibility[field.name] = !showTargets.has(field.name);
+  }
+
+  const effectiveRequired: Record<string, boolean> = {};
+  for (const field of fields) {
+    const authored = field.required === true;
+    effectiveRequired[field.name] =
+      visibility[field.name] && (authored || requiredByAction.has(field.name));
+  }
+
+  const resolveJump = (fromStep: string): string | null => {
+    for (const rule of ruleset.rules) {
+      if (rule.stepId !== fromStep) continue;
+      const jump = activeActions(rule, answers, knownNames).find((a) => a.kind === "jump");
+      if (jump && jump.kind === "jump") return jump.toStep;
+    }
+    return null;
+  };
+
+  return {
+    visibility,
+    effectiveRequired,
+    computedValues: {},
+    setValues,
+    hideSubmit,
+    redirectUrl,
+    resolveJump,
+  };
+};
+
+export { THANK_YOU_STEP };

--- a/src/lib/logic/extract-ruleset.test.ts
+++ b/src/lib/logic/extract-ruleset.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { Value } from "platejs";
+import { extractRuleset } from "./extract-ruleset";
+
+const FIRST_STEP = "step-0";
+
+const content = (extra: Record<string, unknown>[] = []): Value =>
+  [
+    { type: "formLabel", id: "country", children: [{ text: "Country" }] },
+    { type: "formInput", children: [{ text: "" }] },
+    {
+      type: "logicBlock",
+      id: "lb1",
+      when: {
+        combinator: "all",
+        children: [{ source: "country", operator: "equals", value: "DE" }],
+      },
+      actions: [{ kind: "show", target: "vat" }],
+      children: [{ text: "" }],
+    },
+    { type: "formLabel", id: "vat", children: [{ text: "VAT" }] },
+    { type: "formInput", children: [{ text: "" }] },
+    ...extra,
+  ] as unknown as Value;
+
+describe("extractRuleset", () => {
+  it("extracts a rule with the step id of its containing step", () => {
+    const { rules } = extractRuleset(content());
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe("lb1");
+    expect(rules[0].stepId).toBe(FIRST_STEP);
+    expect(rules[0].actions[0]).toEqual({ kind: "show", target: "vat" });
+  });
+
+  it("assigns the opening pageBreak id as the step id for later steps", () => {
+    const value = [
+      { type: "pageBreak", id: "pb1", children: [{ text: "" }] },
+      { type: "formLabel", id: "q2", children: [{ text: "Q2" }] },
+      { type: "formInput", children: [{ text: "" }] },
+      {
+        type: "logicBlock",
+        id: "lb2",
+        when: { combinator: "all", children: [{ source: "q2", operator: "isNotEmpty" }] },
+        actions: [{ kind: "jump", toStep: "__thankYou__" }],
+        children: [{ text: "" }],
+      },
+    ] as unknown as Value;
+    const { rules } = extractRuleset(value);
+    expect(rules[0].stepId).toBe("pb1");
+  });
+
+  it("flags an orphaned condition source", () => {
+    const value = [
+      {
+        type: "logicBlock",
+        id: "lb",
+        when: {
+          combinator: "all",
+          children: [{ source: "ghost", operator: "equals", value: "x" }],
+        },
+        actions: [{ kind: "hide", target: "vat" }],
+        children: [{ text: "" }],
+      },
+      { type: "formLabel", id: "vat", children: [{ text: "VAT" }] },
+      { type: "formInput", children: [{ text: "" }] },
+    ] as unknown as Value;
+    const { orphanedRefs } = extractRuleset(value);
+    expect(orphanedRefs).toContain("ghost");
+  });
+
+  it("drops a repeatable field used as a condition source and flags it", () => {
+    const value = [
+      { type: "formLabel", id: "emails", children: [{ text: "Emails" }] },
+      { type: "formEmail", isFieldArray: true, children: [{ text: "" }] },
+      {
+        type: "logicBlock",
+        id: "lb",
+        when: {
+          combinator: "all",
+          children: [{ source: "emails", operator: "contains", value: "@x" }],
+        },
+        actions: [{ kind: "hide", target: "emails" }],
+        children: [{ text: "" }],
+      },
+    ] as unknown as Value;
+    const { rules, orphanedRefs } = extractRuleset(value);
+    // hide-target "emails" is fine; the condition source "emails" (repeatable) is dropped.
+    expect(orphanedRefs).toContain("emails");
+    expect(rules[0].when.children).toHaveLength(0);
+  });
+
+  it("returns an empty ruleset for content with no logic blocks", () => {
+    const value = [
+      { type: "formLabel", id: "q", children: [{ text: "Q" }] },
+      { type: "formInput", children: [{ text: "" }] },
+    ] as unknown as Value;
+    expect(extractRuleset(value)).toEqual({ rules: [], orphanedRefs: [] });
+  });
+});

--- a/src/lib/logic/extract-ruleset.ts
+++ b/src/lib/logic/extract-ruleset.ts
@@ -1,0 +1,94 @@
+import type { Value } from "platejs";
+import { transformPlateForPreview } from "@/lib/editor/transform-plate-for-preview";
+import { THANK_YOU_STEP } from "./types";
+import type { ConditionGroup, LogicBlockNode, Rule, Ruleset } from "./types";
+
+const FIRST_STEP_ID = "step-0";
+
+interface FieldMeta {
+  name: string;
+  isFieldArray: boolean;
+}
+
+/** Build name → isFieldArray map + step-id set via the canonical preview transform. */
+const collectFields = (content: Value): Map<string, FieldMeta> => {
+  const map = new Map<string, FieldMeta>();
+  const { steps } = transformPlateForPreview(content);
+  for (const segments of steps) {
+    for (const seg of segments) {
+      if (seg.type !== "field") continue;
+      const field = seg.field;
+      const isFieldArray = (field as { isFieldArray?: boolean }).isFieldArray === true;
+      map.set(field.name, { name: field.name, isFieldArray });
+    }
+  }
+  return map;
+};
+
+/** Strip orphaned / repeatable-source conditions from a group, recording dropped refs. */
+const sanitizeGroup = (
+  group: ConditionGroup,
+  fields: Map<string, FieldMeta>,
+  orphans: Set<string>,
+): ConditionGroup => {
+  const children: ConditionGroup["children"] = [];
+  for (const child of group.children) {
+    if ("combinator" in child) {
+      children.push(sanitizeGroup(child, fields, orphans));
+      continue;
+    }
+    const cond = child;
+    const meta = fields.get(cond.source);
+    if (!meta) {
+      orphans.add(cond.source);
+      continue; // fail closed: drop unknown source
+    }
+    if (meta.isFieldArray) {
+      orphans.add(cond.source); // Wave 1: repeatable not a valid source
+      continue;
+    }
+    children.push(cond);
+  }
+  return { combinator: group.combinator, children };
+};
+
+export const extractRuleset = (content: Value): Ruleset => {
+  const fields = collectFields(content);
+  const stepIds = new Set<string>([FIRST_STEP_ID]);
+  const orphans = new Set<string>();
+  const rules: Rule[] = [];
+
+  let currentStep = FIRST_STEP_ID;
+  for (const node of content) {
+    const type = (node as { type?: string }).type;
+    if (type === "pageBreak") {
+      currentStep = (node as { id?: string }).id ?? currentStep;
+      stepIds.add(currentStep);
+      continue;
+    }
+    if (type !== "logicBlock") continue;
+    const lb = node as unknown as LogicBlockNode;
+    rules.push({
+      id: lb.id,
+      stepId: currentStep,
+      when: sanitizeGroup(lb.when ?? { combinator: "all", children: [] }, fields, orphans),
+      actions: lb.actions ?? [],
+      elseActions: lb.elseActions,
+    });
+  }
+
+  // Flag orphaned action targets / jump targets (both Do and Else Do branches).
+  for (const rule of rules) {
+    for (const action of [...rule.actions, ...(rule.elseActions ?? [])]) {
+      if (action.kind === "jump") {
+        if (action.toStep !== THANK_YOU_STEP && !stepIds.has(action.toStep)) {
+          orphans.add(action.toStep);
+        }
+      } else if (action.kind !== "hideSubmit" && action.kind !== "redirect") {
+        if (!fields.has(action.target)) orphans.add(action.target);
+      }
+    }
+  }
+
+  return { rules, orphanedRefs: [...orphans] };
+};

--- a/src/lib/logic/labels.ts
+++ b/src/lib/logic/labels.ts
@@ -1,0 +1,82 @@
+/** Operator labels + per-field-type operator matrix for the IF/THEN authoring UI.
+ * Pure — no framework imports. */
+import type { OperatorId } from "./types";
+
+export const OPERATOR_LABELS: Record<OperatorId, string> = {
+  equals: "is",
+  notEquals: "is not",
+  contains: "contains",
+  notContains: "does not contain",
+  greaterThan: "greater than",
+  lessThan: "less than",
+  greaterThanOrEqual: "≥",
+  lessThanOrEqual: "≤",
+  isEmpty: "is empty",
+  isNotEmpty: "is not empty",
+};
+
+const OPERATORS_WITHOUT_OPERAND = new Set<OperatorId>(["isEmpty", "isNotEmpty"]);
+
+export const operatorNeedsOperand = (op: OperatorId): boolean => !OPERATORS_WITHOUT_OPERAND.has(op);
+
+/** Operators offered per field type in the authoring UI. */
+const OPERATORS_BY_FIELD_TYPE: Record<string, OperatorId[]> = {
+  // text-like
+  Input: ["equals", "notEquals", "contains", "notContains", "isEmpty", "isNotEmpty"],
+  Textarea: ["equals", "notEquals", "contains", "notContains", "isEmpty", "isNotEmpty"],
+  Email: ["equals", "notEquals", "contains", "notContains", "isEmpty", "isNotEmpty"],
+  Link: ["equals", "notEquals", "contains", "notContains", "isEmpty", "isNotEmpty"],
+  Phone: ["equals", "notEquals", "contains", "notContains", "isEmpty", "isNotEmpty"],
+  // numeric / temporal — add comparisons
+  Number: [
+    "equals",
+    "notEquals",
+    "greaterThan",
+    "lessThan",
+    "greaterThanOrEqual",
+    "lessThanOrEqual",
+    "isEmpty",
+    "isNotEmpty",
+  ],
+  Date: [
+    "equals",
+    "notEquals",
+    "greaterThan",
+    "lessThan",
+    "greaterThanOrEqual",
+    "lessThanOrEqual",
+    "isEmpty",
+    "isNotEmpty",
+  ],
+  Time: [
+    "equals",
+    "notEquals",
+    "greaterThan",
+    "lessThan",
+    "greaterThanOrEqual",
+    "lessThanOrEqual",
+    "isEmpty",
+    "isNotEmpty",
+  ],
+  // single choice (radio) — one value
+  MultiChoice: ["equals", "notEquals", "isEmpty", "isNotEmpty"],
+  // multi-value (arrays) — `contains` checks membership; `equals` would compare a
+  // joined string, so it's omitted to avoid misleading authors.
+  Checkbox: ["contains", "notContains", "isEmpty", "isNotEmpty"],
+  MultiSelect: ["contains", "notContains", "isEmpty", "isNotEmpty"],
+  Ranking: ["contains", "notContains", "isEmpty", "isNotEmpty"],
+  // file upload — only presence checks are meaningful
+  FileUpload: ["isEmpty", "isNotEmpty"],
+};
+
+const DEFAULT_OPERATORS: OperatorId[] = [
+  "equals",
+  "notEquals",
+  "contains",
+  "notContains",
+  "isEmpty",
+  "isNotEmpty",
+];
+
+export const operatorsForFieldType = (fieldType: string | undefined): OperatorId[] =>
+  (fieldType && OPERATORS_BY_FIELD_TYPE[fieldType]) || DEFAULT_OPERATORS;

--- a/src/lib/logic/operators.test.ts
+++ b/src/lib/logic/operators.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { applyOperator } from "./operators";
+
+describe("applyOperator", () => {
+  it("equals / notEquals compare as strings", () => {
+    expect(applyOperator("equals", "Germany", "Germany")).toBe(true);
+    expect(applyOperator("equals", "Germany", "France")).toBe(false);
+    expect(applyOperator("notEquals", "Germany", "France")).toBe(true);
+  });
+
+  it("contains / notContains do substring match", () => {
+    expect(applyOperator("contains", "hello world", "world")).toBe(true);
+    expect(applyOperator("contains", "hello", "z")).toBe(false);
+    expect(applyOperator("notContains", "hello", "z")).toBe(true);
+  });
+
+  it("numeric comparisons coerce both sides", () => {
+    expect(applyOperator("greaterThan", "10", "5")).toBe(true);
+    expect(applyOperator("greaterThan", "5", "10")).toBe(false);
+    expect(applyOperator("lessThan", "5", "10")).toBe(true);
+    expect(applyOperator("greaterThanOrEqual", "5", "5")).toBe(true);
+    expect(applyOperator("lessThanOrEqual", "5", "5")).toBe(true);
+  });
+
+  it("non-numeric input fails numeric comparisons", () => {
+    expect(applyOperator("greaterThan", "abc", "5")).toBe(false);
+  });
+
+  it("isEmpty / isNotEmpty handle null, empty string, and empty arrays", () => {
+    expect(applyOperator("isEmpty", "", undefined)).toBe(true);
+    expect(applyOperator("isEmpty", null, undefined)).toBe(true);
+    expect(applyOperator("isEmpty", undefined, undefined)).toBe(true);
+    expect(applyOperator("isEmpty", [], undefined)).toBe(true);
+    expect(applyOperator("isEmpty", ["", ""], undefined)).toBe(true);
+    expect(applyOperator("isEmpty", "x", undefined)).toBe(false);
+    expect(applyOperator("isNotEmpty", "x", undefined)).toBe(true);
+    expect(applyOperator("isNotEmpty", ["a"], undefined)).toBe(true);
+  });
+
+  it("compares ISO dates and times chronologically via lexicographic fallback", () => {
+    expect(applyOperator("greaterThan", "2026-06-01", "2026-01-01")).toBe(true);
+    expect(applyOperator("lessThan", "2026-01-01", "2026-06-01")).toBe(true);
+    expect(applyOperator("greaterThanOrEqual", "2026-06-01", "2026-06-01")).toBe(true);
+    expect(applyOperator("greaterThan", "14:30", "09:15")).toBe(true);
+    expect(applyOperator("lessThan", "09:15", "14:30")).toBe(true);
+  });
+
+  it("empty answers are non-comparable in numeric operators (not coerced to 0)", () => {
+    expect(applyOperator("greaterThanOrEqual", "", "0")).toBe(false);
+    expect(applyOperator("lessThan", undefined, "5")).toBe(false);
+    expect(applyOperator("greaterThan", "   ", "-1")).toBe(false);
+    expect(applyOperator("lessThanOrEqual", null, "10")).toBe(false);
+    // a real zero still compares
+    expect(applyOperator("greaterThanOrEqual", "0", "0")).toBe(true);
+  });
+});

--- a/src/lib/logic/operators.ts
+++ b/src/lib/logic/operators.ts
@@ -1,0 +1,65 @@
+import type { OperatorId } from "./types";
+
+const isEmptyValue = (value: unknown): boolean => {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "string") return value.trim() === "";
+  if (Array.isArray(value)) return value.every((v) => isEmptyValue(v));
+  return false;
+};
+
+const asString = (value: unknown): string => {
+  if (value === null || value === undefined) return "";
+  if (Array.isArray(value)) return value.join(", ");
+  return String(value);
+};
+
+/** Pure predicate for one condition. Numeric comparisons coerce; bad numbers → false. */
+export const applyOperator = (
+  operator: OperatorId,
+  answer: unknown,
+  operand: string | undefined,
+): boolean => {
+  switch (operator) {
+    case "isEmpty":
+      return isEmptyValue(answer);
+    case "isNotEmpty":
+      return !isEmptyValue(answer);
+    case "equals":
+      return asString(answer) === asString(operand);
+    case "notEquals":
+      return asString(answer) !== asString(operand);
+    case "contains":
+      return asString(answer).includes(asString(operand));
+    case "notContains":
+      return !asString(answer).includes(asString(operand));
+    case "greaterThan":
+    case "lessThan":
+    case "greaterThanOrEqual":
+    case "lessThanOrEqual": {
+      // Empty answer is non-comparable — don't let Number("") === 0 fire threshold rules.
+      if (isEmptyValue(answer)) return false;
+      const a = Number(asString(answer));
+      const b = Number(operand);
+      const aIsNum = !Number.isNaN(a);
+      const bIsNum = !Number.isNaN(b);
+      // Both numeric → numeric compare. Both non-numeric → lexicographic, which is
+      // chronological for ISO dates (YYYY-MM-DD) and zero-padded times (HH:MM).
+      // A numeric/non-numeric mismatch is non-comparable → false.
+      if (aIsNum !== bIsNum) return false;
+      const sa = asString(answer);
+      const sb = asString(operand);
+      switch (operator) {
+        case "greaterThan":
+          return aIsNum ? a > b : sa > sb;
+        case "lessThan":
+          return aIsNum ? a < b : sa < sb;
+        case "greaterThanOrEqual":
+          return aIsNum ? a >= b : sa >= sb;
+        default:
+          return aIsNum ? a <= b : sa <= sb;
+      }
+    }
+    default:
+      return false;
+  }
+};

--- a/src/lib/logic/sanitize-submission.test.ts
+++ b/src/lib/logic/sanitize-submission.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import * as v from "valibot";
+import type { Value } from "platejs";
+import { buildVisibleSchema, sanitizeSubmission } from "./sanitize-submission";
+
+const content = [
+  { type: "formLabel", id: "country", children: [{ text: "Country" }] },
+  { type: "formInput", children: [{ text: "" }] },
+  {
+    type: "logicBlock",
+    id: "lb",
+    when: { combinator: "all", children: [{ source: "country", operator: "equals", value: "US" }] },
+    actions: [{ kind: "hide", target: "vat" }],
+    children: [{ text: "" }],
+  },
+  { type: "formLabel", id: "vat", children: [{ text: "VAT" }] },
+  { type: "formInput", children: [{ text: "" }] },
+] as unknown as Value;
+
+describe("sanitizeSubmission", () => {
+  it("keeps answers for visible fields", () => {
+    const { data, hiddenStripped } = sanitizeSubmission(content, { country: "DE", vat: "DE123" });
+    expect(data).toEqual({ country: "DE", vat: "DE123" });
+    expect(hiddenStripped).toEqual([]);
+  });
+
+  it("strips and flags an answer the client sent for a server-hidden field", () => {
+    const { data, hiddenStripped, rejected } = sanitizeSubmission(content, {
+      country: "US",
+      vat: "SHOULD_NOT_BE_HERE",
+    });
+    expect(data).toEqual({ country: "US" });
+    expect(hiddenStripped).toContain("vat");
+    expect(rejected).toContain("vat");
+  });
+});
+
+const requiredVatContent = [
+  { type: "formLabel", id: "country", children: [{ text: "Country" }] },
+  { type: "formInput", children: [{ text: "" }] },
+  {
+    type: "logicBlock",
+    id: "lb",
+    when: { combinator: "all", children: [{ source: "country", operator: "equals", value: "US" }] },
+    actions: [{ kind: "hide", target: "vat" }],
+    children: [{ text: "" }],
+  },
+  { type: "formLabel", id: "vat", children: [{ text: "VAT" }] },
+  { type: "formInput", required: true, children: [{ text: "" }] },
+] as unknown as Value;
+
+describe("buildVisibleSchema", () => {
+  it("omits a hidden required field so it can't block submit", () => {
+    const schema = buildVisibleSchema(requiredVatContent, { country: "US" });
+    expect(v.safeParse(schema, { country: "US" }).success).toBe(true);
+  });
+
+  it("enforces a visible required field", () => {
+    const schema = buildVisibleSchema(requiredVatContent, { country: "DE" });
+    expect(v.safeParse(schema, { country: "DE" }).success).toBe(false);
+    expect(v.safeParse(schema, { country: "DE", vat: "DE123" }).success).toBe(true);
+  });
+});

--- a/src/lib/logic/sanitize-submission.ts
+++ b/src/lib/logic/sanitize-submission.ts
@@ -1,0 +1,89 @@
+import type { Value } from "platejs";
+import * as v from "valibot";
+import {
+  getFieldsFromSegments,
+  transformPlateForPreview,
+} from "@/lib/editor/transform-plate-for-preview";
+import { generateZodSchemaFromFields } from "@/lib/form-schema/generate-preview-schema";
+import type { PlateFormField } from "@/lib/editor/transform-plate-to-form";
+import { evaluate } from "./engine";
+import { extractRuleset } from "./extract-ruleset";
+import type { EngineField } from "./types";
+
+/** Full answerable fields from content (Button excluded), in document order. */
+const collectAllFields = (content: Value): PlateFormField[] => {
+  const out: PlateFormField[] = [];
+  const { steps } = transformPlateForPreview(content);
+  for (const segments of steps) {
+    for (const field of getFieldsFromSegments(segments)) {
+      if (field.fieldType === "Button") continue;
+      out.push(field);
+    }
+  }
+  return out;
+};
+
+const toEngineFields = (fields: PlateFormField[]): EngineField[] =>
+  fields.map((f) => ({
+    name: f.name,
+    required: (f as { required?: boolean }).required === true,
+  }));
+
+const collectEngineFields = (content: Value): EngineField[] =>
+  toEngineFields(collectAllFields(content));
+
+export interface SanitizeResult {
+  data: Record<string, unknown>;
+  /** field names hidden by the server-side engine */
+  hiddenStripped: string[];
+  /** submitted keys the client shouldn't have sent (subset of hiddenStripped that was present) */
+  rejected: string[];
+}
+
+/** Authoritative server pass: drop answers for server-hidden fields; flag client overreach. */
+export const sanitizeSubmission = (
+  content: Value,
+  submitted: Record<string, unknown>,
+): SanitizeResult => {
+  const fields = collectEngineFields(content);
+  const ruleset = extractRuleset(content);
+  const { visibility, setValues } = evaluate(ruleset, submitted, fields);
+
+  const hiddenStripped: string[] = [];
+  const rejected: string[] = [];
+  const data: Record<string, unknown> = { ...submitted };
+
+  for (const field of fields) {
+    if (visibility[field.name] === false) {
+      hiddenStripped.push(field.name);
+      if (field.name in submitted) {
+        rejected.push(field.name);
+        delete data[field.name];
+      }
+    }
+  }
+
+  // Authoritatively force "Set value" targets — don't trust a client-sent override.
+  for (const [name, value] of Object.entries(setValues)) {
+    if (visibility[name] !== false) data[name] = value;
+  }
+
+  return { data, hiddenStripped, rejected };
+};
+
+/** Valibot schema covering only the fields visible for `answers`, with logic-driven
+ * effective-required applied. Shared by client (live validation) and server (authoritative
+ * submit validation) so both enforce identical rules. Hidden fields are excluded, so a
+ * hidden-but-authored-required field never blocks; a passing require-action adds requiredness. */
+export const buildVisibleSchema = (
+  content: Value,
+  answers: Record<string, unknown>,
+): v.ObjectSchema<v.ObjectEntries, undefined> => {
+  const allFields = collectAllFields(content);
+  const ruleset = extractRuleset(content);
+  const { visibility, effectiveRequired } = evaluate(ruleset, answers, toEngineFields(allFields));
+  const visibleFields = allFields
+    .filter((f) => visibility[f.name] !== false)
+    .map((f) => ({ ...f, required: effectiveRequired[f.name] === true }) as PlateFormField);
+  return generateZodSchemaFromFields(visibleFields);
+};

--- a/src/lib/logic/types.ts
+++ b/src/lib/logic/types.ts
@@ -1,0 +1,91 @@
+/** Conditional-logic data model. Pure types — no runtime, no imports.
+ * All field references use the form-state `name` key (see transforms), never raw Plate ids. */
+
+/** Operators available per field type. Wave 1 sources are always scalar. */
+export type OperatorId =
+  | "equals"
+  | "notEquals"
+  | "contains"
+  | "notContains"
+  | "greaterThan"
+  | "lessThan"
+  | "greaterThanOrEqual"
+  | "lessThanOrEqual"
+  | "isEmpty"
+  | "isNotEmpty";
+
+/** A single test against one field's current answer. `value` is absent for isEmpty/isNotEmpty. */
+export interface Condition {
+  /** field `name` being tested */
+  source: string;
+  operator: OperatorId;
+  value?: string;
+}
+
+/** AND (`all`) / OR (`any`) over child conditions or nested groups. The engine
+ * supports arbitrary nesting (story 5); Wave-1 editor authors flat groups. */
+export interface ConditionGroup {
+  combinator: "all" | "any";
+  children: Array<Condition | ConditionGroup>;
+}
+
+export type Action =
+  | { kind: "show"; target: string } // field name
+  | { kind: "hide"; target: string }
+  | { kind: "require"; target: string }
+  | { kind: "setValue"; target: string; value: string } // auto-fill a field
+  | { kind: "jump"; toStep: string } // step id, or the sentinel THANK_YOU_STEP
+  | { kind: "hideSubmit" }
+  | { kind: "redirect"; url: string };
+
+export interface Rule {
+  /** logicBlock node id */
+  id: string;
+  /** id of the step that physically contains this logic block — drives jump timing */
+  stepId: string;
+  when: ConditionGroup;
+  /** actions applied when `when` passes ("Do") */
+  actions: Action[];
+  /** actions applied when `when` does NOT pass ("Else Do") */
+  elseActions?: Action[];
+}
+
+export interface Ruleset {
+  rules: Rule[];
+  /** referenced names/targets/steps that don't resolve to a real block — editor warns; engine fails closed */
+  orphanedRefs: string[];
+}
+
+/** Sentinel jump target meaning "finish — go to the Thank You page". */
+export const THANK_YOU_STEP = "__thankYou__" as const;
+
+/** Minimal field info the engine needs (decoupled from PlateFormField). */
+export interface EngineField {
+  name: string;
+  required?: boolean;
+}
+
+export interface EvaluationResult {
+  /** fieldName → visible */
+  visibility: Record<string, boolean>;
+  /** fieldName → required (always implies visible) */
+  effectiveRequired: Record<string, boolean>;
+  /** Wave 2 — always {} in Wave 1 */
+  computedValues: Record<string, never>;
+  /** fieldName → value to auto-fill (from a passing "Set value" action) */
+  setValues: Record<string, string>;
+  hideSubmit: boolean;
+  redirectUrl: string | null;
+  /** first matching jump rule tied to `fromStep`, else null (caller falls through) */
+  resolveJump: (fromStep: string) => string | null;
+}
+
+/** A Plate logicBlock node, as persisted in forms.content. */
+export interface LogicBlockNode {
+  type: "logicBlock";
+  id: string;
+  when: ConditionGroup;
+  actions: Action[];
+  elseActions?: Action[];
+  children: [{ text: "" }];
+}

--- a/src/lib/server-fn/custom-domain-view-rsc.impl.tsx
+++ b/src/lib/server-fn/custom-domain-view-rsc.impl.tsx
@@ -3,6 +3,7 @@ import type { Value } from "platejs";
 
 import { transformPlateForPreview } from "@/lib/editor/transform-plate-for-preview";
 import type { PreviewStepResult } from "@/lib/editor/transform-plate-for-preview";
+import { buildFormLogic } from "@/lib/logic/build-form-logic";
 import { applyFormCacheHeaders } from "@/lib/server-fn/cdn-cache";
 import { isAppHost } from "@/lib/server-fn/custom-domain-loader";
 import {
@@ -42,6 +43,9 @@ const buildPayload = async (base: Awaited<ReturnType<typeof loadFormForCustomDom
     : [];
   const preloadModuleUrls = await getFieldChunkUrls(firstStepFieldTypes);
 
+  // Card-mode logic payload (this path renders un-chunked card steps).
+  const logic = base.form ? buildFormLogic(base.form.content as Value, steps, false) : null;
+
   return {
     ...base,
     steps: stepComponents,
@@ -49,6 +53,7 @@ const buildPayload = async (base: Awaited<ReturnType<typeof loadFormForCustomDom
     thankYou,
     header,
     preloadModuleUrls,
+    logic,
   };
 };
 

--- a/src/lib/server-fn/public-form-view-rsc.impl.tsx
+++ b/src/lib/server-fn/public-form-view-rsc.impl.tsx
@@ -25,6 +25,7 @@ import type {
 } from "@/lib/editor/transform-plate-for-preview";
 import { extractFormHeader } from "@/lib/editor/transform-plate-to-form";
 import type { PlateFormField } from "@/lib/editor/transform-plate-to-form";
+import { buildFormLogic } from "@/lib/logic/build-form-logic";
 import { applyFormCacheHeaders } from "@/lib/server-fn/cdn-cache";
 import { getFieldChunkUrls } from "@/lib/server-fn/field-chunk-manifest.server";
 import { getPublishedFormByShortId } from "@/lib/server-fn/public-form-view";
@@ -407,6 +408,12 @@ export const runPublicFormViewRSC = async (data: { shortId: string }) => {
     : [];
   const preloadModuleUrls = await getFieldChunkUrls(firstStepFieldTypes);
 
+  // Conditional-logic payload (plain JSON) so the public renderer enforces the same
+  // visibility/jumps/set-value/hide-submit the builder preview does. null when no content.
+  const logic = base.form
+    ? buildFormLogic(base.form.content as Value, steps, isFieldByField)
+    : null;
+
   return {
     ...base,
     steps: stepComponents,
@@ -415,5 +422,6 @@ export const runPublicFormViewRSC = async (data: { shortId: string }) => {
     header,
     preloadModuleUrls,
     formHeaderIconColor,
+    logic,
   };
 };

--- a/src/lib/server-fn/public-submissions.ts
+++ b/src/lib/server-fn/public-submissions.ts
@@ -19,6 +19,7 @@ import {
   transformPlateStateToFormElements,
 } from "@/lib/editor/transform-plate-to-form";
 import type { ErrorCode } from "@/lib/errors/codes";
+import { buildVisibleSchema, sanitizeSubmission } from "@/lib/logic/sanitize-submission";
 import { isServerPlan } from "./plan-helpers";
 import { recordOwnerSubmissionNotification } from "./notifications-helpers.server";
 import { sendFormSubmissionNotification, sendRespondentConfirmation } from "@/integrations/email";
@@ -228,8 +229,7 @@ export const createPublicSubmission = createServerFn({ method: "POST" })
       }
     }
 
-    // Shape-only sanitize for drafts: strip keys not on published form. Final submits
-    // enforce shape via client Zod schema, so skip the transform on the hot path.
+    // Shape-only sanitize for drafts: strip keys not on published form.
     let sanitizedData = data.data;
     if (!data.isCompleted && version?.content) {
       const allowed = getAllowedFieldNames(form.lastPublishedVersionId, version.content as Value);
@@ -238,6 +238,26 @@ export const createPublicSubmission = createServerFn({ method: "POST" })
           Object.entries(data.data).filter(([k]) => allowed.has(k)),
         );
       }
+    }
+
+    // Completed submits: authoritative conditional-logic pass. Re-run the engine against the
+    // published content + submitted answers, strip answers for server-hidden fields, then
+    // validate the visible set against the effective-required schema. Don't trust the client.
+    if (data.isCompleted && version?.content) {
+      const publishedContent = version.content as Value;
+      const { data: cleaned } = sanitizeSubmission(publishedContent, data.data);
+      const result = v.safeParse(buildVisibleSchema(publishedContent, data.data), cleaned);
+      if (!result.success) {
+        throw createError({
+          code: "submissions/invalid" satisfies ErrorCode,
+          status: 400,
+          message: "Submission failed validation",
+          why: "Submitted answers don't satisfy the published form's visible/required fields",
+          fix: "Complete all required visible fields and resubmit",
+          internal: { issueCount: result.issues.length },
+        });
+      }
+      sanitizedData = cleaned;
     }
 
     const existing = data.draftId

--- a/src/routes/$slug.tsx
+++ b/src/routes/$slug.tsx
@@ -112,6 +112,7 @@ const CustomDomainSlugRoute = () => {
                 thankYou: loaderData.thankYou,
                 stepCount: loaderData.stepCount,
                 header: loaderData.header,
+                logic: loaderData.logic,
               }
             : undefined
         }

--- a/src/routes/f/$formId.tsx
+++ b/src/routes/f/$formId.tsx
@@ -119,6 +119,7 @@ const CustomDomainFormIdRoute = () => {
                 thankYou: loaderData.thankYou,
                 stepCount: loaderData.stepCount,
                 header: loaderData.header,
+                logic: loaderData.logic,
               }
             : undefined
         }

--- a/src/routes/forms/$shortId.tsx
+++ b/src/routes/forms/$shortId.tsx
@@ -135,6 +135,7 @@ const PublicFormRoute = () => {
                 stepCount: loaderData.stepCount,
                 header: loaderData.header,
                 formHeaderIconColor: loaderData.formHeaderIconColor,
+                logic: loaderData.logic,
               }
             : undefined
         }

--- a/src/routes/forms/-components/public-form-page.tsx
+++ b/src/routes/forms/-components/public-form-page.tsx
@@ -8,6 +8,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FormPreviewRSC } from "@/components/form-components/form-preview-rsc";
+import type { FormLogicValue } from "@/lib/logic/build-form-logic";
 import type { StepRSC } from "@/components/form-components/form-preview-rsc";
 import { BrandingFooter } from "./branding-footer";
 import { AlreadySubmitted, FormClosed } from "@/routes/forms/-components/form-closed";
@@ -93,6 +94,8 @@ interface PublicFormPageProps {
     header?: unknown;
     /** Icon bg color from Plate formHeader node; field-by-field only (card mode uses pre-rendered header). */
     formHeaderIconColor?: string | null;
+    /** Conditional-logic payload (plain JSON) for the public renderer. */
+    logic?: FormLogicValue | null;
   };
 }
 
@@ -605,6 +608,7 @@ const PublicFormMain = ({
       steps={rsc.steps}
       thankYou={(rsc.thankYou as string | null) ?? null}
       stepCount={rsc.stepCount}
+      logic={rsc.logic}
       header={hideTitle && !(form.cover || form.icon) ? null : rsc.header}
       onSubmit={handleSubmit}
       settings={settings}


### PR DESCRIPTION
Add If / Do / Else Do conditional logic blocks to the form builder:
- Pure isomorphic engine (src/lib/logic): operators, evaluate, ruleset extractor, server sanitizer + shared buildFormLogic.
- Actions: show / hide / require / set value / jump-to-step / hide-submit / redirect, with an Else Do (inverse) branch.
- Editor: logicBlock void Plate node with an inline token-pill builder (type-aware value controls: choice dropdown, number stepper, date/time picker), insertable via block menu and the / slash command.
- Runtime: visibility-driven rendering, dynamic required, history-stack navigation with jumps, auto-filled (read-only) set-value fields — wired into BOTH the builder preview and the public RSC renderer (incl. custom domains) via a server-computed logic payload.
- Server: authoritative enforcement in createPublicSubmission (strip hidden answers, force set-values, validate the visible field set).

Tests: engine/operators/extractor/sanitizer/reducer unit suites.