### PR TITLE
perf(editor): stop collection over-subscriptions re-rendering on edit

### DIFF
--- a/src/collections/init.ts
+++ b/src/collections/init.ts
@@ -89,6 +89,10 @@ export const initCollections = (queryClient: QueryClient, serverFns: ServerFns) 
       const realKeys = Object.keys(changes).filter((k) => k !== "updatedAt");
       if (realKeys.length === 0) return { refetch: false };
       const isCustomizationOnly = realKeys.length === 1 && realKeys[0] === "customization";
+      // Editor-body save: persist, but skip refetch — it'd pull the server's fresh updatedAt and
+      // reshuffle/re-render the sidebar (sorts by updatedAt) on every keystroke. Recency reconciles
+      // on the next natural refetch (focus/remount/staleTime). Optimistic content holds, no flash-back.
+      const isContentOnly = realKeys.length === 1 && realKeys[0] === "content";
 
       const data = stripNulls({
         id: m.original.id,
@@ -99,7 +103,7 @@ export const initCollections = (queryClient: QueryClient, serverFns: ServerFns) 
       // Skip per-handler refetch (`{ refetch: false }`) — would fire N concurrent refetches during a drag; bucket refetches once after the call lands.
       if (!isCustomizationOnly) {
         await serverFns.updateForm(data);
-        return;
+        return isContentOnly ? { refetch: false } : undefined;
       }
 
       const formId = m.original.id;

--- a/src/components/form-builder/share-summary-sidebar.tsx
+++ b/src/components/form-builder/share-summary-sidebar.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader } from "@/components/ui/sidebar";
 import { SidebarSection } from "@/components/ui/sidebar-section";
 import { Tabs, TabsIndicator, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useForm } from "@/hooks/use-live-hooks";
+import { useFormShareMeta } from "@/hooks/use-live-hooks";
 import { useEditorSidebar } from "@/hooks/use-editor-sidebar";
 import { publishForm } from "@/hooks/use-form-versions";
 import { getFormListings } from "@/collections";
@@ -44,7 +44,7 @@ interface ShareSummarySidebarProps {
 
 export const ShareSummarySidebar = ({ formId }: ShareSummarySidebarProps) => {
   const { closeSidebar } = useEditorSidebar();
-  const { data: savedDocs } = useForm(formId);
+  const { data: savedDocs } = useFormShareMeta(formId);
   const doc = savedDocs?.[0];
   const { data: session } = useSession();
   const orgId = session?.session?.activeOrganizationId ?? undefined;

--- a/src/components/ui/app-header.tsx
+++ b/src/components/ui/app-header.tsx
@@ -23,7 +23,7 @@ import { TextSwap } from "@/components/transitions/text-swap";
 import { toggleFavoriteLocal, updateFormStatus } from "@/collections";
 import { useEditorSidebar } from "@/hooks/use-editor-sidebar";
 import { discardChanges, publishForm, useHasUnpublishedChanges } from "@/hooks/use-form-versions";
-import { useForm, useIsFavorite, useWorkspace } from "@/hooks/use-live-hooks";
+import { useFormMeta, useWorkspace } from "@/hooks/use-live-hooks";
 import { useSession } from "@/lib/auth/auth-client";
 import { HOTKEYS, formatForDisplay } from "@/lib/hotkeys";
 import { cn } from "@/lib/utils";
@@ -106,7 +106,7 @@ export const AppHeader = ({ isDistractionHidden = false }: AppHeaderProps) => {
   };
 
   const { data: workspace } = useWorkspace(workspaceId);
-  const { data: savedDocs, isLoading: isLoadingSavedDocs } = useForm(formId);
+  const { data: savedDocs, isLoading: isLoadingSavedDocs } = useFormMeta(formId);
 
   const hasUnpublishedChanges = useHasUnpublishedChanges(formId);
   const hasPublishedVersion = !!savedDocs?.[0]?.lastPublishedVersionId;
@@ -119,8 +119,6 @@ export const AppHeader = ({ isDistractionHidden = false }: AppHeaderProps) => {
 
   const isDiscarding = workflowState === "discarding";
   const isPublishing = workflowState === "publishing";
-
-  useIsFavorite(session?.user?.id, formId);
 
   const isLeftSidebarOpen = state === "expanded";
 
@@ -494,7 +492,7 @@ const buildFormBuilderMenuItems = ({
 
 interface HeaderBreadcrumbProps {
   workspace: ReturnType<typeof useWorkspace>["data"];
-  savedDoc: NonNullable<ReturnType<typeof useForm>["data"]>[0];
+  savedDoc: NonNullable<ReturnType<typeof useFormMeta>["data"]>[0];
   workspaceId: string | undefined;
   formId: string | undefined;
   isEditRoute: boolean;
@@ -703,7 +701,7 @@ interface FormBuilderHeaderActionsProps {
   activeMenu: ActiveMenu;
   workspaceId: string | undefined;
   formId: string | undefined;
-  savedDocs: ReturnType<typeof useForm>["data"];
+  savedDocs: ReturnType<typeof useFormMeta>["data"];
   menuItems: MenuItem[];
   onTogglePreview: () => void;
   onToggleCustomizeSidebar: () => void;

--- a/src/components/ui/customize-sidebar.tsx
+++ b/src/components/ui/customize-sidebar.tsx
@@ -31,7 +31,7 @@ import { localFormCollection } from "@/collections/local/form";
 import { useEditorTheme } from "@/contexts/editor-theme-context";
 import { useEditorSidebar } from "@/hooks/use-editor-sidebar";
 import { useFileUpload } from "@/hooks/use-file-upload";
-import { useForm, useLocalForm } from "@/hooks/use-live-hooks";
+import { useFormCustomizationMeta, useLocalFormCustomization } from "@/hooks/use-live-hooks";
 import { FONT_REGISTRY } from "@/lib/theme/font-registry";
 import { TOKEN_NAMES } from "@/lib/theme/generate-theme-css";
 import { loadGoogleFont } from "@/lib/theme/load-google-font";
@@ -225,8 +225,8 @@ export const CustomizeSidebar = ({ formId, isLocal }: CustomizeSidebarProps) => 
   const { closeSidebar } = useEditorSidebar();
   const { updateHeaderMedia } = useEditorTheme();
   const { setTheme } = useTheme();
-  const cloudForm = useForm(isLocal ? undefined : formId);
-  const localFormResult = useLocalForm(isLocal ? formId : undefined);
+  const cloudForm = useFormCustomizationMeta(isLocal ? undefined : formId);
+  const localFormResult = useLocalFormCustomization(isLocal ? formId : undefined);
   const formResult = isLocal ? localFormResult : cloudForm;
   const formDoc = formResult.data?.[0] ?? null;
   const collection = (isLocal ? localFormCollection : getFormListings()) as ReturnType<

--- a/src/components/ui/form-option-item-node.tsx
+++ b/src/components/ui/form-option-item-node.tsx
@@ -2,8 +2,8 @@ import type { TElement } from "platejs";
 import type { PlateElementProps } from "platejs/react";
 
 import { DndPlugin } from "@platejs/dnd";
-import { PlateElement, useEditorRef, useEditorVersion, usePluginOption } from "platejs/react";
-import { useLayoutEffect, useMemo } from "react";
+import { PlateElement, useEditorRef, useEditorSelector, usePluginOption } from "platejs/react";
+import { useLayoutEffect } from "react";
 
 import { Checkbox } from "@/components/ui/checkbox";
 import { CheckCheckIcon, ChevronDownIcon } from "@/components/ui/icons";
@@ -86,57 +86,65 @@ export const FormOptionItemElement = ({ children, ...props }: PlateElementProps)
   const editor = useEditorRef();
   const isDark = useFormIsDark();
 
-  // Subscribe to every editor change so optionIndex tracks reorders. props.path (useNodePath)
-  // doesn't update on reorder (slate-react memoizes by identity); look up index by node identity.
-  const version = useEditorVersion();
-  const focusIndex = editor.selection?.focus.path[0];
+  // Narrow subscription: re-render only when this option's derived state changes, not on every
+  // keystroke. Index by node identity since props.path (useNodePath) doesn't update on reorder
+  // (slate-react memoizes by identity). Shallow equality skips re-renders when all 4 are unchanged.
+  const { optionIndex, isLastInGroup, isGroupFocused, isStandalone } = useEditorSelector(
+    (ed) => {
+      const nodes = ed.children as TElement[];
+      const pathIdx = nodes.indexOf(element);
+      if (pathIdx < 0)
+        return {
+          optionIndex: 0,
+          isLastInGroup: false,
+          isGroupFocused: false,
+          isStandalone: false,
+        };
 
-  const { optionIndex, isLastInGroup, isGroupFocused, isStandalone } = useMemo(() => {
-    const nodes = editor.children as TElement[];
-    const pathIdx = nodes.indexOf(element);
-    if (pathIdx < 0)
-      return {
-        optionIndex: 0,
-        isLastInGroup: false,
-        isGroupFocused: false,
-        isStandalone: false,
-      };
-
-    let idx = 0;
-    for (let i = pathIdx - 1; i >= 0; i--) {
-      if (nodes[i]?.type === "formOptionItem") idx++;
-      else break;
-    }
-
-    const nextNode = nodes[pathIdx + 1];
-    const isLast = !nextNode || nextNode.type !== "formOptionItem";
-
-    // Standalone = no formLabel above AND no sibling option — decides whether to anchor the
-    // required badge inline (grouped options' badge floats over the formLabel instead).
-    const prevNode = pathIdx > 0 ? nodes[pathIdx - 1] : null;
-    const standalone = idx === 0 && isLast && prevNode?.type !== "formLabel";
-
-    let groupFocused = false;
-    if (focusIndex !== undefined) {
-      const focusNode = nodes[focusIndex];
-      if (focusNode?.type === "formOptionItem") {
-        let groupStart = pathIdx;
-        while (groupStart > 0 && nodes[groupStart - 1]?.type === "formOptionItem") groupStart--;
-        let groupEnd = pathIdx;
-        while (groupEnd < nodes.length - 1 && nodes[groupEnd + 1]?.type === "formOptionItem")
-          groupEnd++;
-        groupFocused = focusIndex >= groupStart && focusIndex <= groupEnd;
+      let idx = 0;
+      for (let i = pathIdx - 1; i >= 0; i--) {
+        if (nodes[i]?.type === "formOptionItem") idx++;
+        else break;
       }
-    }
 
-    return {
-      optionIndex: idx,
-      isLastInGroup: isLast,
-      isGroupFocused: groupFocused,
-      isStandalone: standalone,
-    };
-    // eslint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps -- version forces recompute on every editor change
-  }, [editor, element, focusIndex, version]);
+      const nextNode = nodes[pathIdx + 1];
+      const isLast = !nextNode || nextNode.type !== "formOptionItem";
+
+      // Standalone = no formLabel above AND no sibling option — decides whether to anchor the
+      // required badge inline (grouped options' badge floats over the formLabel instead).
+      const prevNode = pathIdx > 0 ? nodes[pathIdx - 1] : null;
+      const standalone = idx === 0 && isLast && prevNode?.type !== "formLabel";
+
+      let groupFocused = false;
+      const focusIndex = ed.selection?.focus.path[0];
+      if (focusIndex !== undefined) {
+        const focusNode = nodes[focusIndex];
+        if (focusNode?.type === "formOptionItem") {
+          let groupStart = pathIdx;
+          while (groupStart > 0 && nodes[groupStart - 1]?.type === "formOptionItem") groupStart--;
+          let groupEnd = pathIdx;
+          while (groupEnd < nodes.length - 1 && nodes[groupEnd + 1]?.type === "formOptionItem")
+            groupEnd++;
+          groupFocused = focusIndex >= groupStart && focusIndex <= groupEnd;
+        }
+      }
+
+      return {
+        optionIndex: idx,
+        isLastInGroup: isLast,
+        isGroupFocused: groupFocused,
+        isStandalone: standalone,
+      };
+    },
+    [element],
+    {
+      equalityFn: (a, b) =>
+        a.optionIndex === b.optionIndex &&
+        a.isLastInGroup === b.isLastInGroup &&
+        a.isGroupFocused === b.isGroupFocused &&
+        a.isStandalone === b.isStandalone,
+    },
+  );
 
   // Suppress "Add option" ghost during any drag — Plate snapshots the option DOM for the
   // preview and would capture a visible ghost row alongside it.

--- a/src/components/ui/logic-block-node.tsx
+++ b/src/components/ui/logic-block-node.tsx
@@ -4,7 +4,7 @@ import type { PlateElementProps } from "platejs/react";
 import {
   PlateElement,
   useEditorRef,
-  useEditorVersion,
+  useEditorSelector,
   useFocused,
   useSelected,
 } from "platejs/react";
@@ -91,6 +91,22 @@ const collectStepOptions = (editor: ReturnType<typeof useEditorRef>): Option[] =
   options.push({ value: THANK_YOU_STEP, label: "Thank You page" });
   return options;
 };
+
+/** Stable key over everything the pickers render, so useEditorSelector skips re-renders on
+ * unrelated edits (e.g. typing in a label elsewhere). Covers field name/label/type/array-flag
+ * + choice options, plus each step's value/label. JSON-encoded (not delimiter-joined) so
+ * user-controlled labels containing separators can't collide into a false-equal key. */
+const fieldsAndStepsKey = ({
+  fields,
+  stepOptions,
+}: {
+  fields: FieldInfo[];
+  stepOptions: Option[];
+}): string =>
+  JSON.stringify([
+    fields.map((f) => [f.name, f.label, f.fieldType, f.isFieldArray, f.options ?? []]),
+    stepOptions.map((o) => [o.value, o.label]),
+  ]);
 
 // ── Token primitives (Figma: white pill, elevation-sm, 8px radius, 32px tall) ──
 
@@ -484,9 +500,6 @@ export const LogicBlockElement = (props: PlateElementProps) => {
   const focused = useFocused();
   const blockRef = React.useRef<HTMLDivElement>(null);
 
-  // Re-render on editor edits so renamed fields / new steps update pickers.
-  useEditorVersion();
-
   // Navigating into the block (keyboard selection from an adjacent block) lands focus on
   // the first control instead of leaving the whole block ring-selected. Layout effect so
   // the control focuses before paint, avoiding a one-frame flash of the selection ring.
@@ -502,14 +515,20 @@ export const LogicBlockElement = (props: PlateElementProps) => {
   const elseActions = (element.elseActions as Action[] | undefined) ?? [];
   const conditions = when.children;
 
-  const fields = collectFields(editor);
+  // Narrow subscription: pickers depend only on the field list + step options, not on every
+  // keystroke. Both are fresh arrays per run, so equality compares a serialized key (field
+  // name/label/type/array-flag/choices + step value/label) — re-render only when those change.
+  const { fields, stepOptions } = useEditorSelector(
+    () => ({ fields: collectFields(editor), stepOptions: collectStepOptions(editor) }),
+    [editor],
+    { equalityFn: (a, b) => fieldsAndStepsKey(a) === fieldsAndStepsKey(b) },
+  );
   const sources = fields.filter((f) => !f.isFieldArray); // Wave 1: repeatable can't be a source
   const sourceOptions = sources.map((f) => ({ value: f.name, label: f.label }));
   const fieldOptions = fields.map((f) => ({ value: f.name, label: f.label }));
   const setTargetOptions = fields
     .filter((f) => SCALAR_FIELD_TYPES.has(f.fieldType) && !f.isFieldArray)
     .map((f) => ({ value: f.name, label: f.label }));
-  const stepOptions = collectStepOptions(editor);
   const fieldTypeByName = new Map(fields.map((f) => [f.name, f.fieldType]));
   const fieldChoicesByName = new Map(fields.map((f) => [f.name, f.options ?? []]));
 

--- a/src/components/ui/page-break-node.tsx
+++ b/src/components/ui/page-break-node.tsx
@@ -2,7 +2,7 @@ import type { PlateElementProps } from "platejs/react";
 import {
   PlateElement,
   useEditorRef,
-  useEditorVersion,
+  useEditorSelector,
   useFocused,
   useReadOnly,
   useSelected,
@@ -36,24 +36,26 @@ export const PageBreakElement = (props: PlateElementProps) => {
 
   const isThankYouPage = (element.isThankYouPage as boolean) ?? false;
 
-  // Subscribe to editor changes so the page number tracks reorders/deletes. Plate memoizes by
-  // identity — without this version dep, a pageBreak after a deleted sibling shows a stale number.
-  useEditorVersion();
-  const pageNumber = (() => {
-    const path = editor.api.findPath(element);
-    if (!path) return 2;
+  // Narrow subscription: re-render only when this pageBreak's own number changes, not on every
+  // keystroke. Returning a primitive lets Plate skip re-renders when the count is unchanged.
+  const pageNumber = useEditorSelector(
+    (ed) => {
+      const path = ed.api.findPath(element);
+      if (!path) return 2;
 
-    let count = 2; // Page 1 is before first pageBreak, so this starts at 2
-    for (const [, nodePath] of editor.api.nodes({
-      at: [],
-      match: { type: "pageBreak" },
-    })) {
-      if (nodePath[0] < path[0]) {
-        count++;
+      let count = 2; // Page 1 is before first pageBreak, so this starts at 2
+      for (const [, nodePath] of ed.api.nodes({
+        at: [],
+        match: { type: "pageBreak" },
+      })) {
+        if (nodePath[0] < path[0]) {
+          count++;
+        }
       }
-    }
-    return count;
-  })();
+      return count;
+    },
+    [element],
+  );
   const handleThankYouToggle = (checked: boolean) => {
     const path = editor.api.findPath(element);
     if (!path) return;

--- a/src/hooks/use-live-hooks.ts
+++ b/src/hooks/use-live-hooks.ts
@@ -69,6 +69,26 @@ export const useOrgForms = (_organizationId?: string) =>
       .orderBy(({ form }) => form.updatedAt, "desc");
   }, []);
 
+/** Header/breadcrumb projection: meta fields only, no `content`. Keeps the app-header off the
+ * editor-content churn — typing the body changes `content` (excluded here) so this stays stable. */
+export const useFormMeta = (formId?: string) =>
+  useLiveQuery(
+    (q) => {
+      if (!formId || !isInitialized()) return undefined;
+      return q
+        .from({ form: getFormListings() })
+        .where(({ form }) => eq(form.id, formId))
+        .select(({ form }) => ({
+          id: form.id,
+          title: form.title,
+          status: form.status,
+          workspaceId: form.workspaceId,
+          lastPublishedVersionId: form.lastPublishedVersionId,
+        }));
+    },
+    [formId],
+  );
+
 /** formListings query, enriched with full detail (content, settings) on demand via TanStack Query. */
 export const useForm = (formId?: string) => {
   const result = useLiveQuery(
@@ -99,6 +119,68 @@ export const useLocalForm = (formId?: string) =>
     [formId],
   );
 
+/** Customize sidebar projection: only the fields it reads. Excludes `content` so editor typing
+ * doesn't re-render the sidebar. Cloud variant. */
+export const useFormCustomizationMeta = (formId?: string) =>
+  useLiveQuery(
+    (q) => {
+      if (!formId || !isInitialized()) return undefined;
+      return q
+        .from({ form: getFormListings() })
+        .where(({ form }) => eq(form.id, formId))
+        .select(({ form }) => ({
+          id: form.id,
+          customization: form.customization,
+          cover: form.cover,
+          icon: form.icon,
+        }));
+    },
+    [formId],
+  );
+
+/** Local-draft variant of [[useFormCustomizationMeta]] — same projection over localFormCollection. */
+export const useLocalFormCustomization = (formId?: string) =>
+  useLiveQuery(
+    (q) => {
+      if (!formId) return undefined;
+      return q
+        .from({ doc: localFormCollection })
+        .where(({ doc }) => eq(doc.id, formId))
+        .select(({ doc }) => ({
+          id: doc.id,
+          customization: doc.customization,
+          cover: doc.cover,
+          icon: doc.icon,
+        }));
+    },
+    [formId],
+  );
+
+/** Share/settings sidebar projection: meta + settings, no `content`. Keeps the share sidebar off
+ * editor-content churn. */
+export const useFormShareMeta = (formId?: string) =>
+  useLiveQuery(
+    (q) => {
+      if (!formId || !isInitialized()) return undefined;
+      return q
+        .from({ form: getFormListings() })
+        .where(({ form }) => eq(form.id, formId))
+        .select(({ form }) => ({
+          id: form.id,
+          title: form.title,
+          status: form.status,
+          icon: form.icon,
+          slug: form.slug,
+          shortId: form.shortId,
+          customDomainId: form.customDomainId,
+          customization: form.customization,
+          draftSettings: form.draftSettings,
+          liveSettings: form.liveSettings,
+        }));
+    },
+    [formId],
+  );
+
 export const useFavorites = (userId?: string) =>
   useLiveQuery(
     (q) => {
@@ -117,21 +199,6 @@ export const useFavorites = (userId?: string) =>
     [userId],
   );
 
-export const useIsFavorite = (userId?: string, formId?: string) => {
-  const { data } = useLiveQuery(
-    (q) => {
-      if (!userId || !formId || !isInitialized()) return undefined;
-      return q
-        .from({ fav: getFavorites() })
-        .where(({ fav }) => eq(fav.userId, userId))
-        .where(({ fav }) => eq(fav.formId, formId))
-        .select(({ fav }) => ({ id: fav.id }));
-    },
-    [userId, formId],
-  );
-  return data !== undefined && data.length > 0;
-};
-
 /** Fetches favorites + listings separately, combines them. */
 export const useFavoriteForms = (userId?: string) => {
   const { data: favs } = useFavorites(userId);
@@ -142,7 +209,6 @@ export const useFavoriteForms = (userId?: string) => {
       title: form.title,
       workspaceId: form.workspaceId,
       status: form.status,
-      updatedAt: form.updatedAt,
       icon: form.icon,
       customization: form.customization,
     }));

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -155,6 +155,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Outlet, useLocation, useParams, useRouter } from "@tanstack/react-router";
 import { createClientOnlyFn } from "@tanstack/react-start";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { parseError } from "@/lib/errors/parse";
 import { generateKeyBetween } from "fractional-indexing";
 import {
@@ -831,6 +832,16 @@ const TrashDialog = ({
       .toSorted((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
   }, [archivedFormsData, orgWorkspacesData, activeOrgId, searchQuery]);
 
+  // Virtualize archived rows — trash grows unbounded; only render visible TrashRows.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: archivedForms.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 53, // TrashRow: px-3 py-2 + two text lines
+    getItemKey: (index) => archivedForms[index].id,
+    overscan: 8,
+  });
+
   const workspaceNames = useMemo(() => {
     if (!orgWorkspacesData) return {};
     return orgWorkspacesData.reduce(
@@ -1010,7 +1021,7 @@ const TrashDialog = ({
           </div>
         </div>
 
-        <div className="max-h-[400px] overflow-y-auto">
+        <div ref={scrollRef} className="max-h-[400px] overflow-y-auto">
           {archivedFormsData === undefined && isFetchingArchived ? (
             <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
               <Loader2Icon className="mb-3 size-6 animate-spin opacity-60" />
@@ -1022,20 +1033,33 @@ const TrashDialog = ({
               <p className="text-sm">Trash is empty</p>
             </div>
           ) : (
+            // Spacer sized to full list; rows absolutely positioned at virtual offsets.
             <div className="p-1">
-              {archivedForms.map((form) => (
-                <TrashRow
-                  key={form.id}
-                  form={form}
-                  workspaceName={workspaceNames[form.workspaceId]}
-                  isSelected={selectedIds.has(form.id)}
-                  isRestoring={restoringIds.has(form.id)}
-                  isDeleting={deletingIds.has(form.id)}
-                  onToggleSelect={handleToggleSelect}
-                  onRestore={handleRestore}
-                  onPermanentDelete={handlePermanentDelete}
-                />
-              ))}
+              <div className="relative w-full" style={{ height: rowVirtualizer.getTotalSize() }}>
+                {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                  const form = archivedForms[virtualRow.index];
+                  return (
+                    <div
+                      key={virtualRow.key}
+                      ref={rowVirtualizer.measureElement}
+                      data-index={virtualRow.index}
+                      className="absolute top-0 left-0 w-full"
+                      style={{ transform: `translateY(${virtualRow.start}px)` }}
+                    >
+                      <TrashRow
+                        form={form}
+                        workspaceName={workspaceNames[form.workspaceId]}
+                        isSelected={selectedIds.has(form.id)}
+                        isRestoring={restoringIds.has(form.id)}
+                        isDeleting={deletingIds.has(form.id)}
+                        onToggleSelect={handleToggleSelect}
+                        onRestore={handleRestore}
+                        onPermanentDelete={handlePermanentDelete}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
             </div>
           )}
         </div>
@@ -2270,7 +2294,6 @@ type FavoriteFormItem = {
   title: string | null;
   workspaceId: string;
   status: string;
-  updatedAt: string;
   icon: string | null;
   customization: unknown;
   favoriteId: string;

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/editor-app.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/editor-app.tsx
@@ -199,7 +199,9 @@ const EditorAppInner = ({
       collection.update(formId, (draft) => {
         draft.content = val;
         if (workspaceId) draft.workspaceId = workspaceId;
-        draft.updatedAt = new Date().toISOString();
+        // No optimistic updatedAt bump: sidebar projects/sorts by updatedAt, so bumping it per
+        // keystroke reshuffles + re-renders the whole sidebar. Server stamps updatedAt (updateForm);
+        // recency reconciles on refetch. Content isn't projected, so this leaves sidebar rows stable.
         if (headerNode) {
           if (headerNode.title !== undefined) draft.title = headerNode.title;
           if (headerNode.icon !== undefined) draft.icon = headerNode.icon ?? null;


### PR DESCRIPTION
Editor content shares the form-listings row with metadata, so each keystroke's optimistic write re-rendered the sidebar, app header, and customize/share panels that only read metadata. Narrow the subscriptions instead.

- editor-app: drop optimistic updatedAt bump on content saves (server stamps it)
- collections/init: return {refetch:false} for content-only saves (no reorder)
- use-live-hooks: add content-excluding projections (useFormMeta, useFormCustomizationMeta, useLocalFormCustomization, useFormShareMeta); drop unused updatedAt from useFavoriteForms; remove dead useIsFavorite
- app-header / customize-sidebar / share-summary-sidebar: use projected hooks
- plate nodes (logic-block, form-option-item, page-break): useEditorVersion ->
  narrow useEditorSelector so one keystroke no longer re-renders every instance (logic-block key is JSON-encoded to avoid label-delimiter collisions)
- _authenticated: virtualize the trash dialog list