### PR TITLE
feat(forms): linear-scale anchors, matrix/ranking redesign, soft Pro …

### DIFF
--- a/src/components/form-builder/embed-preview-mockup.tsx
+++ b/src/components/form-builder/embed-preview-mockup.tsx
@@ -156,7 +156,8 @@ export const EmbedPreviewMockup = ({
     rawCustomization ? { customization: rawCustomization } : null,
     resolvedAppTheme,
   );
-  const [isPopupExpanded, setIsPopupExpanded] = useState(false);
+  // Popup preview opens expanded first, then auto-collapses to its bubble (see effect below).
+  const [isPopupExpanded, setIsPopupExpanded] = useState(true);
   const hasAnimated = useRef(false);
   const isResizing = useRef(false);
 
@@ -181,10 +182,11 @@ export const EmbedPreviewMockup = ({
     return () => ro.disconnect();
   }, [embedType]);
 
-  // Auto-expand popup after 2s when in popup mode
+  // Open expanded first, then auto-collapse to the bubble after 2s when in popup mode.
   useEffect(() => {
     if (embedType !== "popup") return;
-    const timer = setTimeout(() => setIsPopupExpanded(true), 2000);
+    setIsPopupExpanded(true);
+    const timer = setTimeout(() => setIsPopupExpanded(false), 2000);
     return () => clearTimeout(timer);
   }, [embedType]);
 

--- a/src/components/form-builder/form-settings-sidebar.tsx
+++ b/src/components/form-builder/form-settings-sidebar.tsx
@@ -16,7 +16,8 @@ export const FormSettingsSidebar = ({ formId, isLocal }: FormSettingsSidebarProp
     <Sidebar
       side="right"
       collapsible="none"
-      className="size-full animate-in border-none duration-200 ease-out slide-in-from-right-[40%]"
+      // [font-variation-settings:normal] un-pins the global opsz20/wght450 so font-weight utils + Figma optical size apply
+      className="size-full animate-in border-none duration-200 ease-out [font-variation-settings:normal] slide-in-from-right-[40%]"
     >
       <SidebarHeader className="shrink-0 gap-2.25 space-y-2 pt-2 pb-3 pl-1">
         <div className="flex items-center justify-between">

--- a/src/components/form-builder/pro-publish-gate.tsx
+++ b/src/components/form-builder/pro-publish-gate.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useForm } from "@/hooks/use-live-hooks";
+import { settingsDialogStore } from "@/hooks/use-settings-dialog";
+import { useUserPlan } from "@/hooks/use-user-plan";
+import { getProCustomizationSections } from "@/lib/theme/pro-customization";
+
+export type PublishOptions = { stripProStyles: boolean };
+
+type PendingPublish = (opts: PublishOptions) => void;
+
+/**
+ * Soft Pro gate for publish. The customize sidebar no longer hard-blocks Pro sections — free
+ * users can experiment in the draft. At publish time, if the draft holds Pro styles, this asks:
+ * upgrade, or publish with the Pro styles left out (the server strips them regardless, this
+ * dialog is the honest heads-up). Pro/business plans pass straight through.
+ */
+export const useProPublishGate = (formId: string | undefined) => {
+  const { isFree } = useUserPlan();
+  const { data } = useForm(formId);
+  const customization = (data?.[0]?.customization ?? {}) as Record<string, string>;
+  const proSections = getProCustomizationSections(customization);
+  const [pendingPublish, setPendingPublish] = useState<PendingPublish | null>(null);
+
+  const guardPublish = (publish: PendingPublish) => {
+    if (isFree && proSections.length > 0) setPendingPublish(() => publish);
+    else publish({ stripProStyles: false });
+  };
+
+  const closeDialog = () => setPendingPublish(null);
+
+  const proPublishDialog = (
+    <AlertDialog open={pendingPublish !== null} onOpenChange={(open) => !open && closeDialog()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>This form uses Pro styles</AlertDialogTitle>
+          <AlertDialogDescription>
+            Your {proSections.join(", ")} customization{proSections.length > 1 ? "s are" : " is"}{" "}
+            part of Reform Pro. Upgrade to publish {proSections.length > 1 ? "them" : "it"}, or
+            publish without — your draft keeps these styles either way.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="outline"
+            onClick={() => {
+              pendingPublish?.({ stripProStyles: true });
+              closeDialog();
+            }}
+          >
+            Publish without Pro styles
+          </AlertDialogAction>
+          <AlertDialogAction
+            onClick={() => {
+              settingsDialogStore.open("billing");
+              closeDialog();
+            }}
+          >
+            Upgrade to Pro
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
+  return { guardPublish, proPublishDialog };
+};

--- a/src/components/form-builder/share-summary-sidebar.tsx
+++ b/src/components/form-builder/share-summary-sidebar.tsx
@@ -29,6 +29,8 @@ import { useForm } from "@/hooks/use-live-hooks";
 import { useEditorSidebar } from "@/hooks/use-editor-sidebar";
 import type { EmbedType } from "@/hooks/use-editor-sidebar";
 import { publishForm } from "@/hooks/use-form-versions";
+import { useProPublishGate } from "@/components/form-builder/pro-publish-gate";
+import type { PublishOptions } from "@/components/form-builder/pro-publish-gate";
 import { getFormListings } from "@/collections";
 import { useSession } from "@/lib/auth/auth-client";
 import { orgDomainsQueryOptions } from "@/lib/server-fn/custom-domains";
@@ -243,16 +245,29 @@ export const ShareSummarySidebar = ({ formId }: ShareSummarySidebarProps) => {
     setDomainState({ domainId, slug });
   }, []);
 
-  const handlePublish = useCallback(async () => {
-    try {
-      const tx = publishForm(formId);
-      await tx.isPersisted.promise;
-      toast.success("Form published successfully!");
-    } catch (error) {
-      toast.error("Failed to publish form");
-      console.error(error);
-    }
-  }, [formId]);
+  // Soft Pro gate: free drafts can hold Pro styles; publishing asks upgrade-or-strip first.
+  const { guardPublish, proPublishDialog } = useProPublishGate(formId);
+
+  const performPublish = useCallback(
+    async ({ stripProStyles }: PublishOptions) => {
+      try {
+        const tx = publishForm(formId, { stripProStyles });
+        await tx.isPersisted.promise;
+        toast.success(
+          stripProStyles ? "Form published without Pro styles" : "Form published successfully!",
+        );
+      } catch (error) {
+        toast.error("Failed to publish form");
+        console.error(error);
+      }
+    },
+    [formId],
+  );
+
+  const handlePublish = useCallback(
+    () => guardPublish((opts) => void performPublish(opts)),
+    [guardPublish, performPublish],
+  );
 
   if (!doc) return null;
 
@@ -266,7 +281,8 @@ export const ShareSummarySidebar = ({ formId }: ShareSummarySidebarProps) => {
     <Sidebar
       side="right"
       collapsible="none"
-      className="size-full animate-in border-none duration-200 ease-out slide-in-from-right-[40%]"
+      // [font-variation-settings:normal] un-pins the global opsz20/wght450 so font-weight utils + Figma optical size apply
+      className="size-full animate-in border-none duration-200 ease-out [font-variation-settings:normal] slide-in-from-right-[40%]"
     >
       <ShareSidebarHeader
         isDraft={isDraft}
@@ -382,6 +398,7 @@ export const ShareSummarySidebar = ({ formId }: ShareSummarySidebarProps) => {
           </form.Subscribe>
         </>
       )}
+      {proPublishDialog}
     </Sidebar>
   );
 };

