### PR TITLE
feat(logic): keyboard nav for logic blocks (Tab/Arrow between blocks)

### DIFF
--- a/src/components/editor/plugins/form-blocks-kit.tsx
+++ b/src/components/editor/plugins/form-blocks-kit.tsx
@@ -14,6 +14,7 @@ import { FormOptionItemElement } from "@/components/ui/form-option-item-node";
 import {
   findNextNonButtonPath,
   findPrevNonButtonPath,
+  insertParagraphAfterPath,
   moveToPath,
 } from "@/components/editor/plugins/form-blocks-utils";
 
@@ -905,21 +906,38 @@ const NavigationPlugin = createPlatePlugin({
     onKeyDown: ({ editor, event }) => {
       if (handleFormFieldEnter(editor, event)) return;
 
-      if (event.key !== "Tab") return;
+      const isLogicBlockNavigation =
+        event.key === "Tab" || event.key === "ArrowDown" || event.key === "ArrowUp";
+      if (!isLogicBlockNavigation) return;
 
       const block = editor.api.block();
       if (!block) return;
-      const [, path] = block;
+      const [node, path] = block;
+      const isLogicBlock = node.type === "logicBlock";
+      if (!isLogicBlock && event.key !== "Tab") return;
 
       event.preventDefault();
       event.stopPropagation();
       event.nativeEvent.stopImmediatePropagation();
 
-      const target = event.shiftKey
+      const goPrev = event.key === "ArrowUp" || (event.key === "Tab" && event.shiftKey);
+      const target = goPrev
         ? findPrevNonButtonPath(editor, path)
         : findNextNonButtonPath(editor, path);
 
-      if (target) moveToPath(editor, target);
+      if (target) {
+        moveToPath(editor, target);
+        editor.tf.focus();
+        return;
+      }
+
+      if (isLogicBlock && !goPrev) {
+        const at = insertParagraphAfterPath(editor, path);
+        setTimeout(() => {
+          editor.tf.select({ offset: 0, path: [...at, 0] });
+          editor.tf.focus();
+        }, 0);
+      }
     },
   },
 });

--- a/src/components/editor/plugins/form-blocks-utils.ts
+++ b/src/components/editor/plugins/form-blocks-utils.ts
@@ -58,6 +58,12 @@ export const findNextNonButtonPath = (editor: PlateEditor, currentPath: Path): P
   return null;
 };
 
