### PR TITLE
feat(theme): form header, color picker & customize sidebar redesign

### DIFF
--- a/src/components/form-components/form-preview-from-plate.tsx
+++ b/src/components/form-components/form-preview-from-plate.tsx
@@ -222,29 +222,38 @@ const PreviewFormHeader = ({
   if (layout === "editor") {
     return (
       <div ref={headerRef} className="mb-7 w-full">
-        {hasCover && renderCover()}
+        {/* Cover sits in a page-width container so "fit" (calc(100% + 56px)) tracks the form
+            width, not the full pane; "fill" still breaks out to 100vw via its var fallback. */}
+        {hasCover && (
+          <div className="mx-auto w-full" style={{ maxWidth: PAGE_MAX_WIDTH.editor }}>
+            {renderCover()}
+          </div>
+        )}
         <div
           className="mx-auto w-full px-8 md:px-0"
           style={{ maxWidth: PAGE_MAX_WIDTH.editor }}
           data-bf-form-container
         >
           {hasIcon && renderIcon()}
-          {/* Spacer matching the editor's hover toolbar (Customize / Add icon / Add cover buttons + margin) */}
+          {/* Mirrors the editor's hover toolbar (form-header-node.tsx): carries no bottom gap, the
+              title owns its top gap (mt-4). The h-8 reserves the toolbar's button row only when the
+              editor would show one (missing cover/icon); with both present it is empty (0-height) so
+              the icon's mb-1 and the title's mt-4 collapse to a constant 16px — matching the editor. */}
           <div
             className={cn(
-              "mb-2 flex gap-1",
+              "flex gap-1",
               !hasCover && !hasIcon && "mt-8 sm:mt-12",
               hasCover && !hasIcon && "mt-4",
-              !hasCover && hasIcon && "mt-0",
+              hasIcon && "mt-0",
             )}
           >
-            <div className="h-8" />
+            {(!hasCover || !hasIcon) && <div className="h-8" />}
           </div>
           {hasTitle && (
             <h1
               data-bf-title
               style={{ textWrap: "pretty" }}
-              className="font-serif text-4xl font-light -tracking-[0.03em] text-foreground sm:text-[48px]"
+              className="mt-4 font-serif text-4xl font-light -tracking-[0.03em] text-foreground sm:text-[48px]"
             >
               {title}
             </h1>
@@ -257,7 +266,12 @@ const PreviewFormHeader = ({
   // For public layout, no negative margin tricks needed
   return (
     <div ref={headerRef} className="mb-7 w-full">
-      {hasCover && renderCover()}
+      {/* Cover in a page-width container so "fit" tracks form width; "fill" still hits 100vw. */}
+      {hasCover && (
+        <div className="mx-auto w-full" style={{ maxWidth: PAGE_MAX_WIDTH.public }}>
+          {renderCover()}
+        </div>
+      )}
 
       <div
         className="mx-auto px-4"
@@ -270,7 +284,7 @@ const PreviewFormHeader = ({
             <h1
               data-bf-title
               style={{ textWrap: "pretty" }}
-              className={`font-serif text-4xl font-light -tracking-[0.03em] text-foreground sm:text-[48px] ${hasIcon ? "mt-3 sm:mt-4" : "mt-6 sm:mt-8"}`}
+              className={`font-serif text-4xl font-light -tracking-[0.03em] text-foreground sm:text-[48px] ${hasIcon ? "mt-3" : "mt-6 sm:mt-8"}`}
             >
               {title}
             </h1>

--- a/src/components/ui/form-header-node.tsx
+++ b/src/components/ui/form-header-node.tsx
@@ -720,23 +720,37 @@ const HeaderCoverSection = ({
   const hasImage = !!cover && !cover.startsWith("#");
   const position = repositioning ? draftPosition : coverPosition;
 
-  // The pill is portaled to <body> and positioned against the VIEWPORT (the cover is
-  // full-bleed and overflows past the viewport, so its own right edge is off-screen).
+  // The pill is portaled to <body> and anchored to the cover's visible bottom-right corner.
+  // We clamp to the editor viewport's right edge (which shrinks when the Customize sidebar
+  // opens) so the pill never lands on top of the sidebar: Fill is clipped to that edge, Fit
+  // rides 12px inside the cover; either way it stays 16px off the viewport at minimum.
   const [coverHovered, setCoverHovered] = useState(false);
   const [pillTop, setPillTop] = useState(0);
+  const [pillRight, setPillRight] = useState(16);
   const showPill = coverHovered || repositioning || coverPopoverOpen;
   const measurePill = useCallback(() => {
     const el = coverRef.current;
-    if (el) setPillTop(el.getBoundingClientRect().bottom);
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    setPillTop(rect.bottom);
+    const editorRight = el.closest(".slate-editor")?.getBoundingClientRect().right;
+    const visibleRight = Math.min(rect.right, editorRight ?? rect.right);
+    setPillRight(Math.max(16, window.innerWidth - visibleRight + 12));
   }, []);
   useEffect(() => {
     if (!showPill) return;
     measurePill();
     window.addEventListener("scroll", measurePill, true);
     window.addEventListener("resize", measurePill);
+    // Sidebar open/close reflows the editor pane without a window resize, and a full-bleed
+    // cover's own size doesn't change — observe the pane so the pill re-measures regardless.
+    const pane = coverRef.current?.closest(".slate-editor") ?? coverRef.current;
+    const ro = pane ? new ResizeObserver(measurePill) : null;
+    if (pane && ro) ro.observe(pane);
     return () => {
       window.removeEventListener("scroll", measurePill, true);
       window.removeEventListener("resize", measurePill);
+      ro?.disconnect();
     };
   }, [showPill, measurePill]);
 
@@ -804,9 +818,9 @@ const HeaderCoverSection = ({
             and public render share one definition. */}
       </div>
 
-      {/* Change | Reposition (Figma 25424:13193) — portaled to <body> and fixed against the
-          viewport's right edge (the full-bleed cover overflows off-screen), anchored to the
-          cover's measured bottom. createPortal keeps it inside the Popover's React context. */}
+      {/* Change | Reposition (Figma 25424:13193) — portaled to <body>, fixed and anchored to
+          the cover's measured bottom-right corner (see measurePill for the Fit/Fill clamp).
+          createPortal keeps it inside the Popover's React context. */}
       {showPill &&
         typeof document !== "undefined" &&
         createPortal(
@@ -816,7 +830,7 @@ const HeaderCoverSection = ({
             style={{
               position: "fixed",
               top: pillTop - 12,
-              right: 16,
+              right: pillRight,
               transform: "translateY(-100%)",
               zIndex: 50,
             }}

--- a/src/lib/server-fn/public-form-view-rsc.impl.tsx
+++ b/src/lib/server-fn/public-form-view-rsc.impl.tsx
@@ -291,28 +291,34 @@ export const renderHeaderComponent = async ({
 
   return createCompositeComponent(() => (
     <div className="mb-4 w-full sm:mb-8">
-      {coverIsHex && cover && (
-        <div className={coverClass} data-bf-cover style={{ backgroundColor: cover }} />
-      )}
-      {coverIsUrl && cover && (
-        <div className={cn(coverClass, "overflow-hidden bg-muted")} data-bf-cover>
-          {tinted && (
-            <div className="pointer-events-none absolute inset-0 z-1 bg-primary opacity-50 mix-blend-color" />
+      {/* Cover in a page-width container so "fit" (calc(100% + 56px)) tracks the form width,
+          not the full page; "fill" still breaks out to 100vw via its var fallback. */}
+      {hasCover && (
+        <div className="mx-auto w-full" style={{ maxWidth: PAGE_MAX_WIDTH }}>
+          {coverIsHex && cover && (
+            <div className={coverClass} data-bf-cover style={{ backgroundColor: cover }} />
           )}
-          <img
-            src={vercelImg(cover, 1200)}
-            srcSet={vercelSrcSet(cover, [...COVER_SRCSET_WIDTHS])}
-            sizes="100vw"
-            alt="Form cover"
-            width={1200}
-            height={200}
-            decoding="async"
-            fetchPriority="high"
-            className={cn(
-              "size-full object-cover",
-              tinted && "relative z-0 brightness-60 grayscale",
-            )}
-          />
+          {coverIsUrl && cover && (
+            <div className={cn(coverClass, "overflow-hidden bg-muted")} data-bf-cover>
+              {tinted && (
+                <div className="pointer-events-none absolute inset-0 z-1 bg-primary opacity-50 mix-blend-color" />
+              )}
+              <img
+                src={vercelImg(cover, 1200)}
+                srcSet={vercelSrcSet(cover, [...COVER_SRCSET_WIDTHS])}
+                sizes="100vw"
+                alt="Form cover"
+                width={1200}
+                height={200}
+                decoding="async"
+                fetchPriority="high"
+                className={cn(
+                  "size-full object-cover",
+                  tinted && "relative z-0 brightness-60 grayscale",
+                )}
+              />
+            </div>
+          )}
         </div>
       )}
       <div className="mx-auto px-4" style={{ maxWidth: PAGE_MAX_WIDTH }} data-bf-form-container>
@@ -352,7 +358,9 @@ export const renderHeaderComponent = async ({
               style={{ textWrap: "pretty" }}
               className={cn(
                 "font-serif text-4xl font-light -tracking-[0.03em] text-foreground sm:text-[48px]",
-                hasIcon ? "mt-3 sm:mt-4" : "mt-6 sm:mt-8",
+                // With an icon: 12px here + the icon's 4px mb = 16px avatar→title, matching the editor
+                // (flex items don't margin-collapse, so the editor's mt-4-only gap is split here).
+                hasIcon ? "mt-3" : "mt-6 sm:mt-8",
               )}
             >
               {title}

--- a/src/lib/theme/generate-theme-css.ts
+++ b/src/lib/theme/generate-theme-css.ts
@@ -188,10 +188,16 @@ const buildModeAgnosticEntries = (
     }
   }
 
-  // Cover width: "fit" contains the cover to the form width (so a radius rounds visible corners);
-  // "fill"/unset stays full-bleed via the styles.css var() fallbacks.
+  // Cover width: "fit" bleeds 28px past the form width on each side (Figma) into the editor
+  // gutter (always >= 64px); "fill"/unset stays full-bleed via the styles.css var() fallbacks.
   if (customization.coverWidth === "fit") {
-    entries.push(["--bf-cover-w", "100%"], ["--bf-cover-mx", "0px"], ["--bf-cover-x", "0px"]);
+    entries.push(
+      ["--bf-cover-w", "calc(100% + 56px)"],
+      ["--bf-cover-mx", "-28px"],
+      ["--bf-cover-x", "0px"],
+      // Fit is a clean rounded card (Figma) — suppress the bottom fade/blur dissolve.
+      ["--bf-cover-fade", "none"],
+    );
   }
 
   return entries;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -791,8 +791,8 @@
   border-radius: var(--bf-cover-radius, 0);
   overflow: hidden;
   /* Full-bleed by default (var fallbacks reproduce the w-screen breakout). Cover width "fit"
-     makes generate-theme-css emit these vars to contain the cover to the form width, so a cover
-     radius rounds corners that are actually on-screen. */
+     makes generate-theme-css emit these vars to bleed the cover 28px past the form width on
+     each side (into the editor gutter), so a radius rounds corners that are on-screen. */
   width: var(--bf-cover-w, 100vw);
   margin-left: var(--bf-cover-mx, -50vw);
   margin-right: var(--bf-cover-mx, -50vw);
@@ -810,6 +810,8 @@
    and the public render (every cover carries [data-bf-cover] and is position: relative). */
 [data-bf-cover]::after {
   content: "";
+  /* Cover width "fit" suppresses the fade (clean rounded card, Figma); fill keeps it. */
+  display: var(--bf-cover-fade, block);
   position: absolute;
   inset-inline: 0;
   bottom: 0;
@@ -820,6 +822,7 @@
 }
 [data-bf-cover]::before {
   content: "";
+  display: var(--bf-cover-fade, block);
   position: absolute;
   inset-inline: 0;
   bottom: 0;


### PR DESCRIPTION
Redesigns the form header (cover/avatar/title), the color picker, and the customize sidebar.

### Latest: cover "fit" width treatment
- **"Fit" cover** bleeds 28px past the form width on each side (Figma) and renders as a clean rounded card — the bottom fade/blur dissolve is suppressed via a new `--bf-cover-fade` var.
- Contained to the page width in the **preview** and **published** render, not just the editor (previously the cover sat outside the page-width container there and looked full-bleed).
- **Change | Reposition** pill anchored to the cover's visible bottom-right corner, clamped to the editor pane so it no longer overlaps the Customize sidebar.
- Avatar→title spacing matched to **16px** across editor, preview, and live form.

"Fill" still breaks out to 100vw via the styles.css var fallbacks.

The earlier commits in this branch cover the broader form-header / color-picker / customize-sidebar redesign.