--- a/src/components/form-builder/version-history-sidebar.tsx
+++ b/src/components/form-builder/version-history-sidebar.tsx
@@ -357,7 +357,8 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
   return (
     <Sidebar
       collapsible="none"
-      className="size-full animate-in border-none duration-200 ease-out slide-in-from-right-[40%]"
+      // [font-variation-settings:normal] un-pins the global opsz20/wght450 so font-weight utils + Figma optical size apply
+      className="size-full animate-in border-none duration-200 ease-out [font-variation-settings:normal] slide-in-from-right-[40%]"
     >
       <SidebarHeader className="h-11 shrink-0 flex-row items-center justify-between border-b border-border py-2 pr-2 pl-4">
         <h2 className="text-sm leading-[1.15] font-medium tracking-[0.14px] text-foreground">

--- a/src/components/form-components/fields/LinearScaleField.tsx
+++ b/src/components/form-components/fields/LinearScaleField.tsx
@@ -5,6 +5,9 @@ import type { FieldRendererProps } from "./shared";
 
 const LinearScaleField = ({ element, form }: FieldRendererProps<"LinearScale">) => {
   const values = buildScaleValues(element.min, element.max, element.step);
+  // Anchor labels under the scale (block menu "Add Anchor", Figma 25634-16668).
+  const { anchorLeft, anchorCenter, anchorRight } = element;
+  const hasAnchors = Boolean(anchorLeft || anchorCenter || anchorRight);
 
   return (
     <form.AppField name={element.name}>
@@ -14,35 +17,45 @@ const LinearScaleField = ({ element, form }: FieldRendererProps<"LinearScale">) 
 
         return (
           <>
-            <div
-              className="flex flex-wrap gap-2"
-              role="radiogroup"
-              aria-labelledby={getAriaLabelledBy(element)}
-              aria-invalid={hasErrors}
-            >
-              {values.map((value) => {
-                const stringValue = String(value);
-                const isSelected = selectedValue === stringValue;
-                return (
-                  <button
-                    key={stringValue}
-                    type="button"
-                    role="radio"
-                    aria-checked={isSelected}
-                    aria-label={stringValue}
-                    onClick={() => f.handleChange(isSelected ? "" : stringValue)}
-                    className={cn(
-                      "flex h-8 min-w-8 cursor-pointer items-center justify-center rounded-[8px] px-2 text-sm tabular-nums elevation-sm transition-colors",
-                      isSelected
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-[var(--form-input-bg,var(--color-gray-50))] text-foreground hover:bg-secondary",
-                      hasErrors && !isSelected && "ring-1 ring-destructive",
-                    )}
-                  >
-                    {stringValue}
-                  </button>
-                );
-              })}
+            {/* w-fit: anchors span exactly the buttons' width so Right sits under the last tile */}
+            <div className="flex w-fit max-w-full flex-col gap-3">
+              <div
+                className="flex flex-wrap gap-2"
+                role="radiogroup"
+                aria-labelledby={getAriaLabelledBy(element)}
+                aria-invalid={hasErrors}
+              >
+                {values.map((value) => {
+                  const stringValue = String(value);
+                  const isSelected = selectedValue === stringValue;
+                  return (
+                    <button
+                      key={stringValue}
+                      type="button"
+                      role="radio"
+                      aria-checked={isSelected}
+                      aria-label={stringValue}
+                      onClick={() => f.handleChange(isSelected ? "" : stringValue)}
+                      className={cn(
+                        "flex h-8 min-w-8 cursor-pointer items-center justify-center rounded-[8px] px-2 text-sm tabular-nums elevation-sm transition-colors",
+                        isSelected
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-[var(--form-input-bg,var(--color-gray-50))] text-foreground hover:bg-secondary",
+                        hasErrors && !isSelected && "ring-1 ring-destructive",
+                      )}
+                    >
+                      {stringValue}
+                    </button>
+                  );
+                })}
+              </div>
+              {hasAnchors && (
+                <div className="flex items-baseline gap-2 text-[13px] leading-none text-muted-foreground">
+                  <span className="flex-1 truncate text-left">{anchorLeft}</span>
+                  <span className="flex-1 truncate text-center">{anchorCenter}</span>
+                  <span className="flex-1 truncate text-right">{anchorRight}</span>
+                </div>
+              )}
             </div>
             <f.FieldError />
           </>

--- a/src/components/form-components/fields/RankingField.tsx
+++ b/src/components/form-components/fields/RankingField.tsx
@@ -18,29 +18,25 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { domMax, LazyMotion, m } from "motion/react";
 
-import { IconSwap } from "@/components/transitions/icon-swap";
-import { ChevronsUpDownIcon } from "@/components/ui/icons";
+import { RankDragHandleIcon } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import { shuffleOptions } from "./shared";
 import type { FieldRendererProps } from "./shared";
 
-type RankingOption = { label: string; value: string };
+type RankingOption = { label: string; value: string; image?: string };
 
 const SortableRankRow = ({
   option,
-  rankIndex,
   hasErrors,
   onRankClick,
 }: {
   option: RankingOption;
-  rankIndex: number;
   hasErrors: boolean;
   onRankClick: (value: string) => void;
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: option.value,
   });
-  const isRanked = rankIndex !== -1;
 
   return (
     <button
@@ -48,33 +44,41 @@ const SortableRankRow = ({
       type="button"
       onClick={() => onRankClick(option.value)}
       // Inline sortable transition overrides the colors-only class while items animate.
-      style={{ transform: CSS.Transform.toString(transform), transition }}
+      // Translate-only (no CSS.Transform): with mixed-height rows (image options) the sortable
+      // scale stretches text rows into the image row's slot — giant distorted labels mid-drag.
+      style={{ transform: CSS.Translate.toString(transform), transition }}
       className={cn(
-        "flex cursor-pointer touch-manipulation items-center gap-2 py-1 text-left text-sm transition-colors",
+        "flex cursor-pointer touch-manipulation gap-2 py-1 text-left text-sm transition-colors",
+        // image rows top-align so the handle/badge stays on the label line
+        option.image ? "items-start" : "items-center",
         isDragging && "relative z-10 cursor-grabbing opacity-80",
         hasErrors && "text-destructive",
       )}
       {...attributes}
       {...listeners}
     >
+      {/* "=" drag glyph on every row (Figma 26153-13884) — no rank-number badge. */}
       <span
         className={cn(
-          "flex size-4 shrink-0 items-center justify-center rounded-[4px]",
-          isRanked
-            ? "bg-primary text-[9px] leading-none font-semibold text-primary-foreground"
-            : cn(
-                "border border-border text-muted-foreground",
-                hasErrors && "border-destructive ring-1 ring-destructive",
-              ),
+          "flex size-4 shrink-0 items-center justify-center text-muted-foreground",
+          option.image && "mt-0.5",
+          hasErrors && "text-destructive",
         )}
       >
-        <IconSwap
-          state={isRanked ? "b" : "a"}
-          iconA={<ChevronsUpDownIcon className="size-2.5" />}
-          iconB={<span>{isRanked ? rankIndex + 1 : ""}</span>}
-        />
+        <RankDragHandleIcon className="size-4" />
       </span>
-      <span>{option.label}</span>
+      <span className="flex min-w-0 flex-col">
+        <span>{option.label}</span>
+        {/* Per-option image — same 4:3 / 200px cover crop as the editor's OptionImageSlot. */}
+        {option.image && (
+          <img
+            src={option.image}
+            alt=""
+            draggable={false}
+            className="mt-1.5 aspect-[4/3] w-[200px] rounded-lg bg-gray-100 object-cover"
+          />
+        )}
+      </span>
     </button>
   );
 };
@@ -143,8 +147,10 @@ const RankingField = ({ element, form }: FieldRendererProps<"Ranking">) => {
             f.handleChange(rankedValues.filter((v) => v !== active.id));
             return;
           }
-          // Reordering within the unranked pool carries no meaning — let it snap back.
-          if (!wasRanked && to >= rankedCount) return;
+          // Dropping at the boundary slot (index === rankedCount) ranks the item as the next
+          // rank — with nothing ranked yet, dragging to the FIRST position ranks it #1, so
+          // drag alone can build the ranking. Only drops deeper in the pool stay meaningless.
+          if (!wasRanked && to > rankedCount) return;
           const next = arrayMove(displayed, from, to)
             .slice(0, wasRanked ? rankedCount : rankedCount + 1)
             .map((o) => o.value);
@@ -177,7 +183,6 @@ const RankingField = ({ element, form }: FieldRendererProps<"Ranking">) => {
                       >
                         <SortableRankRow
                           option={option}
-                          rankIndex={rankedValues.indexOf(option.value)}
                           hasErrors={hasErrors}
                           onRankClick={handleRankClick}
                         />

--- a/src/components/ui/about-sidebar.tsx
+++ b/src/components/ui/about-sidebar.tsx
@@ -9,7 +9,8 @@ interface AboutSidebarProps {
 }
 
 export const AboutSidebar = ({ onClose }: AboutSidebarProps) => (
-  <div className="flex h-full animate-in flex-col bg-background duration-200 ease-out slide-in-from-right-[40%]">
+  // [font-variation-settings:normal] un-pins the global opsz20/wght450 so font-weight utils apply
+  <div className="flex h-full animate-in flex-col bg-background duration-200 ease-out [font-variation-settings:normal] slide-in-from-right-[40%]">
     <div className="flex h-10 shrink-0 items-center justify-between border-b border-border/40 px-3">
       <span className="text-[13px]">About</span>
       <Button

--- a/src/components/ui/app-header.tsx
+++ b/src/components/ui/app-header.tsx
@@ -20,6 +20,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TextSwap } from "@/components/transitions/text-swap";
+import { useProPublishGate } from "@/components/form-builder/pro-publish-gate";
+import type { PublishOptions } from "@/components/form-builder/pro-publish-gate";
 import { toggleFavoriteLocal, updateFormStatus } from "@/collections";
 import { useEditorSidebar } from "@/hooks/use-editor-sidebar";
 import { discardChanges, publishForm, useHasUnpublishedChanges } from "@/hooks/use-form-versions";
@@ -128,6 +130,7 @@ export const AppHeader = ({ isDistractionHidden = false }: AppHeaderProps) => {
     handleToggleFavorite,
     handleDeleteForm,
     handlePublish,
+    proPublishDialog,
     handleDiscardChanges,
     handleEditForm,
     handleDismissSidebars,
@@ -292,6 +295,7 @@ export const AppHeader = ({ isDistractionHidden = false }: AppHeaderProps) => {
         onDeleteForm={handleDeleteForm}
         onDiscardChanges={handleDiscardChanges}
       />
+      {proPublishDialog}
     </>
   );
 };
@@ -342,13 +346,16 @@ const useAppHeaderFormActions = ({
     }
   };
 
-  const handlePublish = async () => {
+  // Soft Pro gate: free drafts can hold Pro styles; publishing asks upgrade-or-strip first.
+  const { guardPublish, proPublishDialog } = useProPublishGate(formId);
+
+  const performPublish = async ({ stripProStyles }: PublishOptions) => {
     if (formId && workspaceId) {
       setWorkflowState("publishing");
       try {
-        const tx = publishForm(formId);
+        const tx = publishForm(formId, { stripProStyles });
         await tx.isPersisted.promise;
-        toast.success("Form published");
+        toast.success(stripProStyles ? "Form published without Pro styles" : "Form published");
         openShare();
         void navigate({
           to: "/workspace/$workspaceId/form-builder/$formId/submissions",
@@ -362,6 +369,8 @@ const useAppHeaderFormActions = ({
       }
     }
   };
+
+  const handlePublish = () => guardPublish((opts) => void performPublish(opts));
 
   const handleDiscardChanges = async () => {
     if (formId) {
@@ -406,6 +415,7 @@ const useAppHeaderFormActions = ({
     handleToggleFavorite,
     handleDeleteForm,
     handlePublish,
+    proPublishDialog,
     handleDiscardChanges,
     handleEditForm,
     handleDismissSidebars,

--- a/src/components/ui/block-draggable.tsx
+++ b/src/components/ui/block-draggable.tsx
@@ -416,7 +416,7 @@ const Draggable = (props: PlateElementProps) => {
                       variant="ghost"
                       size="icon"
                       tabIndex={-1}
-                      className="size-auto rounded-lg border border-transparent has-[>svg]:px-1 has-[>svg]:py-1.5"
+                      className="flex size-auto items-center justify-center rounded-lg border-0 hover:bg-accent has-[>svg]:px-1 has-[>svg]:py-1.5"
                       onClick={handleDeleteBlock}
                       data-plate-prevent-deselect
                       aria-label="Delete block"
@@ -437,7 +437,7 @@ const Draggable = (props: PlateElementProps) => {
                       variant="ghost"
                       size="icon"
                       tabIndex={-1}
-                      className="size-auto rounded-lg border border-transparent has-[>svg]:px-1 has-[>svg]:py-1.5"
+                      className="flex size-auto items-center justify-center rounded-lg border-0 hover:bg-accent has-[>svg]:px-1 has-[>svg]:py-1.5"
                       onClick={handleAddBlock}
                       data-plate-prevent-deselect
                     />

--- a/src/components/ui/block-menu.tsx
+++ b/src/components/ui/block-menu.tsx
@@ -433,6 +433,7 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
         updateButtonText: handlers.handleUpdateButtonText,
         setScaleRange: handlers.handleSetScaleRange,
         setScaleStep: handlers.handleSetScaleStep,
+        setAnchorLabel: handlers.handleSetAnchorLabel,
         updateStarCount: handlers.handleUpdateStarCount,
         deleteBlock: handleDelete,
         duplicateBlock: handleDuplicate,
@@ -562,6 +563,9 @@ interface BlockMenuInputNode {
   scaleMin?: number;
   scaleMax?: number;
   scaleStep?: number;
+  anchorLeft?: string;
+  anchorCenter?: string;
+  anchorRight?: string;
   starCount?: number;
   multiple?: boolean;
 }
@@ -679,6 +683,17 @@ const useBlockMenuFieldHandlers = ({
       // Never persist a non-finite step (e.g. a stray NaN from the slider) — it'd render "NaN".
       const safeStep = Number.isFinite(step) ? Math.max(1, step) : LINEAR_SCALE_DEFAULTS.step;
       editor.tf.setNodes({ scaleStep: safeStep }, { at: inputPath });
+    },
+    [getInputPath, editor.tf],
+  );
+  // Linear scale anchor labels (Figma 26153-13445) — written per keystroke; empty unsets so
+  // the anchor row under the scale hides.
+  const handleSetAnchorLabel = React.useCallback(
+    (key: "anchorLeft" | "anchorCenter" | "anchorRight", value: string) => {
+      const inputPath = getInputPath();
+      if (!inputPath) return;
+      if (value) editor.tf.setNodes({ [key]: value }, { at: inputPath });
+      else editor.tf.unsetNodes([key], { at: inputPath });
     },
     [getInputPath, editor.tf],
   );
@@ -906,6 +921,7 @@ const useBlockMenuFieldHandlers = ({
       handleUpdateButtonText,
       handleSetScaleRange,
       handleSetScaleStep,
+      handleSetAnchorLabel,
       handleUpdateStarCount,
     }),
     [
@@ -934,6 +950,7 @@ const useBlockMenuFieldHandlers = ({
       handleUpdateButtonText,
       handleSetScaleRange,
       handleSetScaleStep,
+      handleSetAnchorLabel,
       handleUpdateStarCount,
     ],
   );
@@ -971,6 +988,7 @@ interface BlockMenuActions {
   updateButtonText: (v: string) => void;
   setScaleRange: (min: number, max: number) => void;
   setScaleStep: (step: number) => void;
+  setAnchorLabel: (key: "anchorLeft" | "anchorCenter" | "anchorRight", value: string) => void;
   updateStarCount: (v: string) => void;
   deleteBlock: () => void;
   duplicateBlock: () => void;
@@ -1883,6 +1901,7 @@ const TurnInto = () => <SubmenuRow icon={<TurnIntoIcon />} label="Turn into" vie
 
 const TURN_INTO_CHOICES: { type: string; label: string }[] = [
   { type: KEYS.p, label: "Paragraph" },
+  { type: "formLabel", label: "Label" },
   { type: KEYS.h1, label: "Heading 1" },
   { type: KEYS.h2, label: "Heading 2" },
   { type: KEYS.h3, label: "Heading 3" },
@@ -2094,12 +2113,46 @@ const ScaleStepPanel = () => {
   );
 };
 
+// Linear scale "Add Anchor" (Figma 25634-16937 / 26153-13445): Left/Center/Right labels
+// rendered under the scale tiles (e.g. Bad … Good).
+const AddAnchor = () => (
+  <SubmenuRow icon={<ConditionalLogicIcon />} label="Add Anchor" view="scale-anchor" />
+);
+
+const ANCHOR_ROWS = [
+  { key: "anchorLeft", label: "Left" },
+  { key: "anchorCenter", label: "Center" },
+  { key: "anchorRight", label: "Right" },
+] as const;
+
+const ScaleAnchorPanel = () => {
+  const { state, actions } = useBlockMenu();
+  return (
+    <PanelBody>
+      {ANCHOR_ROWS.map(({ key, label }) => (
+        <div key={key} className="flex items-center gap-2.5">
+          <span className="w-[60px] shrink-0 text-[14px] text-foreground">{label}</span>
+          <Input
+            value={state.inputNode?.[key] ?? ""}
+            onChange={(e) => actions.setAnchorLabel(key, e.target.value)}
+            onKeyDown={stopKeyEventPropagation}
+            placeholder="Add a label"
+            aria-label={`${label} anchor label`}
+            className="h-7 flex-1 rounded-lg border-none bg-(--color-gray-alpha-100) px-2 text-[13px] shadow-none"
+          />
+        </div>
+      ))}
+    </PanelBody>
+  );
+};
+
 const LinearScaleFieldMenu = () => (
   <>
     <RequiredToggle />
     <ScaleRange />
     <ScaleStep />
     <MenuDivider />
+    <AddAnchor />
     <MenuActions />
   </>
 );
@@ -2228,6 +2281,7 @@ const INLINE_PANELS: Record<string, { label: string; width?: string; Panel: Reac
   labels: { label: "Labels", Panel: OptionLabelsPanel },
   scale: { label: "Scale", Panel: ScaleRangePanel },
   "scale-step": { label: "Scale step", Panel: ScaleStepPanel },
+  "scale-anchor": { label: "Scale Anchor", Panel: ScaleAnchorPanel },
   "stars-count": { label: "Stars count", Panel: StarsCountPanel },
   "turn-into": { label: "Turn into", Panel: TurnIntoPanel },
   "bulk-insert": { label: "Add options", Panel: BulkInsertPanel },
@@ -2346,6 +2400,9 @@ interface BlockMenuFirstNode {
   scaleMin?: number;
   scaleMax?: number;
   scaleStep?: number;
+  anchorLeft?: string;
+  anchorCenter?: string;
+  anchorRight?: string;
   starCount?: number;
   multiple?: boolean;
 }

--- a/src/components/ui/customize-sidebar.tsx
+++ b/src/components/ui/customize-sidebar.tsx
@@ -3,7 +3,6 @@ import { useTheme, useResolvedTheme } from "@/components/theme-provider";
 import { Button } from "@/components/ui/button";
 import { IconPickerPreview } from "@/components/icon-picker";
 import { ColorPicker } from "@/components/ui/color-picker";
-import { FeatureGate } from "@/components/ui/feature-gate";
 import {
   CaretDownIcon,
   DarkModeIcon,
@@ -362,7 +361,8 @@ export const CustomizeSidebar = ({ formId, isLocal }: CustomizeSidebarProps) => 
     <Sidebar
       side="right"
       collapsible="none"
-      className="size-full animate-in border-none duration-200 ease-out slide-in-from-right-[40%]"
+      // [font-variation-settings:normal] un-pins the global opsz20/wght450 so font-weight utils + Figma optical size apply
+      className="size-full animate-in border-none duration-200 ease-out [font-variation-settings:normal] slide-in-from-right-[40%]"
     >
       <CustomizeSidebarHeader closeSidebar={closeSidebar} />
 
@@ -424,7 +424,8 @@ export const CustomizeSidebar = ({ formId, isLocal }: CustomizeSidebarProps) => 
 const CustomizeSidebarHeader = ({ closeSidebar }: { closeSidebar: () => void }) => (
   <SidebarHeader className="shrink-0 gap-2.25 space-y-2 pt-2 pb-3 pl-1">
     <div className="flex items-center justify-between">
-      <h2 className="pl-2.5 font-sans text-base font-normal text-foreground">Customize</h2>
+      {/* drop font-sans so the root's variation reset isn't re-pinned */}
+      <h2 className="pl-2.5 text-base font-normal text-foreground">Customize</h2>
       <Button
         variant="ghost"
         size="icon-xs"
@@ -710,91 +711,90 @@ const TypographySection = ({
         </div>
       }
     >
-      <FeatureGate requiredPlan="pro" variant="block">
-        <div className="flex flex-col gap-1.5">
-          <ConfigRow label="Font" surface="flat">
-            <Select value={fontValue} onValueChange={(v) => v && onFontChange(v)}>
-              <SelectTrigger
-                className={selectTriggerFigmaCls}
-                icon={<CaretDownIcon className="size-3" />}
-              >
-                {FONT_OPTIONS.find((o) => o.value === fontValue)?.label ?? fontValue}
-              </SelectTrigger>
-              <SelectContent>
-                {FONT_OPTIONS.map((o) => (
-                  <SelectItem key={o.value} value={o.value}>
-                    {o.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </ConfigRow>
-          <NumberRow
-            label="Size"
-            value={customization[sizeKey]}
-            onChange={(v) => updateScrubberField(sizeKey, v)}
-            allowAuto
-            isAuto={!customization[sizeKey]}
-            onAutoChange={() => resetScrubberField(sizeKey)}
-            min={isTitle ? 24 : 12}
-            max={isTitle ? 72 : 24}
-            step={isTitle ? 2 : 1}
-            unit="px"
-            displayUnit=""
-            className={CONFIG_INPUT_CLS}
+      {/* No hard Pro gate — free users can experiment; publish strips Pro keys (pro-publish-gate) */}
+      <div className="flex flex-col gap-1.5">
+        <ConfigRow label="Font" surface="flat">
+          <Select value={fontValue} onValueChange={(v) => v && onFontChange(v)}>
+            <SelectTrigger
+              className={selectTriggerFigmaCls}
+              icon={<CaretDownIcon className="size-3" />}
+            >
+              {FONT_OPTIONS.find((o) => o.value === fontValue)?.label ?? fontValue}
+            </SelectTrigger>
+            <SelectContent>
+              {FONT_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </ConfigRow>
+        <NumberRow
+          label="Size"
+          value={customization[sizeKey]}
+          onChange={(v) => updateScrubberField(sizeKey, v)}
+          allowAuto
+          isAuto={!customization[sizeKey]}
+          onAutoChange={() => resetScrubberField(sizeKey)}
+          min={isTitle ? 24 : 12}
+          max={isTitle ? 72 : 24}
+          step={isTitle ? 2 : 1}
+          unit="px"
+          displayUnit=""
+          className={CONFIG_INPUT_CLS}
+        />
+        <NumberRow
+          label="Spacing"
+          value={customization[spacingKey]}
+          onChange={(v) => updateScrubberField(spacingKey, v)}
+          allowAuto
+          isAuto={!customization[spacingKey]}
+          onAutoChange={() => resetScrubberField(spacingKey)}
+          min={isTitle ? -3 : 0}
+          max={isTitle ? 3 : 0.2}
+          step={isTitle ? 0.25 : 0.005}
+          unit={isTitle ? "px" : "em"}
+          displayUnit=""
+          className={CONFIG_INPUT_CLS}
+        />
+        <NumberRow
+          label="Line height"
+          value={customization[lineHeightKey]}
+          onChange={(v) => updateScrubberField(lineHeightKey, v)}
+          allowAuto
+          isAuto={!customization[lineHeightKey]}
+          onAutoChange={() => resetScrubberField(lineHeightKey)}
+          min={1}
+          max={2}
+          step={0.05}
+          unit=""
+          className={CONFIG_INPUT_CLS}
+        />
+        <ConfigRow label="Alignment" surface="flat">
+          <PillToggle
+            value={customization[alignKey] || "left"}
+            onChange={(v) => updateScrubberField(alignKey, v)}
+            options={[
+              {
+                value: "left",
+                label: "Left",
+                icon: <TextAlignLeftIcon className="size-[18px]" />,
+              },
+              {
+                value: "center",
+                label: "Center",
+                icon: <TextAlignCenterIcon className="size-[18px]" />,
+              },
+              {
+                value: "right",
+                label: "Right",
+                icon: <TextAlignRightIcon className="size-[18px]" />,
+              },
+            ]}
           />
-          <NumberRow
-            label="Spacing"
-            value={customization[spacingKey]}
-            onChange={(v) => updateScrubberField(spacingKey, v)}
-            allowAuto
-            isAuto={!customization[spacingKey]}
-            onAutoChange={() => resetScrubberField(spacingKey)}
-            min={isTitle ? -3 : 0}
-            max={isTitle ? 3 : 0.2}
-            step={isTitle ? 0.25 : 0.005}
-            unit={isTitle ? "px" : "em"}
-            displayUnit=""
-            className={CONFIG_INPUT_CLS}
-          />
-          <NumberRow
-            label="Line height"
-            value={customization[lineHeightKey]}
-            onChange={(v) => updateScrubberField(lineHeightKey, v)}
-            allowAuto
-            isAuto={!customization[lineHeightKey]}
-            onAutoChange={() => resetScrubberField(lineHeightKey)}
-            min={1}
-            max={2}
-            step={0.05}
-            unit=""
-            className={CONFIG_INPUT_CLS}
-          />
-          <ConfigRow label="Alignment" surface="flat">
-            <PillToggle
-              value={customization[alignKey] || "left"}
-              onChange={(v) => updateScrubberField(alignKey, v)}
-              options={[
-                {
-                  value: "left",
-                  label: "Left",
-                  icon: <TextAlignLeftIcon className="size-[18px]" />,
-                },
-                {
-                  value: "center",
-                  label: "Center",
-                  icon: <TextAlignCenterIcon className="size-[18px]" />,
-                },
-                {
-                  value: "right",
-                  label: "Right",
-                  icon: <TextAlignRightIcon className="size-[18px]" />,
-                },
-              ]}
-            />
-          </ConfigRow>
-        </div>
-      </FeatureGate>
+        </ConfigRow>
+      </div>
     </SidebarSection>
   );
 };
@@ -823,16 +823,14 @@ const ColorsSection = ({
       </div>
     }
   >
-    <FeatureGate requiredPlan="pro" variant="block">
-      <div className="relative isolate z-50 flex flex-col gap-1.5 overflow-visible">
-        <DeferredColorPickers
-          tokens={SEMANTIC_COLOR_TOKENS}
-          customization={customization}
-          updateField={updateWithCustomPreset}
-          mode={activeMode}
-        />
-      </div>
-    </FeatureGate>
+    <div className="relative isolate z-50 flex flex-col gap-1.5 overflow-visible">
+      <DeferredColorPickers
+        tokens={SEMANTIC_COLOR_TOKENS}
+        customization={customization}
+        updateField={updateWithCustomPreset}
+        mode={activeMode}
+      />
+    </div>
   </SidebarSection>
 );
 
@@ -842,81 +840,79 @@ const InputsSection = ({
   resetScrubberField,
 }: ScrubberProps) => (
   <SidebarSection label="Inputs" collapsible={false} headerRight={<ProBadge />}>
-    <FeatureGate requiredPlan="pro" variant="block">
-      <div className="flex flex-col gap-1.5">
-        <NumberRow
-          label="Input width"
-          value={customization.inputWidth}
-          onChange={(v) => updateScrubberField("inputWidth", v)}
-          allowAuto
-          isAuto={!customization.inputWidth}
-          onAutoChange={() => resetScrubberField("inputWidth")}
-          min={20}
-          max={100}
-          step={5}
-          unit="%"
-          className={CONFIG_INPUT_CLS}
-        />
-        <NumberRow
-          label="Input height"
-          value={customization.inputHeight}
-          onChange={(v) => updateScrubberField("inputHeight", v)}
-          allowAuto
-          isAuto={!customization.inputHeight}
-          onAutoChange={() => resetScrubberField("inputHeight")}
-          min={24}
-          max={64}
-          step={1}
-          unit="px"
-          displayUnit=""
-          className={CONFIG_INPUT_CLS}
-        />
-        <NumberRow
-          label="Radius"
-          value={customization.inputRadius}
-          onChange={(v) => updateScrubberField("inputRadius", v)}
-          allowAuto
-          isAuto={!customization.inputRadius}
-          onAutoChange={() => resetScrubberField("inputRadius")}
-          min={0}
-          max={32}
-          step={1}
-          unit="px"
-          displayUnit=""
-          markStyle="dot"
-          endIcon={<RadiusEndIcon value={customization.inputRadius} max={32} />}
-          className={CONFIG_INPUT_CLS}
-        />
-        <NumberRow
-          label="Margin bottom"
-          value={customization.inputMarginBottom}
-          onChange={(v) => updateScrubberField("inputMarginBottom", v)}
-          allowAuto
-          isAuto={!customization.inputMarginBottom}
-          onAutoChange={() => resetScrubberField("inputMarginBottom")}
-          min={0}
-          max={64}
-          step={2}
-          unit="px"
-          displayUnit=""
-          className={CONFIG_INPUT_CLS}
-        />
-        <NumberRow
-          label="Padding"
-          value={customization.inputPadding}
-          onChange={(v) => updateScrubberField("inputPadding", v)}
-          allowAuto
-          isAuto={!customization.inputPadding}
-          onAutoChange={() => resetScrubberField("inputPadding")}
-          min={0}
-          max={32}
-          step={1}
-          unit="px"
-          displayUnit=""
-          className={CONFIG_INPUT_CLS}
-        />
-      </div>
-    </FeatureGate>
+    <div className="flex flex-col gap-1.5">
+      <NumberRow
+        label="Input width"
+        value={customization.inputWidth}
+        onChange={(v) => updateScrubberField("inputWidth", v)}
+        allowAuto
+        isAuto={!customization.inputWidth}
+        onAutoChange={() => resetScrubberField("inputWidth")}
+        min={20}
+        max={100}
+        step={5}
+        unit="%"
+        className={CONFIG_INPUT_CLS}
+      />
+      <NumberRow
+        label="Input height"
+        value={customization.inputHeight}
+        onChange={(v) => updateScrubberField("inputHeight", v)}
+        allowAuto
+        isAuto={!customization.inputHeight}
+        onAutoChange={() => resetScrubberField("inputHeight")}
+        min={24}
+        max={64}
+        step={1}
+        unit="px"
+        displayUnit=""
+        className={CONFIG_INPUT_CLS}
+      />
+      <NumberRow
+        label="Radius"
+        value={customization.inputRadius}
+        onChange={(v) => updateScrubberField("inputRadius", v)}
+        allowAuto
+        isAuto={!customization.inputRadius}
+        onAutoChange={() => resetScrubberField("inputRadius")}
+        min={0}
+        max={32}
+        step={1}
+        unit="px"
+        displayUnit=""
+        markStyle="dot"
+        endIcon={<RadiusEndIcon value={customization.inputRadius} max={32} />}
+        className={CONFIG_INPUT_CLS}
+      />
+      <NumberRow
+        label="Margin bottom"
+        value={customization.inputMarginBottom}
+        onChange={(v) => updateScrubberField("inputMarginBottom", v)}
+        allowAuto
+        isAuto={!customization.inputMarginBottom}
+        onAutoChange={() => resetScrubberField("inputMarginBottom")}
+        min={0}
+        max={64}
+        step={2}
+        unit="px"
+        displayUnit=""
+        className={CONFIG_INPUT_CLS}
+      />
+      <NumberRow
+        label="Padding"
+        value={customization.inputPadding}
+        onChange={(v) => updateScrubberField("inputPadding", v)}
+        allowAuto
+        isAuto={!customization.inputPadding}
+        onAutoChange={() => resetScrubberField("inputPadding")}
+        min={0}
+        max={32}
+        step={1}
+        unit="px"
+        displayUnit=""
+        className={CONFIG_INPUT_CLS}
+      />
+    </div>
   </SidebarSection>
 );
 
@@ -926,52 +922,50 @@ const ButtonsSection = ({
   resetScrubberField,
 }: ScrubberProps) => (
   <SidebarSection label="Buttons" collapsible={false} headerRight={<ProBadge />}>
-    <FeatureGate requiredPlan="pro" variant="block">
-      <div className="flex flex-col gap-1.5">
-        <NumberRow
-          label="Width"
-          value={customization.buttonWidth}
-          onChange={(v) => updateScrubberField("buttonWidth", v)}
-          allowAuto
-          isAuto={!customization.buttonWidth}
-          onAutoChange={() => resetScrubberField("buttonWidth")}
-          min={80}
-          max={400}
-          step={4}
-          unit="px"
-          displayUnit=""
-          className={CONFIG_INPUT_CLS}
-        />
-        <NumberRow
-          label="Height"
-          value={customization.buttonHeight}
-          onChange={(v) => updateScrubberField("buttonHeight", v)}
-          allowAuto
-          isAuto={!customization.buttonHeight}
-          onAutoChange={() => resetScrubberField("buttonHeight")}
-          min={24}
-          max={64}
-          step={1}
-          unit="px"
-          displayUnit=""
-          className={CONFIG_INPUT_CLS}
-        />
-        <NumberRow
-          label="Radius"
-          value={customization.buttonRadius}
-          onChange={(v) => updateScrubberField("buttonRadius", v)}
-          allowAuto
-          isAuto={!customization.buttonRadius}
-          onAutoChange={() => resetScrubberField("buttonRadius")}
-          min={0}
-          max={32}
-          step={1}
-          unit="px"
-          displayUnit=""
-          className={CONFIG_INPUT_CLS}
-        />
-      </div>
-    </FeatureGate>
+    <div className="flex flex-col gap-1.5">
+      <NumberRow
+        label="Width"
+        value={customization.buttonWidth}
+        onChange={(v) => updateScrubberField("buttonWidth", v)}
+        allowAuto
+        isAuto={!customization.buttonWidth}
+        onAutoChange={() => resetScrubberField("buttonWidth")}
+        min={80}
+        max={400}
+        step={4}
+        unit="px"
+        displayUnit=""
+        className={CONFIG_INPUT_CLS}
+      />
+      <NumberRow
+        label="Height"
+        value={customization.buttonHeight}
+        onChange={(v) => updateScrubberField("buttonHeight", v)}
+        allowAuto
+        isAuto={!customization.buttonHeight}
+        onAutoChange={() => resetScrubberField("buttonHeight")}
+        min={24}
+        max={64}
+        step={1}
+        unit="px"
+        displayUnit=""
+        className={CONFIG_INPUT_CLS}
+      />
+      <NumberRow
+        label="Radius"
+        value={customization.buttonRadius}
+        onChange={(v) => updateScrubberField("buttonRadius", v)}
+        allowAuto
+        isAuto={!customization.buttonRadius}
+        onAutoChange={() => resetScrubberField("buttonRadius")}
+        min={0}
+        max={32}
+        step={1}
+        unit="px"
+        displayUnit=""
+        className={CONFIG_INPUT_CLS}
+      />
+    </div>
   </SidebarSection>
 );
 
@@ -983,18 +977,16 @@ interface CustomCssSectionProps {
 
 const CustomCssSection = ({ cssValue, handleCssChange, activeMode }: CustomCssSectionProps) => (
   <SidebarSection label="Custom CSS" collapsible={false} divider={false} headerRight={<ProBadge />}>
-    <FeatureGate requiredPlan="pro" variant="block">
-      <div className="overflow-hidden rounded-lg bg-muted">
-        <Textarea
-          value={cssValue}
-          onChange={handleCssChange}
-          aria-label={`Custom CSS (${activeMode} mode)`}
-          className="h-36 rounded-none border-0 bg-muted p-3 font-mono text-[14px] text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-          placeholder={"<style>\n.reform-block {...\n\n\n</style>"}
-          spellCheck={false}
-        />
-      </div>
-    </FeatureGate>
+    <div className="overflow-hidden rounded-lg bg-muted">
+      <Textarea
+        value={cssValue}
+        onChange={handleCssChange}
+        aria-label={`Custom CSS (${activeMode} mode)`}
+        className="h-36 rounded-none border-0 bg-muted p-3 font-mono text-[14px] text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+        placeholder={"<style>\n.reform-block {...\n\n\n</style>"}
+        spellCheck={false}
+      />
+    </div>
   </SidebarSection>
 );
 

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -30,7 +30,7 @@ export const DrawerOverlay = ({
   <DrawerPrimitive.Overlay
     data-slot="drawer-overlay"
     className={cn(
-      "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+      "fixed inset-0 z-50 bg-[var(--color-gray-200)] data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
       className,
     )}
     {...props}

--- a/src/components/ui/form-field-node.tsx
+++ b/src/components/ui/form-field-node.tsx
@@ -85,7 +85,7 @@ export const FormFieldElement = (allProps: PlateElementProps) => {
           "data-bf-input-fill": "true",
         }}
         className={cn(
-          "relative flex h-7 w-full cursor-text items-center gap-[4px] rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] pr-[8px] pl-[10px] text-sm caret-current elevation-sm",
+          "relative flex h-7 w-full cursor-text items-center gap-[4px] rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] px-[10px] text-sm caret-current elevation-sm",
           isSelected && focused && "ring-[3px] ring-ring/50",
         )}
         element={element}
@@ -121,7 +121,7 @@ export const FormFieldElement = (allProps: PlateElementProps) => {
               className="mt-2 flex items-center gap-2 select-none"
             >
               <div
-                className="relative flex h-7 flex-1 items-center gap-[4px] rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] pr-[8px] pl-[10px] text-sm elevation-sm"
+                className="relative flex h-7 flex-1 items-center gap-[4px] rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] px-[10px] text-sm elevation-sm"
                 aria-hidden="true"
               >
                 <span className="line-clamp-1 min-w-0 flex-1 break-all text-muted-foreground/50">

--- a/src/components/ui/form-header-node.tsx
+++ b/src/components/ui/form-header-node.tsx
@@ -651,7 +651,7 @@ export const FormHeaderElement = (props: PlateElementProps) => {
                       <Button
                         variant="ghost"
                         size="sm"
-                        prefix={<CircleUserRoundIcon />}
+                        prefix={<CircleUserRoundIcon className="size-4" />}
                         onMouseDown={(e) => e.preventDefault()}
                       />
                     }
@@ -664,7 +664,7 @@ export const FormHeaderElement = (props: PlateElementProps) => {
                     variant="ghost"
                     size="sm"
                     onClick={handleAddCover}
-                    prefix={<ImageIcon />}
+                    prefix={<ImageIcon className="size-4" />}
                     onMouseDown={(e) => e.preventDefault()}
                   >
                     Add cover

--- a/src/components/ui/form-linear-scale-node.tsx
+++ b/src/components/ui/form-linear-scale-node.tsx
@@ -18,6 +18,12 @@ export const FormLinearScaleElement = ({ children, ...props }: PlateElementProps
   const step = (element.scaleStep as number | undefined) ?? LINEAR_SCALE_DEFAULTS.step;
   const values = buildScaleValues(min, max, step);
 
+  // Anchor labels under the scale (block menu "Add Anchor", Figma 25634-16668).
+  const anchorLeft = (element.anchorLeft as string | undefined)?.trim();
+  const anchorCenter = (element.anchorCenter as string | undefined)?.trim();
+  const anchorRight = (element.anchorRight as string | undefined)?.trim();
+  const hasAnchors = Boolean(anchorLeft || anchorCenter || anchorRight);
+
   return (
     <PlateElement
       attributes={{ ...attributes, "data-bf-input": "true" }}
@@ -29,15 +35,27 @@ export const FormLinearScaleElement = ({ children, ...props }: PlateElementProps
       {...rest}
     >
       <div className="hidden">{children}</div>
-      <div contentEditable={false} className="flex flex-1 flex-wrap gap-2">
-        {values.map((value) => (
-          <span
-            key={String(value)}
-            className="flex h-8 min-w-8 items-center justify-center rounded-[8px] bg-[var(--form-input-bg,var(--color-gray-50))] px-2 text-sm text-foreground tabular-nums elevation-sm"
-          >
-            {String(value)}
-          </span>
-        ))}
+      <div contentEditable={false} className="flex flex-1 flex-col">
+        {/* w-fit: anchors span exactly the tiles' width so Right sits under the last tile */}
+        <div className="flex w-fit max-w-full flex-col gap-3">
+          <div className="flex flex-wrap gap-2">
+            {values.map((value) => (
+              <span
+                key={String(value)}
+                className="flex h-8 min-w-8 items-center justify-center rounded-[8px] bg-[var(--form-input-bg,var(--color-gray-50))] px-2 text-sm text-foreground tabular-nums elevation-sm"
+              >
+                {String(value)}
+              </span>
+            ))}
+          </div>
+          {hasAnchors && (
+            <div className="flex items-baseline gap-2 text-[13px] leading-none text-muted-foreground">
+              <span className="flex-1 truncate text-left">{anchorLeft}</span>
+              <span className="flex-1 truncate text-center">{anchorCenter}</span>
+              <span className="flex-1 truncate text-right">{anchorRight}</span>
+            </div>
+          )}
+        </div>
       </div>
       <Tooltip>
         <TooltipTrigger

--- a/src/components/ui/form-matrix-node.tsx
+++ b/src/components/ui/form-matrix-node.tsx
@@ -206,17 +206,18 @@ export const FormMatrixElement = ({ children, ...props }: PlateElementProps) => 
   return (
     <PlateElement
       attributes={{ ...attributes, "data-bf-input": "true" }}
-      className="relative flex w-full cursor-default items-start rounded-[8px]"
+      className="group/matrix relative flex w-full cursor-default items-start rounded-[8px]"
       element={element}
       {...rest}
     >
       <div className="hidden">{children}</div>
 
-      <div
-        contentEditable={false}
-        className="flex flex-1 overflow-hidden rounded-lg bg-background elevation-sm dark:border dark:border-border dark:shadow-none"
-      >
-        <div className="flex min-w-0 flex-1 flex-col">
+      {/* Figma 25644-10558: bare table card; add-column / add-row live OUTSIDE as gray pill
+          strips (26153-13554 / 13569) with a 4px gap. The strips FLOAT (absolute, out of flow)
+          so the hidden state reserves no space and revealing them never reflows the table.
+          Tab-order is unchanged: column headers → add-column → row labels → add-row. */}
+      <div contentEditable={false} className="relative min-w-0 flex-1">
+        <div className="flex min-w-0 flex-col overflow-hidden rounded-lg bg-background elevation-sm dark:border dark:border-border dark:shadow-none">
           {/* Header: empty label cell + column-header inputs */}
           <div
             className="grid items-center border-b border-(--color-gray-200) bg-muted/30"
@@ -268,25 +269,10 @@ export const FormMatrixElement = ({ children, ...props }: PlateElementProps) => 
               ))}
             </div>
           ))}
-
-          {/* Add row — bottom-left corner rounds to the card; bottom-right meets the Add-column strip. */}
-          <div className="border-t border-(--color-gray-200)">
-            <button
-              ref={register(ADD_ROW_KEY)}
-              type="button"
-              onClick={() => addRowAfter(null)}
-              onKeyDown={handleButtonKeyDown(ADD_ROW_KEY)}
-              onPointerDown={(e) => e.stopPropagation()}
-              className="flex w-full items-center gap-1.5 rounded-bl-lg px-3 py-2 text-sm text-muted-foreground outline-none hover:text-foreground focus-visible:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-            >
-              <PlusGlyph />
-              Add row
-            </button>
-          </div>
         </div>
 
-        {/* Add column — vertical strip that's part of the table surface (shares the card, split
-            by a left divider), mirroring the full-width "Add row". Right corners round to the card. */}
+        {/* Add column — floating 24px pill spanning the table height, 4px right of the card
+            (Figma 26153-13554). Hidden until the matrix is hovered or the strip is Tab-focused. */}
         <button
           ref={register(ADD_COL_KEY)}
           type="button"
@@ -294,10 +280,23 @@ export const FormMatrixElement = ({ children, ...props }: PlateElementProps) => 
           onKeyDown={handleButtonKeyDown(ADD_COL_KEY)}
           onPointerDown={(e) => e.stopPropagation()}
           aria-label="Add column"
-          className="flex shrink-0 flex-col items-center justify-center gap-1.5 rounded-r-lg border-l border-(--color-gray-200) px-2 text-sm text-muted-foreground outline-none hover:text-foreground focus-visible:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+          className="absolute inset-y-0 -right-7 flex w-6 items-center justify-center rounded-full bg-muted text-muted-foreground opacity-0 transition-opacity duration-150 outline-none group-hover/matrix:opacity-100 hover:text-foreground focus-visible:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring"
         >
           <PlusGlyph />
-          <span className="[writing-mode:vertical-rl]">Add column</span>
+        </button>
+
+        {/* Add row — floating 24px pill spanning the table width, 4px below the card
+            (Figma 26153-13569). Same reveal rules as add-column. */}
+        <button
+          ref={register(ADD_ROW_KEY)}
+          type="button"
+          onClick={() => addRowAfter(null)}
+          onKeyDown={handleButtonKeyDown(ADD_ROW_KEY)}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label="Add row"
+          className="absolute inset-x-0 -bottom-7 flex h-6 items-center justify-center rounded-full bg-muted text-muted-foreground opacity-0 transition-opacity duration-150 outline-none group-hover/matrix:opacity-100 hover:text-foreground focus-visible:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <PlusGlyph />
         </button>
       </div>
 

--- a/src/components/ui/form-option-item-node.tsx
+++ b/src/components/ui/form-option-item-node.tsx
@@ -21,9 +21,9 @@ import { BlockSelection } from "@/components/ui/block-selection";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   ChevronDownIcon,
-  ChevronsUpDownIcon,
   Loader2Icon,
   PhotoIcon,
+  RankDragHandleIcon,
   TagIcon,
   XIcon,
 } from "@/components/ui/icons";
@@ -69,10 +69,10 @@ const OptionIcon = ({
         </span>
       );
     case "ranking":
-      // Reorder handle (Figma 25650-15798): up/down chevrons left of each rankable option.
+      // Reorder handle (Figma 26153-13884): "=" two-bar drag glyph left of each rankable option.
       return (
         <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">
-          <ChevronsUpDownIcon className="size-3.5" />
+          <RankDragHandleIcon className="size-4" />
         </span>
       );
     case "multiChoice":

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -1133,6 +1133,23 @@ export const SelectChevronIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+/** Figma icon/line/menu (26153-13886) — "=" two-bar drag handle on ranking option rows. */
+export const RankDragHandleIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M12.5 10C12.7761 10 13 10.2239 13 10.5C13 10.7761 12.7761 11 12.5 11H2.5C2.22386 11 2 10.7761 2 10.5C2 10.2239 2.22386 10 2.5 10H12.5ZM12.5 6C12.7761 6 13 6.22386 13 6.5C13 6.77614 12.7761 7 12.5 7H2.5C2.22386 7 2 6.77614 2 6.5C2 6.22386 2.22386 6 2.5 6H12.5Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 /** Inline value-select caret — thin stroked chevron-down (Figma's filled caret reads too heavy). */
 export const CaretDownIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg

--- a/src/hooks/use-form-versions.ts
+++ b/src/hooks/use-form-versions.ts
@@ -13,6 +13,7 @@ import {
   publishFormVersion,
   restoreFormVersion,
 } from "@/lib/server-fn/form-versions";
+import { stripProCustomization } from "@/lib/theme/pro-customization";
 import { useForm } from "./use-live-hooks";
 
 const EMPTY_STATUS = {
@@ -82,8 +83,9 @@ export const useFormPublishStatus = (formId: string | undefined) => {
 export const useHasUnpublishedChanges = (formId: string | undefined): boolean =>
   useFormPublishStatus(formId).hasAnyChanges;
 
-/** Publish draft. Optimistically sets status "published". */
-export const publishForm = (formId: string) => {
+/** Publish draft. Optimistically sets status "published". `stripProStyles` mirrors the server's
+ * free-plan Pro-key strip so the optimistic publishedContentHash matches what the server stores. */
+export const publishForm = (formId: string, opts?: { stripProStyles?: boolean }) => {
   const queryClient = getQueryClient();
   const tx = createTransaction({
     mutationFn: async () => {
@@ -105,7 +107,9 @@ export const publishForm = (formId: string) => {
       // Align publishedContentHash + liveSettings so both dirty flags clear before server refetch.
       draft.publishedContentHash = computeContentHash({
         content: draft.content,
-        customization: draft.customization,
+        customization: opts?.stripProStyles
+          ? stripProCustomization((draft.customization ?? {}) as Record<string, string>)
+          : draft.customization,
         title: draft.title,
         icon: draft.icon,
         cover: draft.cover,

--- a/src/lib/editor/transform-plate-to-form.ts
+++ b/src/lib/editor/transform-plate-to-form.ts
@@ -226,7 +226,7 @@ export type PlateFormField =
       label?: string;
       labelType?: string;
       required?: boolean;
-      options: { value: string; label: string }[];
+      options: { value: string; label: string; image?: string }[];
       /** Randomize initial option order in the live form. */
       shuffle?: boolean;
     }
@@ -241,6 +241,10 @@ export type PlateFormField =
       min: number;
       max: number;
       step: number;
+      /** Anchor labels rendered under the scale (Figma 25634-16668), e.g. Bad … Good. */
+      anchorLeft?: string;
+      anchorCenter?: string;
+      anchorRight?: string;
     }
   | {
       id: string;

--- a/src/lib/form-schema/form-field-constants.ts
+++ b/src/lib/form-schema/form-field-constants.ts
@@ -131,14 +131,36 @@ export const MATRIX_DEFAULTS = {
 /** Hard caps for the matrix editor's add-row / add-column affordances. */
 export const MATRIX_MAX = { rows: 50, columns: 20 } as const;
 
-/** `formLinearScale` settings live on the node (`scaleMin`/`scaleMax`/`scaleStep`);
- * fall back to the NPS defaults so a freshly inserted field renders 1–10. */
+// Anchor label (Left/Center/Right under the scale) — only non-blank strings survive.
+const readAnchor = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() ? value : undefined;
+
+/** `formLinearScale` settings live on the node (`scaleMin`/`scaleMax`/`scaleStep`,
+ * `anchorLeft`/`anchorCenter`/`anchorRight`); fall back to the NPS defaults so a
+ * freshly inserted field renders 1–10. */
 export const extractLinearScaleFields = (
   node: Record<string, unknown>,
-): { min: number; max: number; step: number } => {
+): {
+  min: number;
+  max: number;
+  step: number;
+  anchorLeft?: string;
+  anchorCenter?: string;
+  anchorRight?: string;
+} => {
   const min = typeof node.scaleMin === "number" ? node.scaleMin : LINEAR_SCALE_DEFAULTS.min;
   const max = typeof node.scaleMax === "number" ? node.scaleMax : LINEAR_SCALE_DEFAULTS.max;
   const rawStep = node.scaleStep;
   const step = typeof rawStep === "number" && rawStep > 0 ? rawStep : LINEAR_SCALE_DEFAULTS.step;
-  return { min, max, step };
+  const anchorLeft = readAnchor(node.anchorLeft);
+  const anchorCenter = readAnchor(node.anchorCenter);
+  const anchorRight = readAnchor(node.anchorRight);
+  return {
+    min,
+    max,
+    step,
+    ...(anchorLeft ? { anchorLeft } : {}),
+    ...(anchorCenter ? { anchorCenter } : {}),
+    ...(anchorRight ? { anchorRight } : {}),
+  };
 };

--- a/src/lib/server-fn/form-versions.ts
+++ b/src/lib/server-fn/form-versions.ts
@@ -11,10 +11,12 @@ import { authMiddleware } from "@/lib/auth/middleware";
 import { canonicalJSON, computeContentHash } from "@/lib/content-hash";
 import type { ErrorCode } from "@/lib/errors/codes";
 import { purgeFormCache } from "@/lib/server-fn/cdn-cache";
+import { stripProCustomization } from "@/lib/theme/pro-customization";
 import { defaultFormSettings } from "@/types/form-settings";
 import type { FormSettings } from "@/types/form-settings";
 import { getActiveOrgId } from "./auth-helpers";
 import { authForm } from "./auth-helpers.server";
+import { getOrgPlanWithPolarSync } from "./plan-helpers.server";
 
 // TODO: make plan-based
 const MAX_VERSIONS_PER_FORM = 20;
@@ -37,6 +39,10 @@ export const publishFormVersion = createServerFn({ method: "POST" })
   .handler(async ({ data, context }) => {
     const orgId = getActiveOrgId(context.session);
     await authForm(data.formId, context.session.user.id, orgId);
+
+    // Pro enforcement: free plans publish with Pro customization keys stripped from the snapshot
+    // (draft keeps them — the customize sidebar lets free users experiment).
+    const plan = await getOrgPlanWithPolarSync(orgId, context.session.user.email ?? null);
 
     const result = await db.transaction(async (tx) => {
       const [form] = await tx.select().from(forms).where(eq(forms.id, data.formId));
@@ -61,9 +67,15 @@ export const publishFormVersion = createServerFn({ method: "POST" })
 
       const now = new Date();
 
+      // Hash over the snapshot actually published (stripped for free) so a later upgrade-to-pro
+      // republish reads as dirty and snapshots the full styles.
+      const draftCustomization = (form.customization ?? {}) as Record<string, string>;
+      const customizationSnapshot =
+        plan === "free" ? stripProCustomization(draftCustomization) : draftCustomization;
+
       const contentHash = computeContentHash({
         content: form.content,
-        customization: form.customization ?? {},
+        customization: customizationSnapshot,
         title: form.title,
         icon: form.icon,
         cover: form.cover,
@@ -110,7 +122,7 @@ export const publishFormVersion = createServerFn({ method: "POST" })
             content: form.content,
             // Settings excluded from versions: null on new rows; legacy rows keep pre-split snapshot.
             settings: null,
-            customization: form.customization ?? {},
+            customization: customizationSnapshot,
             title: form.title,
             icon: form.icon,
             cover: form.cover,

--- a/src/lib/server-fn/form-versions.ts
+++ b/src/lib/server-fn/form-versions.ts
@@ -40,10 +40,6 @@ export const publishFormVersion = createServerFn({ method: "POST" })
     const orgId = getActiveOrgId(context.session);
     await authForm(data.formId, context.session.user.id, orgId);
 
-    // Pro enforcement: free plans publish with Pro customization keys stripped from the snapshot
-    // (draft keeps them — the customize sidebar lets free users experiment).
-    const plan = await getOrgPlanWithPolarSync(orgId, context.session.user.email ?? null);
-
     const result = await db.transaction(async (tx) => {
       const [form] = await tx.select().from(forms).where(eq(forms.id, data.formId));
 
@@ -67,11 +63,20 @@ export const publishFormVersion = createServerFn({ method: "POST" })
 
       const now = new Date();
 
-      // Hash over the snapshot actually published (stripped for free) so a later upgrade-to-pro
-      // republish reads as dirty and snapshots the full styles.
+      // Pro enforcement: free plans publish with Pro customization stripped (the draft keeps them
+      // — the customize sidebar lets free users experiment). Resolve the plan (DB read + possible
+      // Polar round-trip) ONLY when the draft actually holds Pro keys, so the common
+      // free-user / clean-draft publish skips it. Hash over the published snapshot so a later
+      // upgrade-to-pro republish reads as dirty and re-snapshots the full styles.
       const draftCustomization = (form.customization ?? {}) as Record<string, string>;
+      const strippedCustomization = stripProCustomization(draftCustomization);
+      const hasProCustomization =
+        Object.keys(strippedCustomization).length !== Object.keys(draftCustomization).length;
       const customizationSnapshot =
-        plan === "free" ? stripProCustomization(draftCustomization) : draftCustomization;
+        hasProCustomization &&
+        (await getOrgPlanWithPolarSync(orgId, context.session.user.email ?? null)) === "free"
+          ? strippedCustomization
+          : draftCustomization;
 
       const contentHash = computeContentHash({
         content: form.content,

--- a/src/lib/server-fn/plan-helpers.ts
+++ b/src/lib/server-fn/plan-helpers.ts
@@ -10,11 +10,13 @@ export type FormProSettingsInput = {
   respondentEmailNotifications?: boolean;
   dataRetention?: boolean;
   analytics?: boolean;
-  customization?: Record<string, unknown> | null;
 };
 
-// Free-plan customization keys (basic Theme controls). Anything outside (per-mode colors,
-// layout, typography, custom CSS) is Pro-only and triggers the customization gate.
+// Free-plan customization keys (basic Theme controls) — consumed by the AI form-gen theming
+// path. NOT a draft-write gate: the soft Pro gate lets free users hold Pro customization in
+// drafts; publishFormVersion strips Pro keys from the published snapshot instead. Gating
+// updateForm here caused an optimistic-rollback loop (hover-applied controls re-fired on
+// every revert).
 export const FREE_CUSTOMIZATION_KEYS: ReadonlySet<string> = new Set([
   "preset",
   "themeColor",
@@ -24,15 +26,8 @@ export const FREE_CUSTOMIZATION_KEYS: ReadonlySet<string> = new Set([
   "defaultMode",
 ]);
 
-const customizationRequiresPro = (value: unknown): boolean => {
-  if (value == null || typeof value !== "object") return false;
-  for (const key of Object.keys(value as Record<string, unknown>)) {
-    if (!FREE_CUSTOMIZATION_KEYS.has(key)) return true;
-  }
-  return false;
-};
-
 // Maps each FormProSettingsInput field → FeatureGate + predicate for when it's gating-eligible.
+// These are LIVE settings (take effect without publish), so they stay hard-gated.
 const FORM_INPUT_GATES: ReadonlyArray<{
   field: keyof FormProSettingsInput;
   gate: FeatureGate;
@@ -46,11 +41,6 @@ const FORM_INPUT_GATES: ReadonlyArray<{
   },
   { field: "dataRetention", gate: "dataRetention", isActive: (v) => v === true },
   { field: "analytics", gate: "analytics", isActive: (v) => v === true },
-  {
-    field: "customization",
-    gate: "customization",
-    isActive: customizationRequiresPro,
-  },
 ];
 
 // FeatureGates this input activates; empty = no plan check needed.

--- a/src/lib/theme/pro-customization.ts
+++ b/src/lib/theme/pro-customization.ts
@@ -1,0 +1,77 @@
+/**
+ * Pro-gated customization keys (the customize-sidebar Pro sections). Free users can tweak them
+ * in the draft (sidebar no longer hard-blocks); publish strips them from the version snapshot —
+ * server-enforced in publishFormVersion, surfaced client-side by the pro-publish-gate dialog.
+ */
+
+// Mode-scoped color token overrides (written as `light:<token>` / `dark:<token>`; legacy rows
+// may carry the bare token name) — the Colors section's SEMANTIC_COLOR_TOKENS.
+const PRO_COLOR_TOKENS = new Set([
+  "title-color",
+  "foreground",
+  "background",
+  "input",
+  "primary",
+  "destructive",
+  "success",
+]);
+
+const PRO_SECTIONS: { label: string; keys: readonly string[] }[] = [
+  {
+    label: "Typography",
+    keys: [
+      "font",
+      "titleFont",
+      "titleFontSize",
+      "baseFontSize",
+      "titleLetterSpacing",
+      "letterSpacing",
+      "titleLineHeight",
+      "lineHeight",
+      "textAlign",
+    ],
+  },
+  // Colors handled via PRO_COLOR_TOKENS (mode-prefixed), Custom CSS via customCss matcher.
+  {
+    label: "Inputs",
+    keys: ["inputWidth", "inputHeight", "inputRadius", "inputMarginBottom", "inputPadding"],
+  },
+  { label: "Buttons", keys: ["buttonWidth", "buttonHeight", "buttonRadius"] },
+];
+
+const PRO_PLAIN_KEY_SECTION = new Map<string, string>(
+  PRO_SECTIONS.flatMap((s) => s.keys.map((k) => [k, s.label] as const)),
+);
+
+/** Section label for a pro-gated key, or null if the key is free. */
+export const proSectionForKey = (key: string): string | null => {
+  const plain = PRO_PLAIN_KEY_SECTION.get(key);
+  if (plain) return plain;
+  // strip optional light:/dark: mode prefix for token + customCss matching
+  const bare = key.replace(/^(?:light|dark):/, "");
+  if (bare === "customCss") return "Custom CSS";
+  if (PRO_COLOR_TOKENS.has(bare)) return "Colors";
+  return null;
+};
+
+/** Ordered Pro section labels with at least one non-empty value set (for the publish dialog). */
+export const getProCustomizationSections = (
+  customization: Record<string, string> | null | undefined,
+): string[] => {
+  const found = new Set<string>();
+  for (const [key, value] of Object.entries(customization ?? {})) {
+    if (!value) continue; // mode-migration leaves ""-valued keys behind — not active styles
+    const section = proSectionForKey(key);
+    if (section) found.add(section);
+  }
+  const order = ["Typography", "Colors", "Inputs", "Buttons", "Custom CSS"];
+  return order.filter((s) => found.has(s));
+};
+
+/** Customization with all pro-gated keys removed — what a free plan actually publishes. */
+export const stripProCustomization = (
+  customization: Record<string, string> | null | undefined,
+): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(customization ?? {}).filter(([key]) => proSectionForKey(key) === null),
+  );

--- a/src/lib/theme/pro-customization.ts
+++ b/src/lib/theme/pro-customization.ts
@@ -1,7 +1,13 @@
+import { FREE_CUSTOMIZATION_KEYS } from "@/lib/server-fn/plan-helpers";
+
 /**
  * Pro-gated customization keys (the customize-sidebar Pro sections). Free users can tweak them
  * in the draft (sidebar no longer hard-blocks); publish strips them from the version snapshot —
  * server-enforced in publishFormVersion, surfaced client-side by the pro-publish-gate dialog.
+ *
+ * FREE_CUSTOMIZATION_KEYS (the basic Theme controls the AI free tier also writes) is the single
+ * source of truth for what is free — proSectionForKey short-circuits to null for those, so a
+ * key listed there (e.g. `font`) can never be stripped or flagged, even if it overlaps a section.
  */
 
 // Mode-scoped color token overrides (written as `light:<token>` / `dark:<token>`; legacy rows
@@ -18,9 +24,10 @@ const PRO_COLOR_TOKENS = new Set([
 
 const PRO_SECTIONS: { label: string; keys: readonly string[] }[] = [
   {
+    // `font` (body font family) is intentionally absent — it's a FREE_CUSTOMIZATION_KEYS basic
+    // Theme control. Only the title font + sizing/spacing/alignment are Pro.
     label: "Typography",
     keys: [
-      "font",
       "titleFont",
       "titleFontSize",
       "baseFontSize",
@@ -45,6 +52,8 @@ const PRO_PLAIN_KEY_SECTION = new Map<string, string>(
 
 /** Section label for a pro-gated key, or null if the key is free. */
 export const proSectionForKey = (key: string): string | null => {
+  // Basic Theme controls are free everywhere (single source of truth) — never strip/flag them.
+  if (FREE_CUSTOMIZATION_KEYS.has(key)) return null;
   const plain = PRO_PLAIN_KEY_SECTION.get(key);
   if (plain) return plain;
   // strip optional light:/dark: mode prefix for token + customCss matching

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -558,7 +558,8 @@ const AppSidebar = () => {
 
   return (
     <>
-      <Sidebar className="h-screen border-r-[0.5px] bg-background">
+      {/* [font-variation-settings:normal] un-pins the global opsz20/wght450 so font-weight utils apply */}
+      <Sidebar className="h-screen border-r-[0.5px] bg-background [font-variation-settings:normal]">
         {showMobileInbox ? (
           <InboxPanelBody
             onClose={closeInbox}
@@ -1287,7 +1288,8 @@ const InboxPanelBody = ({ onClose, headerLeft }: InboxPanelBodyProps) => {
   const hasPendingInvitations = pendingInvitations.length > 0;
 
   return (
-    <div className="flex size-full flex-col">
+    // [font-variation-settings:normal] un-pins the global opsz20/wght450 so font-weight utils apply
+    <div className="flex size-full flex-col [font-variation-settings:normal]">
       <SidebarHeader className="shrink-0 gap-2.25 space-y-2 pt-2 pb-3 pl-1">
         <div className="flex items-center justify-between gap-1">
           <div className="flex min-w-0 items-center gap-1">

--- a/src/routes/_authenticated/-components/user-menu-minimal.tsx
+++ b/src/routes/_authenticated/-components/user-menu-minimal.tsx
@@ -3,6 +3,7 @@ import { useResolvedTheme, useTheme } from "@/components/theme-provider";
 import { IconSwap } from "@/components/transitions/icon-swap";
 import { auth, useSession } from "@/lib/auth/auth-client";
 import { settingsDialogStore } from "@/hooks/use-settings-dialog";
+import { useUserPlan } from "@/hooks/use-user-plan";
 import { cn } from "@/lib/utils";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
@@ -50,6 +51,10 @@ export const UserMenuMinimal = ({ onOpenTrash }: UserMenuMinimalProps) => {
     select: (d) => d.activeOrg,
   });
   const displayName = activeOrg?.name ?? session?.user?.name ?? "User";
+
+  // Was hardcoded "Free Plan" — read the active org's real subscription tier.
+  const { plan, isLoading: isPlanLoading } = useUserPlan();
+  const planLabel = { free: "Free Plan", pro: "Pro Plan", business: "Business Plan" }[plan];
 
   const signOutMutation = useMutation(
     auth.signOut.mutationOptions({
@@ -148,7 +153,10 @@ export const UserMenuMinimal = ({ onOpenTrash }: UserMenuMinimalProps) => {
             </div>
             <div className="flex min-w-0 flex-col">
               <span className="truncate text-[13px] text-foreground">{displayName}</span>
-              <span className="text-[11px] text-muted-foreground">Free Plan</span>
+              {/* nbsp placeholder while loading — avoids flashing the wrong tier */}
+              <span className="text-[11px] text-muted-foreground">
+                {isPlanLoading ? " " : planLabel}
+              </span>
             </div>
           </div>
 

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-drawer.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-drawer.tsx
@@ -54,7 +54,7 @@ export const PreviewDrawer = ({ open, onClose, children }: PreviewDrawerProps) =
     >
       <DrawerPortal>
         <DrawerOverlay />
-        <DrawerPrimitive.Content className="fixed inset-2 z-50 flex flex-col overflow-hidden rounded-[10px] bg-background shadow-[0px_0px_4px_0px_rgba(0,0,0,0.08)] outline-none">
+        <DrawerPrimitive.Content className="preview-zoom-drawer fixed inset-2 z-50 flex flex-col overflow-hidden rounded-[10px] bg-background shadow-[0px_0px_4px_0px_rgba(0,0,0,0.08)] outline-none">
           <DrawerTitle className="sr-only">Form preview</DrawerTitle>
           <div className="pointer-events-none absolute inset-x-2 top-2 z-30 flex items-center justify-between">
             {/* Own view-transition groups: tab switches snapshot only "preview-content", keeping the chrome static (no cross-fade flash). */}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -931,11 +931,11 @@
 }
 
 /* Input fill metrics: unset fallbacks match the current literal classes
-   (h-7 = 1.75rem, rounded-[8px], pr-[8px] pl-[10px]) so unset = identical. */
+   (h-7 = 1.75rem, rounded-[8px], px-[10px]) so unset = identical. */
 .bf-themed [data-bf-input-fill] {
   height: var(--bf-input-height, 1.75rem);
   border-radius: var(--bf-input-radius, 8px);
-  padding: var(--bf-input-padding, 0 8px 0 10px);
+  padding: var(--bf-input-padding, 0 10px);
 }
 
 /* Submit button metrics: unset fallbacks match current submit button

--- a/src/styles/vaul-base.css
+++ b/src/styles/vaul-base.css
@@ -218,6 +218,38 @@
   }
 }
 
+/* Preview drawer: zoom from center instead of sliding up from the bottom. */
+.preview-zoom-drawer[data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="bottom"][data-open] {
+  animation-name: previewZoomIn;
+}
+.preview-zoom-drawer[data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="bottom"]:not(
+    [data-open]
+  ) {
+  animation-name: previewZoomOut;
+}
+
+@keyframes previewZoomIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes previewZoomOut {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+
 @keyframes slideFromTop {
   from {
     transform: translate3d(0, calc(var(--initial-transform, 100%) * -1), 0);

--- a/src/test/ai-theme-merge.test.ts
+++ b/src/test/ai-theme-merge.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { requiresProForFormSettings } from "@/lib/server-fn/plan-helpers";
 import {
   mergeSetThemeOpIntoCustomization,
   mergeThemeIntoCustomization,
@@ -36,9 +35,6 @@ describe("mergeThemeIntoCustomization (theme-mode optimistic write)", () => {
       ...freeThemePayload,
       preset: "custom",
     });
-
-    // The whole point of Bug 1's fix: the gate must NOT fire for this payload.
-    expect(requiresProForFormSettings({ customization: merged })).toBeFalsy();
   });
 
   it("merges a free-tier theme on top of an existing free preset without triggering the Pro gate", () => {
@@ -50,15 +46,13 @@ describe("mergeThemeIntoCustomization (theme-mode optimistic write)", () => {
     // Theme overrides existing themeColor; preset is rewritten to "custom".
     expect(merged.themeColor).toBe("blue");
     expect(merged.preset).toBe("custom");
-
-    expect(requiresProForFormSettings({ customization: merged })).toBeFalsy();
   });
 
-  it("merges a Pro-tier theme — gate fires (so the server can plan-check)", () => {
+  it("merges a Pro-tier theme — light/dark token overrides land in customization", () => {
+    // Customization is no longer a draft-write gate (soft Pro gate strips at publish instead).
     const merged = mergeThemeIntoCustomization({}, proThemePayload);
-
-    // Pro payload writes light:/dark: token overrides. Those are Pro-only.
-    expect(requiresProForFormSettings({ customization: merged })).toBeTruthy();
+    expect(merged["light:primary"]).toBe("#2563eb");
+    expect(merged["dark:primary"]).toBe("#3b82f6");
   });
 
   it("strips stale Pro-tier keys when merging a free-tier theme (no key carry-over)", () => {
@@ -78,17 +72,16 @@ describe("mergeThemeIntoCustomization (theme-mode optimistic write)", () => {
     expect(merged.customCss).toBeUndefined();
   });
 
-  it("after stripping stale Pro keys on a free-tier merge, the resulting customization passes the gate", () => {
+  it("after stripping stale Pro keys on a free-tier merge, only free keys remain", () => {
     const merged = mergeThemeIntoCustomization(
       { "light:primary": "#abcdef", customCss: ".x {}", themeColor: "zinc" },
       freeThemePayload,
     );
 
-    // New theme is applied, preset flipped to custom.
+    // New theme is applied, preset flipped to custom; no Pro-tier keys survive the strip.
     expect(merged.themeColor).toBe("blue");
     expect(merged.preset).toBe("custom");
-    // The whole point: the resulting customization no longer trips the gate.
-    expect(requiresProForFormSettings({ customization: merged })).toBeFalsy();
+    expect(Object.keys(merged).some((k) => k.includes(":") || k === "customCss")).toBeFalsy();
   });
 
   it("keeps existing Pro-tier keys when merging a Pro-tier theme (Pro users retain their full customization)", () => {

--- a/src/test/plan-write-gates.test.ts
+++ b/src/test/plan-write-gates.test.ts
@@ -59,10 +59,6 @@ describe("plan-write-gates", () => {
       expect(requiresProForFormSettings({})).toBeFalsy();
     });
 
-    it("false when customization is an empty object", () => {
-      expect(requiresProForFormSettings({ customization: {} })).toBeFalsy();
-    });
-
     it("true when branding is being removed", () => {
       expect(requiresProForFormSettings({ branding: false })).toBeTruthy();
     });
@@ -79,50 +75,23 @@ describe("plan-write-gates", () => {
       expect(requiresProForFormSettings({ analytics: true })).toBeTruthy();
     });
 
-    it("true when customization carries a Pro-tier key (light/dark token override)", () => {
-      expect(
-        requiresProForFormSettings({ customization: { "light:primary": "#abcdef" } }),
-      ).toBeTruthy();
-    });
-
-    it("true when customization carries a non-free key (e.g. customCss)", () => {
-      expect(
-        requiresProForFormSettings({ customization: { customCss: ".x { color: red }" } }),
-      ).toBeTruthy();
-    });
-
-    it("false when customization only contains basic Theme keys (preset / themeColor / baseColor / font / radius / defaultMode)", () => {
+    // Customization is NOT a draft-write gate: free drafts may hold Pro keys (soft Pro gate);
+    // publishFormVersion strips them from the published snapshot. Gating updateForm caused an
+    // optimistic-rollback loop on hover-driven customize controls.
+    it("false when customization carries Pro-tier keys (soft-gated at publish, not draft write)", () => {
       expect(
         requiresProForFormSettings({
-          customization: {
-            preset: "custom",
-            themeColor: "blue",
-            baseColor: "neutral",
-            font: "Inter",
-            radius: "medium",
-            defaultMode: "system",
-          },
-        }),
+          customization: { "light:primary": "#abcdef", customCss: ".x {}" },
+        } as Parameters<typeof requiresProForFormSettings>[0]),
       ).toBeFalsy();
     });
 
-    it("true when basic Theme keys are mixed with a Pro-tier key", () => {
-      expect(
-        requiresProForFormSettings({
-          customization: {
-            themeColor: "blue",
-            "light:primary": "#abcdef",
-          },
-        }),
-      ).toBeTruthy();
-    });
-
-    it("true when multiple Pro fields are combined", () => {
+    it("true when a live Pro setting is combined with customization", () => {
       expect(
         requiresProForFormSettings({
           branding: false,
           customization: { customCss: ".x {}" },
-        }),
+        } as Parameters<typeof requiresProForFormSettings>[0]),
       ).toBeTruthy();
     });
 

--- a/src/test/pro-customization.test.ts
+++ b/src/test/pro-customization.test.ts
@@ -31,9 +31,18 @@ describe("proSectionForKey", () => {
       "themeColor",
       "radius",
       "spacing",
+      // `font` (body font family) is a FREE_CUSTOMIZATION_KEYS basic Theme control — must NOT be
+      // classified Pro, else free users (incl. AI free-tier theming) lose their font on publish.
+      "font",
     ]) {
       expect(proSectionForKey(key)).toBeNull();
     }
+  });
+
+  it("keeps the title font and body sizing/spacing Pro (only body `font` is free)", () => {
+    expect(proSectionForKey("titleFont")).toBe("Typography");
+    expect(proSectionForKey("baseFontSize")).toBe("Typography");
+    expect(proSectionForKey("letterSpacing")).toBe("Typography");
   });
 });
 

--- a/src/test/pro-customization.test.ts
+++ b/src/test/pro-customization.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  getProCustomizationSections,
+  proSectionForKey,
+  stripProCustomization,
+} from "@/lib/theme/pro-customization";
+
+describe("proSectionForKey", () => {
+  it("classifies pro keys to their sections", () => {
+    expect(proSectionForKey("titleFont")).toBe("Typography");
+    expect(proSectionForKey("textAlign")).toBe("Typography");
+    expect(proSectionForKey("light:primary")).toBe("Colors");
+    expect(proSectionForKey("dark:title-color")).toBe("Colors");
+    expect(proSectionForKey("foreground")).toBe("Colors"); // legacy unprefixed token
+    expect(proSectionForKey("inputRadius")).toBe("Inputs");
+    expect(proSectionForKey("buttonHeight")).toBe("Buttons");
+    expect(proSectionForKey("customCss")).toBe("Custom CSS");
+    expect(proSectionForKey("dark:customCss")).toBe("Custom CSS");
+  });
+
+  it("leaves free (Appearance/preset) keys ungated", () => {
+    for (const key of [
+      "pageWidth",
+      "coverWidth",
+      "coverRadius",
+      "logoRadius",
+      "logoWidth",
+      "defaultMode",
+      "preset",
+      "baseColor",
+      "themeColor",
+      "radius",
+      "spacing",
+    ]) {
+      expect(proSectionForKey(key)).toBeNull();
+    }
+  });
+});
+
+describe("getProCustomizationSections", () => {
+  it("returns ordered labels for active pro values only", () => {
+    expect(
+      getProCustomizationSections({
+        buttonRadius: "8",
+        titleFont: "Inter",
+        pageWidth: "80%",
+        foreground: "", // mode-migration leftover — inactive
+      }),
+    ).toEqual(["Typography", "Buttons"]);
+  });
+
+  it("handles null/empty customization", () => {
+    expect(getProCustomizationSections(null)).toEqual([]);
+    expect(getProCustomizationSections({})).toEqual([]);
+  });
+});
+
+describe("stripProCustomization", () => {
+  it("removes pro keys, keeps free keys", () => {
+    expect(
+      stripProCustomization({
+        pageWidth: "80%",
+        preset: "custom",
+        titleFont: "Inter",
+        "light:primary": "#ff0000",
+        inputHeight: "40",
+        customCss: ".x{}",
+        defaultMode: "dark",
+      }),
+    ).toEqual({ pageWidth: "80%", preset: "custom", defaultMode: "dark" });
+  });
+
+  it("is identity for pro-free customization", () => {
+    const free = { pageWidth: "70%", coverRadius: "12" };
+    expect(stripProCustomization(free)).toEqual(free);
+    expect(stripProCustomization(null)).toEqual({});
+  });
+});


### PR DESCRIPTION
…gate

- linear scale: "Add Anchor" block-menu submenu (Left/Center/Right labels),
  rendered under the scale in editor + preview, width-matched to the tiles
- matrix: bare table card with floating add-row/add-column pills (hover/focus
  reveal, absolute so no layout reflow); keyboard tab-order preserved
- ranking: Figma "=" drag handle in editor + preview, per-option images in
  preview, CSS.Translate to avoid mixed-height drag distortion, drag-to-rank
- soft Pro gate: free users can experiment with Pro customization in drafts;
  publishFormVersion strips Pro keys from the published snapshot, with an
  upgrade-or-publish-without dialog. Removes the draft-write customization gate
  that caused an optimistic-rollback loop on hover-driven customize controls
- user menu shows the real plan tier (was hardcoded "Free Plan")
- per-sidebar font-variation-settings reset so weights/optical size match Figma