+export const insertParagraphAfterPath = (editor: PlateEditor, path: Path): Path => {
+  const at = [path[0] + 1];
+  editor.tf.insertNodes({ type: "p", children: [{ text: "" }] } as TElement, { at });
+  return at;
+};
+
 export const findPrevNonButtonPath = (editor: PlateEditor, currentPath: Path): Path | null => {
   const children = editor.children as TElement[];
   const currentIndex = currentPath[0];

--- a/src/components/ui/logic-block-node.tsx
+++ b/src/components/ui/logic-block-node.tsx
@@ -501,6 +501,10 @@ export const LogicBlockElement = (props: PlateElementProps) => {
     [editor, element],
   );
 
+  // Cancel a still-pending deferred caret-focus if the block unmounts first.
+  const pendingNavFocus = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  React.useEffect(() => () => clearTimeout(pendingNavFocus.current), []);
+
   // Tab/Shift+Tab and Up/Down move to adjacent blocks like every other editor block. The inner
   // controls steal DOM focus, so the global NavigationPlugin (which reads the editor
   // selection) never fires for this void node - handle it here where the keydown bubbles
@@ -511,6 +515,15 @@ export const LogicBlockElement = (props: PlateElementProps) => {
       const isTab = event.key === "Tab";
       const isVerticalArrow = event.key === "ArrowDown" || event.key === "ArrowUp";
       if (!isTab && !isVerticalArrow) return;
+      // Arrow keys have native meaning inside the block's own controls: date/time/number
+      // input segments and opening a Select menu. Leave those to the focused control; only
+      // Tab is a deliberate block-level jump regardless of which control holds focus.
+      if (
+        isVerticalArrow &&
+        (event.target as HTMLElement).closest("input, textarea, [role='combobox']")
+      ) {
+        return;
+      }
       const path = editor.api.findPath(element);
       if (!path) return;
       event.preventDefault();
@@ -530,7 +543,7 @@ export const LogicBlockElement = (props: PlateElementProps) => {
         const at = insertParagraphAfterPath(editor, path);
         // Defer select+focus until the new paragraph has rendered; focusing a node that
         // isn't in the DOM yet no-ops, leaving no visible caret.
-        setTimeout(() => {
+        pendingNavFocus.current = setTimeout(() => {
           editor.tf.select({ offset: 0, path: [...at, 0] });
           editor.tf.focus();
         }, 0);

--- a/src/components/ui/logic-block-node.tsx
+++ b/src/components/ui/logic-block-node.tsx
@@ -17,6 +17,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  findNextNonButtonPath,
+  findPrevNonButtonPath,
+  insertParagraphAfterPath,
+  moveToPath,
+} from "@/components/editor/plugins/form-blocks-utils";
 import { transformPlateForPreview } from "@/lib/editor/transform-plate-for-preview";
 import { operatorNeedsOperand, operatorsForFieldType, OPERATOR_LABELS } from "@/lib/logic/labels";
 import { THANK_YOU_STEP } from "@/lib/logic/types";
@@ -495,6 +501,44 @@ export const LogicBlockElement = (props: PlateElementProps) => {
     [editor, element],
   );
 
+  // Tab/Shift+Tab and Up/Down move to adjacent blocks like every other editor block. The inner
+  // controls steal DOM focus, so the global NavigationPlugin (which reads the editor
+  // selection) never fires for this void node - handle it here where the keydown bubbles
+  // up from the focused control. Focus the editor afterwards so the destination's caret
+  // (text block) or selection ring (void block) is visible.
+  const handleBlockKeyDown = React.useCallback(
+    (event: React.KeyboardEvent) => {
+      const isTab = event.key === "Tab";
+      const isVerticalArrow = event.key === "ArrowDown" || event.key === "ArrowUp";
+      if (!isTab && !isVerticalArrow) return;
+      const path = editor.api.findPath(element);
+      if (!path) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const goPrev = event.key === "ArrowUp" || (isTab && event.shiftKey);
+      const target = goPrev
+        ? findPrevNonButtonPath(editor, path)
+        : findNextNonButtonPath(editor, path);
+      if (target) {
+        moveToPath(editor, target);
+        editor.tf.focus();
+        return;
+      }
+      // No block below (logic block is last before the submit button) - create an
+      // empty paragraph after it and drop the caret there so the author isn't stuck.
+      if (!goPrev) {
+        const at = insertParagraphAfterPath(editor, path);
+        // Defer select+focus until the new paragraph has rendered; focusing a node that
+        // isn't in the DOM yet no-ops, leaving no visible caret.
+        setTimeout(() => {
+          editor.tf.select({ offset: 0, path: [...at, 0] });
+          editor.tf.focus();
+        }, 0);
+      }
+    },
+    [editor, element],
+  );
+
   // Conditions
   const updateCondition = (index: number, next: Condition) =>
     patch({ when: { ...when, children: conditions.map((c, i) => (i === index ? next : c)) } });
@@ -549,9 +593,11 @@ export const LogicBlockElement = (props: PlateElementProps) => {
       <div
         contentEditable={false}
         role="presentation"
+        onKeyDown={handleBlockKeyDown}
         className={cn(
           "flex flex-col gap-0.5 rounded-xl bg-muted/50 p-1.5",
-          selected && focused && "ring-2 ring-ring ring-offset-2",
+          // Soft selection halo matching form fields (no hard ring-offset border).
+          selected && focused && "ring-[3px] ring-ring/50",
         )}
       >
         {/* IF — conditions */}


### PR DESCRIPTION
- NavigationPlugin handles ArrowUp/ArrowDown for logic blocks, not just Tab
- insertParagraphAfterPath escape hatch when logic block is last before submit
- soft selection halo (ring/50) matching form fields