### PR TITLE
feat(forms): @-mention field tokens + multi-value logic, with review fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@platejs/list": "^52.3.10",
     "@platejs/markdown": "^52.3.22",
     "@platejs/media": "^52.3.10",
+    "@platejs/mention": "52.3.10",
     "@platejs/resizable": "^52.3.10",
     "@platejs/selection": "^52.3.10",
     "@platejs/slash-command": "^52.3.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@platejs/media':
         specifier: ^52.3.10
         version: 52.3.10(platejs@52.3.21(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@platejs/mention':
+        specifier: 52.3.10
+        version: 52.3.10(platejs@52.3.21(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@platejs/resizable':
         specifier: ^52.3.10
         version: 52.3.10(platejs@52.3.21(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -2419,6 +2422,13 @@ packages:
     resolution: {integrity: sha512-crUkwHqlDUBMwdk0fFZUls+5cj7HHYpXx75tzc6Fe4PhyqucPUFqJiLRlFgdo+lCj7HCPqTzKcsycGJmvqEv6Q==}
     peerDependencies:
       platejs: '>=52.0.11'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@platejs/mention@52.3.10':
+    resolution: {integrity: sha512-73Yp5WfbokDkJ4lBcvsnUVD79r0ANkVNEdu3I8VW4TEhwoYrBd+mkqCnimkyjQn1bf9P6MlB1RirlKdj9RvCpw==}
+    peerDependencies:
+      platejs: '>=52.0.15'
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
@@ -9459,6 +9469,14 @@ snapshots:
   '@platejs/media@52.3.10(platejs@52.3.21(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       js-video-url-parser: 0.5.1
+      platejs: 52.3.21(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6))
+      react: 19.2.6
+      react-compiler-runtime: 1.0.0(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@platejs/mention@52.3.10(platejs@52.3.21(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@platejs/combobox': 52.3.10(platejs@52.3.21(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       platejs: 52.3.21(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6))
       react: 19.2.6
       react-compiler-runtime: 1.0.0(react@19.2.6)

--- a/src/components/editor/editor-kit.tsx
+++ b/src/components/editor/editor-kit.tsx
@@ -24,6 +24,7 @@ import { LinkKit } from "@/components/editor/plugins/link-kit";
 import { ListKit } from "@/components/editor/plugins/list-kit";
 import { MarkdownKit } from "@/components/editor/plugins/markdown-kit";
 import { MediaKit } from "@/components/editor/plugins/media-kit";
+import { MentionKit } from "@/components/editor/plugins/mention-kit";
 import { SlashKit } from "@/components/editor/plugins/slash-kit";
 import { TocKit } from "@/components/editor/plugins/toc-kit";
 import { ToggleKit } from "@/components/editor/plugins/toggle-kit";
@@ -53,6 +54,7 @@ export const EditorKit = [
   TabGuardPlugin,
 
   ...SlashKit,
+  ...MentionKit,
   ...AutoformatKit,
   ...CursorOverlayKit,
   ...BlockMenuKit,

--- a/src/components/editor/plugins/mention-fields.ts
+++ b/src/components/editor/plugins/mention-fields.ts
@@ -1,0 +1,79 @@
+import type { TElement } from "platejs";
+import type { PlateEditor } from "platejs/react";
+
+import { fieldsBefore } from "@/lib/editor/resolve-mentions";
+import {
+  getFieldsFromSegments,
+  transformPlateForPreview,
+} from "@/lib/editor/transform-plate-for-preview";
+import { INPUT_TYPE_TO_FIELD_TYPE } from "@/lib/form-schema/form-field-constants";
+
+/** Field types whose answer is a single, displayable value — what an `@`-mention can
+ * usefully inline. Excludes Matrix/Signature/FileUpload/Button (object/binary answers). */
+const MENTIONABLE_FIELD_TYPES = new Set([
+  "Input",
+  "Textarea",
+  "Email",
+  "Phone",
+  "Number",
+  "Link",
+  "Date",
+  "Time",
+  "Checkbox",
+  "MultiChoice",
+  "Ranking",
+  "LinearScale",
+  "Rating",
+]);
+
+/** Top-level node types that don't begin a field (skipped so the start-index scan stays
+ * aligned 1:1 with transformPlateForPreview's field order). */
+const NON_FIELD_TYPES = new Set(["pageBreak", "logicBlock", "formButton", "formHeader"]);
+
+/** Mirrors createSegments' field detection: a node that begins a new field. Consecutive
+ * option items collapse into one field, so only the first of a run counts. */
+const isFieldStart = (type: string | undefined, prevType: string | undefined): boolean => {
+  if (!type) return false;
+  if (INPUT_TYPE_TO_FIELD_TYPE[type]) return true;
+  if (type === "formMatrix") return true;
+  if (type === "formOptionItem") return prevType !== "formOptionItem";
+  return false;
+};
+
+export interface MentionableField {
+  /** Stable field `name` — stored on the mention node so renames don't break it. */
+  key: string;
+  /** Display label shown in the picker and on the pill. */
+  text: string;
+}
+
+/** Fields a `@`-mention at `element` may reference: only those positioned BEFORE it in the
+ * document (excludes the field this mention belongs to and everything after), filtered to
+ * value-bearing types. Guarantees the referenced answer exists by the time the field renders. */
+export const getMentionableFields = (
+  editor: PlateEditor,
+  element: TElement,
+): MentionableField[] => {
+  // Global field list — names match the ones used at resolution time.
+  const { steps } = transformPlateForPreview(editor.children);
+  const fields = steps.flatMap(getFieldsFromSegments).filter((f) => f.fieldType !== "Button");
+
+  // Parallel scan: top-level index where each field begins, in the same order as `fields`.
+  const nodes = editor.children as Array<{ type?: string }>;
+  const startIndices: number[] = [];
+  for (let t = 0; t < nodes.length; t++) {
+    const type = nodes[t]?.type;
+    if (type && NON_FIELD_TYPES.has(type)) continue;
+    if (isFieldStart(type, nodes[t - 1]?.type)) startIndices.push(t);
+  }
+
+  // Cutoff = first field at/after the mention's block → the owning/following field; excluded.
+  const path = editor.api.findPath(element);
+  const blockIndex = path?.[0] ?? nodes.length;
+  const cutoffIdx = startIndices.findIndex((idx) => idx >= blockIndex);
+  const cutoffName = cutoffIdx === -1 ? null : (fields[cutoffIdx]?.name ?? null);
+
+  return fieldsBefore(fields, cutoffName)
+    .filter((f) => MENTIONABLE_FIELD_TYPES.has(f.fieldType))
+    .map((f) => ({ key: f.name, text: f.label ?? f.name }));
+};

--- a/src/components/editor/plugins/mention-kit.tsx
+++ b/src/components/editor/plugins/mention-kit.tsx
@@ -1,0 +1,12 @@
+import { MentionInputPlugin, MentionPlugin } from "@platejs/mention/react";
+
+import { MentionElement, MentionInputElement } from "@/components/ui/mention-node";
+
+// `@` opens a field picker (see mention-node). Insert-only — no space appended, so a token
+// can sit mid-sentence ("hi , @Name , ...").
+export const MentionKit = [
+  MentionPlugin.configure({ options: { insertSpaceAfterMention: false } }).withComponent(
+    MentionElement,
+  ),
+  MentionInputPlugin.withComponent(MentionInputElement),
+];

--- a/src/components/form-components/fields/shared.tsx
+++ b/src/components/form-components/fields/shared.tsx
@@ -1,9 +1,14 @@
+import { useStore } from "@tanstack/react-form";
+import { Fragment } from "react";
+
 import { getOptionOrdinal } from "@/components/ui/form-option-item-constants";
 import type { OptionLabelStyle } from "@/components/ui/form-option-item-constants";
 import { CheckIcon, ImageIcon } from "@/components/ui/icons";
 import { Label } from "@/components/ui/label";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { AppForm } from "@/hooks/use-form-builder";
+import { resolveMentions } from "@/lib/editor/resolve-mentions";
+import type { LabelTokenNode } from "@/lib/editor/resolve-mentions";
 import type { PlateFormField } from "@/lib/editor/transform-plate-to-form";
 import { cn } from "@/lib/utils";
 
@@ -23,6 +28,7 @@ export const getFieldLabelProps = (element: PlateFormField) => ({
   label: "label" in element ? (element.label ?? "") : "",
   required: "required" in element ? !!element.required : false,
   labelType: "labelType" in element ? element.labelType : undefined,
+  labelNodes: "labelNodes" in element ? element.labelNodes : undefined,
 });
 
 export const getAriaLabelFallback = (element: PlateFormField): string | undefined => {
@@ -255,12 +261,61 @@ export const ImageOptionGrid = ({
   </div>
 );
 
+/** Label/description body. With `@`-mention tokens (labelNodes) it subscribes to the live
+ * form values and swaps each token for its answer — a faint placeholder until answered. */
+const LabelBody = ({
+  text,
+  labelNodes,
+  form,
+}: {
+  text: string;
+  labelNodes?: LabelTokenNode[];
+  form?: AppForm;
+}) => {
+  // Gate the hook in a child so its order stays stable — removing a label's last mention flips
+  // labelNodes to undefined, and a conditional useStore here would change the hook count → crash.
+  if (!labelNodes || !form) return <>{text}</>;
+  return <LabelBodyWithMentions labelNodes={labelNodes} form={form} />;
+};
+
+const LabelBodyWithMentions = ({
+  labelNodes,
+  form,
+}: {
+  labelNodes: LabelTokenNode[];
+  form: AppForm;
+}) => {
+  // Subscribe to all values so a token re-renders the moment its source field changes.
+  const values = useStore(form.store, (s) => s.values) as Record<string, unknown>;
+  const runs = resolveMentions(labelNodes, {
+    getValue: (name) => values[name],
+    getLabel: () => undefined,
+  });
+  return (
+    <>
+      {runs.map((run, i) => (
+        <Fragment key={i}>
+          {run.kind === "placeholder" ? (
+            <span className="text-muted-foreground" data-bf-mention-placeholder>
+              {run.text}
+            </span>
+          ) : (
+            run.text
+          )}
+        </Fragment>
+      ))}
+    </>
+  );
+};
+
 export const FieldLabelText = ({
   text,
   labelType,
   htmlFor,
   required,
   asGroupLabel = false,
+  labelNodes,
+  form,
 }: {
   text: string;
   labelType?: string;
@@ -268,17 +323,23 @@ export const FieldLabelText = ({
   required?: boolean;
   /** Render label as non-<label> w/ stable id. Group fields (Checkbox/MultiChoice/Ranking) have no single <input id>; role="group" wrapper uses aria-labelledby. */
   asGroupLabel?: boolean;
+  /** Raw label children when the label carries `@`-mention tokens (see transform). */
+  labelNodes?: LabelTokenNode[];
+  /** Live form instance — required to resolve mention tokens to answers. */
+  form?: AppForm;
 }) => {
-  if (!text) return null;
+  // A mention-only label flattens to "" but still has content to render.
+  if (!text && !labelNodes) return null;
   const badge = required ? <RequiredBadge /> : null;
   const labelId = fieldLabelId(htmlFor);
+  const body = <LabelBody text={text} labelNodes={labelNodes} form={form} />;
 
   // Heading/blockquote labels are non-<label>, can't use htmlFor. Stable id; input wires aria-labelledby (see RenderStepPreviewInput).
   if (labelType === "h1") {
     return (
       <div className="flex w-full items-center py-2.5">
         <h1 id={labelId} className="font-heading flex-1 text-4xl font-semibold">
-          {text}
+          {body}
         </h1>
         {badge}
       </div>
@@ -288,7 +349,7 @@ export const FieldLabelText = ({
     return (
       <div className="flex w-full items-center py-2.5">
         <h2 id={labelId} className="font-heading flex-1 text-2xl font-semibold">
-          {text}
+          {body}
         </h2>
         {badge}
       </div>
@@ -298,7 +359,7 @@ export const FieldLabelText = ({
     return (
       <div className="flex w-full items-center py-2.5">
         <h3 id={labelId} className="font-heading flex-1 text-xl font-semibold">
-          {text}
+          {body}
         </h3>
         {badge}
       </div>
@@ -308,7 +369,7 @@ export const FieldLabelText = ({
     return (
       <div className="flex w-full items-center py-2.5">
         <blockquote id={labelId} className="flex-1 border-l-2 pl-6 italic">
-          {text}
+          {body}
         </blockquote>
         {badge}
       </div>
@@ -323,7 +384,7 @@ export const FieldLabelText = ({
         className="flex w-full items-center gap-1 py-2.5 text-sm select-none"
         data-bf-field-label
       >
-        <span>{text}</span>
+        <span>{body}</span>
         {badge}
       </span>
     );
@@ -331,7 +392,7 @@ export const FieldLabelText = ({
 
   return (
     <Label htmlFor={htmlFor} id={labelId} className="w-full gap-1" data-bf-field-label>
-      <span>{text}</span>
+      <span>{body}</span>
       {badge}
     </Label>
   );

--- a/src/components/form-components/form-preview-rsc.tsx
+++ b/src/components/form-components/form-preview-rsc.tsx
@@ -2,7 +2,10 @@
 import { CompositeComponent } from "@tanstack/react-start/rsc";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { RenderFieldComponent } from "@/components/form-components/render-step-preview-input";
+import {
+  RenderFieldComponent,
+  RenderStepPreviewInput,
+} from "@/components/form-components/render-step-preview-input";
 import { ServerFormIcon } from "@/components/form-components/server-form-icon";
 import { SuccessCheck } from "@/components/transitions/success-check";
 import { Button } from "@/components/ui/button";
@@ -335,9 +338,16 @@ const StepFormRSC = ({
       const rendered = requiredFieldNames
         ? { ...field, required: requiredFieldNames.has(field.name) }
         : field;
+      // Mention labels render label+input client-side (reactive resolution); the server omitted
+      // ServerFieldLabel for these (see public-form-view-rsc.impl). RenderStepPreviewInput owns the wrapper.
+      const hasMentionLabel = "labelNodes" in rendered && rendered.labelNodes;
       return (
         <div data-bf-question-id={field.id} className={`w-full${autoFilled ? " opacity-75" : ""}`}>
-          <RenderFieldComponent key={fieldId} element={rendered} form={form} />
+          {hasMentionLabel ? (
+            <RenderStepPreviewInput key={fieldId} element={rendered} form={form} />
+          ) : (
+            <RenderFieldComponent key={fieldId} element={rendered} form={form} />
+          )}
         </div>
       );
     },

--- a/src/components/form-components/render-step-preview-input-eager.tsx
+++ b/src/components/form-components/render-step-preview-input-eager.tsx
@@ -56,7 +56,7 @@ export const RenderStepPreviewInputEager = ({
   if (!Component) return null;
   const isFieldArray = isFieldArrayElement(element);
   return (
-    <PreviewInputShell element={element}>
+    <PreviewInputShell element={element} form={form}>
       {isFieldArray ? (
         <RepeatableField element={element} form={form} ItemComponent={Component as never} />
       ) : (

--- a/src/components/form-components/render-step-preview-input.tsx
+++ b/src/components/form-components/render-step-preview-input.tsx
@@ -52,11 +52,14 @@ interface RenderStepPreviewInputProps {
 export const PreviewInputShell = ({
   element,
   children,
+  form,
 }: {
   element: PlateFormField;
   children: React.ReactNode;
+  /** Passed through to the label so `@`-mention tokens resolve to live answers. */
+  form?: AppForm;
 }) => {
-  const { label, required, labelType } = getFieldLabelProps(element);
+  const { label, required, labelType, labelNodes } = getFieldLabelProps(element);
   // Group fields (Checkbox/MultiChoice/Ranking) render N controls, no single labelable input — wrap in role=group + aria-labelledby. Others: <label htmlFor>/heading wiring (field reads via element.name). Repeatable scalars also group-label.
   const isGroup =
     ("fieldType" in element && GROUP_FIELD_TYPES.has(element.fieldType)) ||
@@ -73,6 +76,8 @@ export const PreviewInputShell = ({
         htmlFor={element.name}
         required={required}
         asGroupLabel={isGroup}
+        labelNodes={labelNodes}
+        form={form}
       />
       {children}
     </div>
@@ -100,7 +105,7 @@ export const RenderStepPreviewInput = ({ element, form }: RenderStepPreviewInput
   if (!Component) return null;
   const isFieldArray = isFieldArrayElement(element);
   return (
-    <PreviewInputShell element={element}>
+    <PreviewInputShell element={element} form={form}>
       {isFieldArray ? (
         <RepeatableField element={element} form={form} ItemComponent={Component as never} />
       ) : (

--- a/src/components/transitions/animated-size.tsx
+++ b/src/components/transitions/animated-size.tsx
@@ -31,7 +31,7 @@ export const AnimatedSize = ({ children }: { children: React.ReactNode }) => {
         style={{ overflow: "clip" }}
         // bounce 0: a bouncy spring's settle tail reads as lag on a popup this small.
         transition={
-          shouldReduceMotion ? { duration: 0 } : { bounce: 0, duration: 0.3, type: "spring" }
+          shouldReduceMotion ? { duration: 0 } : { bounce: 0, duration: 0.2, type: "spring" }
         }
       >
         <div className="w-fit" ref={ref}>

--- a/src/components/ui/block-draggable.tsx
+++ b/src/components/ui/block-draggable.tsx
@@ -491,12 +491,38 @@ const Gutter = ({
   const isSelectionAreaVisible = usePluginOption(BlockSelectionPlugin, "isSelectionAreaVisible");
   const selected = useSelected();
 
+  // Center the controls on the block's FIRST line, not its full height. A single-line label is
+  // shorter than the 28px control group, so centering in h-full lands the controls on the line —
+  // but a label/heading that WRAPS to multiple lines would float the controls at the block's
+  // vertical middle (between lines). Measure the first line-box so items-center stays on line 1.
+  // (Single-line: first-line height == full height, so this is a no-op.) "top" gutters keep h-full.
+  const gutterRef = React.useRef<HTMLDivElement>(null);
+  const [firstLineH, setFirstLineH] = React.useState<number | null>(null);
+  React.useLayoutEffect(() => {
+    if (gutterPosition !== "center") {
+      setFirstLineH(null);
+      return;
+    }
+    const content = gutterRef.current?.parentElement?.querySelector(
+      ":scope > .slate-blockWrapper",
+    )?.firstElementChild;
+    if (!content) return;
+    const range = document.createRange();
+    range.selectNodeContents(content);
+    const rect = range.getClientRects()[0];
+    setFirstLineH(rect ? rect.height : null);
+  }, [element, gutterPosition]);
+
+  const useFullHeight = gutterPosition === "top" || firstLineH == null;
+
   return (
     <div
+      ref={gutterRef}
       {...props}
       className={cn(
         "slate-gutterLeft",
-        "absolute z-50 flex h-full -translate-x-full cursor-text hover:opacity-100",
+        "absolute z-50 flex -translate-x-full cursor-text hover:opacity-100",
+        useFullHeight && "h-full",
         gutterPosition === "top" ? "top-0 items-start" : "top-0 items-center",
         !selected && "sm:opacity-0",
         getPluginByType(editor, element.type)?.node.isContainer
@@ -506,6 +532,7 @@ const Gutter = ({
         selected && "opacity-100",
         className,
       )}
+      style={useFullHeight ? props.style : { ...props.style, height: `${firstLineH}px` }}
       contentEditable={false}
     >
       {children}

--- a/src/components/ui/block-menu.tsx
+++ b/src/components/ui/block-menu.tsx
@@ -34,7 +34,7 @@ import {
   BlockSelectionPlugin,
 } from "@platejs/selection/react";
 import type { TElement } from "platejs";
-import { KEYS, PathApi } from "platejs";
+import { KEYS } from "platejs";
 import { useEditorPlugin, useEditorSelector, useHotkeys, usePluginOption } from "platejs/react";
 import * as React from "react";
 
@@ -226,13 +226,19 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
 
   const handleAddLogic = React.useCallback(() => {
     if (!firstPath) return;
-    // Insert the logic block as the next sibling of the selected block.
+    // Insert after the whole field, not the selected node. For a choice field the selection may
+    // land on a label or a middle option; walk past the trailing option run so the logic block
+    // lands below the last option instead of splitting the group.
+    const inputPath = getInputPath() ?? firstPath;
+    const nodes = editor.children as TElement[];
+    let last = inputPath[0];
+    while (last < nodes.length - 1 && nodes[last + 1]?.type === "formOptionItem") last++;
     editor.tf.insertNodes(createLogicBlockNode() as unknown as TElement, {
-      at: PathApi.next(firstPath),
+      at: [last + 1],
       select: false,
     });
     api.blockMenu.hide();
-  }, [editor, firstPath, api.blockMenu]);
+  }, [editor, firstPath, getInputPath, api.blockMenu]);
 
   const handleTurnInto = React.useCallback(
     (type: string) => {
@@ -501,7 +507,7 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
                       initial="initial"
                       animate="animate"
                       exit="exit"
-                      transition={{ duration: 0.2, ease: "easeOut" }}
+                      transition={{ duration: 0.15, ease: "easeOut" }}
                     >
                       <FieldMenu />
                     </m.div>
@@ -514,7 +520,7 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
                       initial="initial"
                       animate="animate"
                       exit="exit"
-                      transition={{ duration: 0.2, ease: "easeOut" }}
+                      transition={{ duration: 0.15, ease: "easeOut" }}
                     >
                       <PanelHeader label={activePanel.label} />
                       <activePanel.Panel />
@@ -1808,6 +1814,8 @@ const BulkInsertOptions = () => {
       <BulkInsertIcon />
       <span className="flex-1 text-left">Bulk insert options</span>
       <DropdownMenuShortcut>⌘O</DropdownMenuShortcut>
+      {/* Chevron marks the morph into the inline bulk-insert panel, matching the other submenu rows. */}
+      <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground" />
     </DropdownMenuItem>
   );
 };

--- a/src/components/ui/form-option-item-constants.ts
+++ b/src/components/ui/form-option-item-constants.ts
@@ -11,7 +11,8 @@ export const getOptionOrdinal = (style: "letters" | "numbers", index: number): s
   style === "numbers" ? String(index + 1) : LETTER_LABELS[index % LETTER_LABELS.length];
 
 // App-chrome surfaces (e.g. the submissions dashboard) follow the global app theme via Tailwind
-// `dark:` variants. Form-preview surfaces must NOT use these — see getMultiSelectColor below.
+// `dark:` variants. Form-preview multi-selects render neutral chips now, so this palette is
+// app-chrome only.
 export const MULTI_SELECT_COLORS = [
   { bg: "bg-red-50 dark:bg-red-950/30", text: "text-red-700 dark:text-red-400" },
   { bg: "bg-orange-50 dark:bg-orange-950/30", text: "text-orange-700 dark:text-orange-400" },
@@ -20,30 +21,3 @@ export const MULTI_SELECT_COLORS = [
   { bg: "bg-blue-50 dark:bg-blue-950/30", text: "text-blue-700 dark:text-blue-400" },
   { bg: "bg-purple-50 dark:bg-purple-950/30", text: "text-purple-700 dark:text-purple-400" },
 ] as const;
-
-// Explicit per-mode palettes (no `dark:` variant). The `dark:` variant keys off any ancestor
-// `.dark` — including the app's <html.dark> — so a light form inside a dark editor would wrongly
-// render dark chips. Form-preview surfaces pick from these by the FORM's own mode instead.
-const MULTI_SELECT_COLORS_LIGHT = [
-  { bg: "bg-red-50", text: "text-red-700" },
-  { bg: "bg-orange-50", text: "text-orange-700" },
-  { bg: "bg-amber-50", text: "text-amber-700" },
-  { bg: "bg-emerald-50", text: "text-emerald-700" },
-  { bg: "bg-blue-50", text: "text-blue-700" },
-  { bg: "bg-purple-50", text: "text-purple-700" },
-] as const;
-
-const MULTI_SELECT_COLORS_DARK = [
-  { bg: "bg-red-950/30", text: "text-red-400" },
-  { bg: "bg-orange-950/30", text: "text-orange-400" },
-  { bg: "bg-amber-950/30", text: "text-amber-400" },
-  { bg: "bg-emerald-950/30", text: "text-emerald-400" },
-  { bg: "bg-blue-950/30", text: "text-blue-400" },
-  { bg: "bg-purple-950/30", text: "text-purple-400" },
-] as const;
-
-/** Chip color for form-preview surfaces — resolved from the FORM's mode, not the app's `.dark`. */
-export const getMultiSelectColor = (index: number, isDark: boolean) => {
-  const palette = isDark ? MULTI_SELECT_COLORS_DARK : MULTI_SELECT_COLORS_LIGHT;
-  return palette[index % palette.length];
-};

--- a/src/components/ui/form-option-item-node.tsx
+++ b/src/components/ui/form-option-item-node.tsx
@@ -20,22 +20,21 @@ import {
 import { BlockSelection } from "@/components/ui/block-selection";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
+  CheckCheckIcon,
   ChevronDownIcon,
   Loader2Icon,
   PhotoIcon,
   RankDragHandleIcon,
-  TagIcon,
   XIcon,
 } from "@/components/ui/icons";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useUploadFile } from "@/hooks/use-upload-file";
 import { RequiredBadgeButton } from "@/components/ui/required-badge-button";
-import { useFormIsDark } from "@/hooks/use-form-theme";
 import { cn } from "@/lib/utils";
 
 type OptionVariant = "checkbox" | "multiChoice" | "ranking";
 
-import { getMultiSelectColor, getOptionOrdinal } from "@/components/ui/form-option-item-constants";
+import { getOptionOrdinal } from "@/components/ui/form-option-item-constants";
 import type { OptionLabelStyle } from "@/components/ui/form-option-item-constants";
 
 // Letters/Numbers labels: an ordinal badge in a gray box (Figma nodes 25578:9710 / 25578:9688) —
@@ -165,13 +164,12 @@ const nodeText = (n: TElement | undefined): string =>
  * the old formMultiSelectInput node). Chips mirror the sibling option nodes: × or Backspace
  * removes a node, Enter in the inline input appends one. Group flags (showAsDropdown, required,
  * selection limits…) live on the FIRST option node, so removing chip 0 pulls the next text up and
- * drops the next node instead of removing the flag-holder. Checkbox groups (multi answer) get the
- * multi-select colored chips; multiChoice groups (single answer) get neutral gray chips + a
- * chevron badge so the two dropdown kinds read apart at a glance. */
+ * drops the next node instead of removing the flag-holder. Both dropdown kinds get neutral gray
+ * chips; the trailing badge tells them apart — a double-tick for checkbox groups (multi answer),
+ * a chevron for multiChoice groups (single answer). */
 const OptionChipsRow = ({ children, ...props }: PlateElementProps) => {
   const { attributes, element, ...rest } = props;
   const editor = useEditorRef();
-  const isDark = useFormIsDark();
   // element is the group's first node — its variant decides the chip treatment.
   const variant = (element.variant as string) || "checkbox";
   const colored = variant === "checkbox";
@@ -418,10 +416,9 @@ const OptionChipsRow = ({ children, ...props }: PlateElementProps) => {
         onMouseDown={(e) => e.stopPropagation()}
       >
         {chips.map((chip, chipIdx) => {
-          // Single-select chips stay neutral — the multi-select colors are its visual signature.
-          const color = colored
-            ? getMultiSelectColor(chipIdx, isDark)
-            : { bg: "bg-gray-100", text: "text-gray-900" };
+          // Neutral chips for both dropdown kinds; the trailing icon (double-tick vs chevron)
+          // is what tells multi-select apart from single-select now.
+          const color = { bg: "bg-gray-100", text: "text-gray-900" };
           const isChipFocused = focusedChipIndex === chipIdx;
           return (
             <span
@@ -479,7 +476,11 @@ const OptionChipsRow = ({ children, ...props }: PlateElementProps) => {
             />
           }
         >
-          {colored ? <TagIcon className="size-3.5" /> : <ChevronDownIcon className="size-3.5" />}
+          {colored ? (
+            <CheckCheckIcon className="size-3.5" />
+          ) : (
+            <ChevronDownIcon className="size-3.5" />
+          )}
         </TooltipTrigger>
         <TooltipContent side="left">
           {colored ? "Multi-select dropdown" : "Dropdown"}
@@ -576,8 +577,12 @@ export const FormOptionItemElement = ({ children, ...props }: PlateElementProps)
   const isAnyDragging = Array.isArray(draggingId) ? draggingId.length > 0 : Boolean(draggingId);
   const showGhost = isLastInGroup && isGroupFocused && !isAnyDragging && !chipsMode;
 
-  // When ghost is visible, push the next block down so it doesn't overlap. Add margin-top to the
+  // When ghost is visible, push the next block down so it doesn't overlap. Reserve space on the
   // block-draggable wrapper's next sibling, not this element — expanding here displaces the gutter.
+  // Use padding-top, not margin-top: margins collapse (max with the option's own block-margin) so a
+  // small needed gap gets swallowed, and a fixed constant can't know the next block's margin (e.g.
+  // the logic block tucks up via a -16px margin-top). Measure the ghost's real bottom against the
+  // next block's real content top and reserve exactly the overflow + a 4px gap.
   useLayoutEffect(() => {
     let domNode: HTMLElement | null = null;
     try {
@@ -586,21 +591,31 @@ export const FormOptionItemElement = ({ children, ...props }: PlateElementProps)
     } catch {
       domNode = null;
     }
-    if (!domNode) return;
-    const blockWrapper = domNode.closest(".slate-blockWrapper");
-    const draggableWrapper = blockWrapper?.parentElement;
-    const nextSibling = draggableWrapper?.nextElementSibling as HTMLElement | null;
-    if (!nextSibling) return;
-    if (showGhost) {
-      // Ghost is 30px tall, offset 4px below option (top-[calc(100%+4px)]),
-      // plus another 4px gap after the ghost → total 38px margin.
-      nextSibling.style.marginTop = "38px";
-    } else {
-      nextSibling.style.marginTop = "";
-    }
-    return () => {
-      nextSibling.style.marginTop = "";
+    const blockWrapper = domNode?.closest(".slate-blockWrapper");
+    const nextSibling = blockWrapper?.parentElement?.nextElementSibling as HTMLElement | null;
+    const clear = () => {
+      if (nextSibling) nextSibling.style.paddingTop = "";
     };
+    if (!domNode || !nextSibling) return;
+    if (!showGhost) {
+      clear();
+      return;
+    }
+    const ghost = domNode.querySelector<HTMLElement>("[data-bf-ghost-row]");
+    if (!ghost) {
+      clear();
+      return clear;
+    }
+    // Reset to the natural layout, then reserve exactly the overflow. Measure the next block's first
+    // rendered element (not its wrapper) — wrappers whose inner node uses a negative margin-top
+    // report a misleading box.
+    nextSibling.style.paddingTop = "";
+    const nextContent =
+      nextSibling.querySelector<HTMLElement>('[data-slate-node="element"]') ?? nextSibling;
+    const overflow =
+      ghost.getBoundingClientRect().bottom + 4 - nextContent.getBoundingClientRect().top;
+    nextSibling.style.paddingTop = overflow > 0 ? `${Math.ceil(overflow)}px` : "";
+    return clear;
   }, [editor, element, showGhost]);
 
   // Per-option image (group "Image" toggle sets showImage on every sibling). Upload via the shared
@@ -641,7 +656,7 @@ export const FormOptionItemElement = ({ children, ...props }: PlateElementProps)
   return (
     <PlateElement
       attributes={{ ...attributes, "data-bf-input": "true" }}
-      className="relative w-full max-w-116 cursor-text rounded-md caret-current before:top-3.5 before:left-7.5 before:-translate-y-1/2 before:text-sm"
+      className="relative w-full max-w-116 cursor-text rounded-md caret-current before:top-3.5 before:left-6.5 before:-translate-y-1/2 before:text-sm"
       element={element}
       {...rest}
     >
@@ -665,6 +680,7 @@ export const FormOptionItemElement = ({ children, ...props }: PlateElementProps)
         <div
           contentEditable={false}
           data-bf-drag-ignore="true"
+          data-bf-ghost-row="true"
           className="pointer-events-none absolute top-[calc(100%+4px)] right-0 left-0 flex h-[30px] items-center gap-2 pl-0.5 opacity-40 select-none"
         >
           <OptionIcon variant={variant} index={optionIndex + 1} optionLabel={optionLabel} />

--- a/src/components/ui/logic-block-node.tsx
+++ b/src/components/ui/logic-block-node.tsx
@@ -1,4 +1,4 @@
-import { ChevronsUpDown, HelpCircle, Zap } from "lucide-react";
+import { ChevronsUpDown, Zap } from "lucide-react";
 import * as React from "react";
 import type { PlateElementProps } from "platejs/react";
 import {
@@ -10,6 +10,7 @@ import {
 } from "platejs/react";
 
 import {
+  ChevronDownIcon,
   ConditionalLogicIcon,
   DeleteIcon,
   DuplicateIcon,
@@ -19,6 +20,7 @@ import {
 } from "@/components/ui/icons";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
@@ -53,7 +55,6 @@ export const createLogicBlockNode = (): LogicBlockNode => ({
   id: crypto.randomUUID(),
   when: { combinator: "all", children: [] },
   actions: [],
-  elseActions: [],
   children: [{ text: "" }],
 });
 
@@ -219,7 +220,7 @@ const TokenStepper = ({
   );
 };
 
-/** Scalar field types — the only ones a "Set value" action can sensibly target. */
+/** Scalar field types — single string answer. */
 const SCALAR_FIELD_TYPES = new Set([
   "Input",
   "Textarea",
@@ -231,27 +232,97 @@ const SCALAR_FIELD_TYPES = new Set([
   "Time",
 ]);
 
-/** Operand/value control matched to the field type: stepper for numbers, native
- * date/time pickers for Date/Time, plain text otherwise. */
+/** Single-choice (radio / single-select): answer is one option `value` string. */
+const SINGLE_CHOICE_TYPES = new Set(["MultiChoice"]);
+/** Multi-choice (checkbox / multi-select): answer is a `string[]` of option `value`s. */
+const MULTI_CHOICE_TYPES = new Set(["Checkbox"]);
+
+/** Field types a "Set value" action can target (Ranking excluded — setting an order has no clear UX). */
+const SET_TARGET_TYPES = new Set([
+  ...SCALAR_FIELD_TYPES,
+  ...SINGLE_CHOICE_TYPES,
+  ...MULTI_CHOICE_TYPES,
+]);
+
+/** A field is a valid Set-value target if its type is settable and it isn't repeatable (array rows). */
+const isSetTarget = (f: FieldInfo): boolean => SET_TARGET_TYPES.has(f.fieldType) && !f.isFieldArray;
+
+/** The empty value for a target's shape: [] for multi-choice, "" otherwise. */
+const blankValueForType = (fieldType: string | undefined): string | string[] =>
+  fieldType && MULTI_CHOICE_TYPES.has(fieldType) ? [] : "";
+
+/** Pill multi-select for Checkbox targets — base-ui checkbox items keep the menu open per toggle.
+ * Selection is stored option-order so the persisted array reads predictably. */
+const MultiTokenSelect = ({
+  value,
+  onChange,
+  ariaLabel,
+  options,
+}: {
+  value: string[];
+  onChange: (value: string[]) => void;
+  ariaLabel: string;
+  options: Option[];
+}) => {
+  const selected = new Set(value);
+  const labels = options.filter((o) => selected.has(o.value)).map((o) => o.label);
+  const toggle = (v: string) => {
+    const next = new Set(selected);
+    if (next.has(v)) next.delete(v);
+    else next.add(v);
+    onChange(options.filter((o) => next.has(o.value)).map((o) => o.value));
+  };
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label={ariaLabel}
+        className="flex h-7 max-w-48 items-center gap-1 rounded-lg bg-[var(--form-input-bg,var(--color-gray-50))] ps-2.5 pe-2 text-[13px] text-foreground elevation-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <span className={cn("truncate", labels.length === 0 && "text-muted-foreground")}>
+          {labels.length > 0 ? labels.join(", ") : "Select options"}
+        </span>
+        <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {options.map((o) => (
+          <DropdownMenuCheckboxItem
+            key={o.value}
+            checked={selected.has(o.value)}
+            onCheckedChange={() => toggle(o.value)}
+          >
+            {o.label}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+/** Operand/value control matched to the field type: stepper for numbers, native date/time pickers,
+ * an option dropdown for single-choice, a multi-select for multi-choice, plain text otherwise. */
 const ValueControl = ({
   fieldType,
+  options,
   value,
   onChange,
   ariaLabel,
 }: {
   fieldType: string | undefined;
-  value: string;
-  onChange: (value: string) => void;
+  /** Selectable options when the target is a choice field. */
+  options: Option[];
+  value: string | string[];
+  onChange: (value: string | string[]) => void;
   ariaLabel: string;
 }) => {
+  const str = typeof value === "string" ? value : "";
   if (fieldType === "Number")
-    return <TokenStepper value={value} onChange={onChange} ariaLabel={ariaLabel} />;
+    return <TokenStepper value={str} onChange={onChange} ariaLabel={ariaLabel} />;
   if (fieldType === "Date")
     return (
       <TokenInput
         type="date"
         widthClass="w-36"
-        value={value}
+        value={str}
         onChange={onChange}
         ariaLabel={ariaLabel}
       />
@@ -261,12 +332,23 @@ const ValueControl = ({
       <TokenInput
         type="time"
         widthClass="w-28"
-        value={value}
+        value={str}
         onChange={onChange}
         ariaLabel={ariaLabel}
       />
     );
-  return <TokenInput placeholder="value" value={value} onChange={onChange} ariaLabel={ariaLabel} />;
+  if (fieldType && SINGLE_CHOICE_TYPES.has(fieldType))
+    return <TokenSelect ariaLabel={ariaLabel} value={str} options={options} onChange={onChange} />;
+  if (fieldType && MULTI_CHOICE_TYPES.has(fieldType))
+    return (
+      <MultiTokenSelect
+        ariaLabel={ariaLabel}
+        value={Array.isArray(value) ? value : []}
+        options={options}
+        onChange={onChange}
+      />
+    );
+  return <TokenInput placeholder="value" value={str} onChange={onChange} ariaLabel={ariaLabel} />;
 };
 
 const AddToken = ({ onClick, label }: { onClick: () => void; label: string }) => (
@@ -367,21 +449,42 @@ const CombinatorLead = ({
 type CondNode = Condition | ConditionGroup;
 const isGroup = (node: CondNode): node is ConditionGroup => "combinator" in node;
 
-// "Learn" menu item — opens conditional-logic docs.
-const learnAboutLogic = () => {
-  // TODO: point at the real docs URL once published.
-};
+/** Flatten a condition tree to its leaf conditions (for validation / warnings). */
+const flattenConditions = (group: ConditionGroup): Condition[] =>
+  group.children.flatMap((c) => (isGroup(c) ? flattenConditions(c) : [c]));
 
+// Opposite pairs (show/hide, require/optional, set/clear) so the inverse condition drives the
+// inverse action — no Else branch needed.
 const ACTION_KIND_OPTIONS: Option[] = [
   { value: "show", label: "Show field" },
   { value: "hide", label: "Hide field" },
   { value: "require", label: "Require field" },
+  { value: "optional", label: "Make optional" },
   { value: "setValue", label: "Set value" },
-  { value: "moveToNext", label: "Move to next field" },
+  { value: "clearValue", label: "Clear value" },
   { value: "jump", label: "Jump to step" },
   { value: "hideSubmit", label: "Hide submit" },
   { value: "redirect", label: "Redirect to URL" },
 ];
+
+/** Field-target actions whose target picker is the full field list. */
+const FIELD_TARGET_KINDS = new Set<Action["kind"]>([
+  "show",
+  "hide",
+  "require",
+  "optional",
+  "clearValue",
+]);
+
+/** Readable verb per field-target action kind, for the self-referential warning. */
+const SELF_REF_VERB: Partial<Record<Action["kind"], string>> = {
+  show: "shows",
+  hide: "hides",
+  require: "requires",
+  optional: "makes optional",
+  setValue: "sets the value of",
+  clearValue: "clears",
+};
 
 const defaultActionForKind = (
   kind: Action["kind"],
@@ -392,8 +495,8 @@ const defaultActionForKind = (
   if (kind === "jump") return { kind, toStep: stepOptions[0]?.value ?? THANK_YOU_STEP };
   if (kind === "redirect") return { kind, url: "" };
   if (kind === "setValue") {
-    const scalar = fields.find((f) => SCALAR_FIELD_TYPES.has(f.fieldType) && !f.isFieldArray);
-    return { kind, target: scalar?.name ?? "", value: "" };
+    const target = fields.find(isSetTarget);
+    return { kind, target: target?.name ?? "", value: blankValueForType(target?.fieldType) };
   }
   return { kind, target: fields[0]?.name ?? "" };
 };
@@ -444,6 +547,7 @@ const normalizeGroup = (group: ConditionGroup): ConditionGroup => {
 /** One condition: field · operator · value (stepper for numbers) · `•••` menu. */
 const ConditionRow = ({
   condition,
+  rowIndex,
   sourceOptions,
   fieldTypeByName,
   fieldChoicesByName,
@@ -451,6 +555,8 @@ const ConditionRow = ({
   menuItems,
 }: {
   condition: Condition;
+  /** 1-based row position, woven into aria-labels so each control is distinguishable. */
+  rowIndex: number;
   sourceOptions: Option[];
   fieldTypeByName: Map<string, string>;
   fieldChoicesByName: Map<string, Option[]>;
@@ -464,10 +570,11 @@ const ConditionRow = ({
     }),
   );
   const choices = fieldChoicesByName.get(condition.source);
+  const prefix = `Condition ${rowIndex}`;
   return (
-    <TokenRow menu={<RowMenu ariaLabel="Condition options" items={menuItems} />}>
+    <TokenRow menu={<RowMenu ariaLabel={`${prefix} options`} items={menuItems} />}>
       <TokenSelect
-        ariaLabel="Field"
+        ariaLabel={`${prefix} field`}
         value={condition.source}
         options={sourceOptions}
         onChange={(source) => {
@@ -480,7 +587,7 @@ const ConditionRow = ({
         }}
       />
       <TokenSelect
-        ariaLabel="Operator"
+        ariaLabel={`${prefix} operator`}
         value={condition.operator}
         options={operatorOptions}
         onChange={(op) => onChange({ ...condition, operator: op as OperatorId })}
@@ -488,17 +595,20 @@ const ConditionRow = ({
       {operatorNeedsOperand(condition.operator) &&
         (choices && choices.length > 0 ? (
           <TokenSelect
-            ariaLabel="Value"
+            ariaLabel={`${prefix} value`}
             value={condition.value ?? ""}
             options={choices}
             onChange={(value) => onChange({ ...condition, value })}
           />
         ) : (
           <ValueControl
-            ariaLabel="Value"
+            ariaLabel={`${prefix} value`}
             fieldType={fieldTypeByName.get(condition.source)}
+            options={[]}
             value={condition.value ?? ""}
-            onChange={(value) => onChange({ ...condition, value })}
+            onChange={(value) =>
+              onChange({ ...condition, value: typeof value === "string" ? value : "" })
+            }
           />
         ))}
     </TokenRow>
@@ -508,6 +618,7 @@ const ConditionRow = ({
 /** One action: kind · target/step/url · `•••` menu. */
 const ActionRow = ({
   action,
+  rowIndex,
   fields,
   fieldOptions,
   setTargetOptions,
@@ -517,6 +628,8 @@ const ActionRow = ({
   menuItems,
 }: {
   action: Action;
+  /** 1-based row position, woven into aria-labels so each control is distinguishable. */
+  rowIndex: number;
   fields: FieldInfo[];
   fieldOptions: Option[];
   /** Scalar-only targets for "Set value" (multi/file/repeatable can't be set). */
@@ -525,62 +638,65 @@ const ActionRow = ({
   stepOptions: Option[];
   onChange: (next: Action) => void;
   menuItems: RowMenuItem[];
-}) => (
-  <TokenRow menu={<RowMenu ariaLabel="Action options" items={menuItems} />}>
-    <TokenSelect
-      ariaLabel="Action"
-      value={action.kind}
-      options={ACTION_KIND_OPTIONS}
-      onChange={(kind) =>
-        onChange(defaultActionForKind(kind as Action["kind"], fields, stepOptions))
-      }
-    />
-    {(action.kind === "show" ||
-      action.kind === "hide" ||
-      action.kind === "require" ||
-      action.kind === "moveToNext") && (
+}) => {
+  const prefix = `Then action ${rowIndex}`;
+  return (
+    <TokenRow menu={<RowMenu ariaLabel={`${prefix} options`} items={menuItems} />}>
       <TokenSelect
-        ariaLabel="Target field"
-        value={action.target}
-        options={fieldOptions}
-        onChange={(target) => onChange({ ...action, target })}
+        ariaLabel={`${prefix} type`}
+        value={action.kind}
+        options={ACTION_KIND_OPTIONS}
+        onChange={(kind) =>
+          onChange(defaultActionForKind(kind as Action["kind"], fields, stepOptions))
+        }
       />
-    )}
-    {action.kind === "setValue" && (
-      <>
+      {FIELD_TARGET_KINDS.has(action.kind) && "target" in action && (
         <TokenSelect
-          ariaLabel="Target field"
+          ariaLabel={`${prefix} target field`}
           value={action.target}
-          options={setTargetOptions}
+          options={fieldOptions}
           onChange={(target) => onChange({ ...action, target })}
         />
-        <ValueControl
-          ariaLabel="Set value"
-          fieldType={fieldTypeByName.get(action.target)}
-          value={action.value}
-          onChange={(value) => onChange({ ...action, value })}
+      )}
+      {action.kind === "setValue" && (
+        <>
+          <TokenSelect
+            ariaLabel={`${prefix} target field`}
+            value={action.target}
+            options={setTargetOptions}
+            onChange={(target) =>
+              onChange({ ...action, target, value: blankValueForType(fieldTypeByName.get(target)) })
+            }
+          />
+          <ValueControl
+            ariaLabel={`${prefix} value`}
+            fieldType={fieldTypeByName.get(action.target)}
+            options={fields.find((f) => f.name === action.target)?.options ?? []}
+            value={action.value}
+            onChange={(value) => onChange({ ...action, value })}
+          />
+        </>
+      )}
+      {action.kind === "jump" && (
+        <TokenSelect
+          ariaLabel={`${prefix} target step`}
+          value={action.toStep}
+          options={stepOptions}
+          onChange={(toStep) => onChange({ ...action, toStep })}
         />
-      </>
-    )}
-    {action.kind === "jump" && (
-      <TokenSelect
-        ariaLabel="Target step"
-        value={action.toStep}
-        options={stepOptions}
-        onChange={(toStep) => onChange({ ...action, toStep })}
-      />
-    )}
-    {action.kind === "redirect" && (
-      <TokenInput
-        ariaLabel="Redirect URL"
-        placeholder="https://…"
-        widthClass="w-48"
-        value={action.url}
-        onChange={(url) => onChange({ ...action, url })}
-      />
-    )}
-  </TokenRow>
-);
+      )}
+      {action.kind === "redirect" && (
+        <TokenInput
+          ariaLabel={`${prefix} redirect URL`}
+          placeholder="https://…"
+          widthClass="w-48"
+          value={action.url}
+          onChange={(url) => onChange({ ...action, url })}
+        />
+      )}
+    </TokenRow>
+  );
+};
 
 // Interactive controls inside the block, in DOM (tab) order. Drives Tab cycling within
 // the block and lands focus on the first control when the block is navigated into.
@@ -620,21 +736,48 @@ export const LogicBlockElement = (props: PlateElementProps) => {
 
   const when = (element.when as ConditionGroup | undefined) ?? { combinator: "all", children: [] };
   const actions = (element.actions as Action[] | undefined) ?? [];
-  const elseActions = (element.elseActions as Action[] | undefined) ?? [];
 
   const fields = collectFields(editor);
   const sources = fields.filter((f) => !f.isFieldArray); // Wave 1: repeatable can't be a source
   const sourceOptions = sources.map((f) => ({ value: f.name, label: f.label }));
   const fieldOptions = fields.map((f) => ({ value: f.name, label: f.label }));
   const setTargetOptions = fields
-    .filter((f) => SCALAR_FIELD_TYPES.has(f.fieldType) && !f.isFieldArray)
+    .filter(isSetTarget)
     .map((f) => ({ value: f.name, label: f.label }));
   const stepOptions = collectStepOptions(editor);
   const fieldTypeByName = new Map(fields.map((f) => [f.name, f.fieldType]));
   const fieldChoicesByName = new Map(fields.map((f) => [f.name, f.options ?? []]));
 
+  // Author-time validation: surface dangling references and self-fighting rules instead of
+  // letting them silently no-op (or fight themselves) at runtime.
+  const knownNames = new Set(fields.map((f) => f.name));
+  const conditions = flattenConditions(when);
+  const conditionSources = new Set(conditions.map((c) => c.source));
+  const warnings: string[] = [];
+  for (const c of conditions) {
+    if (c.source && !knownNames.has(c.source)) {
+      warnings.push("A condition refers to a field that was deleted.");
+    } else {
+      const choices = fieldChoicesByName.get(c.source);
+      if (choices && choices.length > 0 && c.value && !choices.some((o) => o.value === c.value)) {
+        warnings.push("A condition uses an option that no longer exists.");
+      }
+    }
+  }
+  for (const a of actions) {
+    if ("target" in a && a.target && !knownNames.has(a.target)) {
+      warnings.push("An action targets a field that was deleted.");
+    }
+    if ("target" in a && conditionSources.has(a.target) && SELF_REF_VERB[a.kind]) {
+      warnings.push(
+        `This rule ${SELF_REF_VERB[a.kind]} the same field it checks — it may fight itself.`,
+      );
+    }
+  }
+  const uniqueWarnings = [...new Set(warnings)];
+
   const patch = React.useCallback(
-    (updates: Partial<Pick<LogicBlockNode, "when" | "actions" | "elseActions">>) => {
+    (updates: Partial<Pick<LogicBlockNode, "when" | "actions">>) => {
       const path = editor.api.findPath(element);
       if (path) editor.tf.setNodes(updates, { at: path });
     },
@@ -768,6 +911,7 @@ export const LogicBlockElement = (props: PlateElementProps) => {
             <div className="min-w-0 flex-1">
               <ConditionRow
                 condition={child}
+                rowIndex={i + 1}
                 sourceOptions={sourceOptions}
                 fieldTypeByName={fieldTypeByName}
                 fieldChoicesByName={fieldChoicesByName}
@@ -791,7 +935,6 @@ export const LogicBlockElement = (props: PlateElementProps) => {
                         },
                       ]
                     : []),
-                  { icon: <HelpCircle />, label: "Learn", onSelect: learnAboutLogic },
                   {
                     icon: <DeleteIcon />,
                     label: "Remove",
@@ -807,11 +950,7 @@ export const LogicBlockElement = (props: PlateElementProps) => {
   );
 
   // ── Action lists (Then / Else) — flat, no grouping ──
-  const makeActionMenu = (
-    list: Action[],
-    key: "actions" | "elseActions",
-    index: number,
-  ): RowMenuItem[] => {
+  const makeActionMenu = (list: Action[], key: "actions", index: number): RowMenuItem[] => {
     const setList = (next: Action[]) => patch({ [key]: next });
     // Hard cap: at most 2 actions per Then/Else, so adding/duplicating is gated.
     const canAdd = list.length < 2;
@@ -840,7 +979,6 @@ export const LogicBlockElement = (props: PlateElementProps) => {
             },
           ]
         : []),
-      { icon: <HelpCircle />, label: "Learn", onSelect: learnAboutLogic },
       {
         icon: <DeleteIcon />,
         label: "Remove",
@@ -849,7 +987,7 @@ export const LogicBlockElement = (props: PlateElementProps) => {
     ];
   };
 
-  const renderActionRows = (list: Action[], key: "actions" | "elseActions") => {
+  const renderActionRows = (list: Action[], key: "actions") => {
     const setList = (next: Action[]) => patch({ [key]: next });
     if (list.length === 0)
       return (
@@ -858,20 +996,32 @@ export const LogicBlockElement = (props: PlateElementProps) => {
           label="Add action"
         />
       );
-    return list.map((action, i) => (
-      <ActionRow
-        // eslint-disable-next-line @eslint-react/no-array-index-key
-        key={i}
-        action={action}
-        fields={fields}
-        fieldOptions={fieldOptions}
-        setTargetOptions={setTargetOptions}
-        fieldTypeByName={fieldTypeByName}
-        stepOptions={stepOptions}
-        onChange={(next) => setList(list.map((a, j) => (j === i ? next : a)))}
-        menuItems={makeActionMenu(list, key, i)}
-      />
-    ));
+    return (
+      <>
+        {list.map((action, i) => (
+          <ActionRow
+            // eslint-disable-next-line @eslint-react/no-array-index-key
+            key={i}
+            action={action}
+            rowIndex={i + 1}
+            fields={fields}
+            fieldOptions={fieldOptions}
+            setTargetOptions={setTargetOptions}
+            fieldTypeByName={fieldTypeByName}
+            stepOptions={stepOptions}
+            onChange={(next) => setList(list.map((a, j) => (j === i ? next : a)))}
+            menuItems={makeActionMenu(list, key, i)}
+          />
+        ))}
+        {/* Hard cap: 2 actions max — mirror the When section's inline add affordance. */}
+        {list.length < 2 && (
+          <AddToken
+            onClick={() => setList([...list, defaultActionForKind("show", fields, stepOptions)])}
+            label="Add action"
+          />
+        )}
+      </>
+    );
   };
 
   // "When" rail lead (icon + label) — row 0 of the condition list, and the empty/seed states.
@@ -901,6 +1051,17 @@ export const LogicBlockElement = (props: PlateElementProps) => {
           selected && focused && "ring-[3px] ring-ring/50",
         )}
       >
+        {uniqueWarnings.length > 0 && (
+          <div
+            role="alert"
+            className="mx-2 mt-1 mb-0.5 flex flex-col gap-0.5 rounded-lg bg-amber-500/10 px-2.5 py-1.5 text-[12px] text-amber-700 dark:text-amber-400"
+          >
+            {uniqueWarnings.map((w) => (
+              <span key={w}>{w}</span>
+            ))}
+          </div>
+        )}
+
         {/* WHEN — conditions. Custom rail layout so the And/Or toggle aligns under "When". */}
         <div className="flex flex-col gap-2 px-2 py-1.5">
           {sources.length === 0 ? (
@@ -930,14 +1091,10 @@ export const LogicBlockElement = (props: PlateElementProps) => {
           )}
         </div>
 
-        {/* THEN — actions when conditions pass */}
+        {/* THEN — actions when conditions pass. No Else: use the inverse action (Hide/Make
+            optional/Clear value) with the inverse condition instead. */}
         <RowShell icon={<Zap className="size-4 text-amber-500" />} label="Then">
           {renderActionRows(actions, "actions")}
-        </RowShell>
-
-        {/* ELSE — actions when conditions fail */}
-        <RowShell icon={<Zap className="size-4 text-muted-foreground" />} label="Else">
-          {renderActionRows(elseActions, "elseActions")}
         </RowShell>
       </div>
       {children}

--- a/src/components/ui/mention-node.tsx
+++ b/src/components/ui/mention-node.tsx
@@ -1,0 +1,93 @@
+import { getMentionOnSelectItem } from "@platejs/mention";
+import type { TComboboxInputElement, TMentionElement } from "platejs";
+import type { PlateElementProps } from "platejs/react";
+import { PlateElement, useFocused, useReadOnly, useSelected } from "platejs/react";
+
+import { getMentionableFields } from "@/components/editor/plugins/mention-fields";
+import { HelpCircleIcon, MoreHorizontalIcon } from "@/components/ui/icons";
+import { cn } from "@/lib/utils";
+
+import {
+  InlineCombobox,
+  InlineComboboxContent,
+  InlineComboboxEmpty,
+  InlineComboboxGroup,
+  InlineComboboxGroupLabel,
+  InlineComboboxInput,
+  InlineComboboxItem,
+} from "./inline-combobox";
+
+// `key` carries the stable field name; `value` the display label (rename-tolerant lookups
+// happen at resolution time — the pill shows the label captured at insert).
+export const MentionElement = (props: PlateElementProps<TMentionElement>) => {
+  const { element } = props;
+  const selected = useSelected();
+  const focused = useFocused();
+  const readOnly = useReadOnly();
+
+  return (
+    <PlateElement
+      {...props}
+      className={cn(
+        // Neutral grey via foreground tokens so it auto-inverts: dark text on light grey (light
+        // mode) ↔ light text on subtle grey (dark mode). Avoids the form's --primary brand color.
+        "inline-block rounded-md bg-foreground/10 px-1.5 py-0.5 align-baseline text-sm font-medium text-foreground",
+        !readOnly && "cursor-pointer",
+        selected && focused && "ring-2 ring-ring",
+      )}
+      attributes={{
+        ...props.attributes,
+        contentEditable: false,
+        "data-slate-value": element.value,
+      }}
+    >
+      {props.children}@{element.value}
+    </PlateElement>
+  );
+};
+
+const onSelectItem = getMentionOnSelectItem();
+
+export const MentionInputElement = (props: PlateElementProps<TComboboxInputElement>) => {
+  const { editor, element } = props;
+  const fields = getMentionableFields(editor, element);
+
+  return (
+    <PlateElement {...props} as="span">
+      <InlineCombobox element={element} trigger="@">
+        <span className="inline-block rounded-md bg-foreground/10 px-1.5 py-0.5 align-baseline text-sm text-foreground">
+          <InlineComboboxInput />
+        </span>
+
+        <InlineComboboxContent>
+          <InlineComboboxGroup>
+            <InlineComboboxGroupLabel>Mention an input field</InlineComboboxGroupLabel>
+
+            <InlineComboboxEmpty>No fields above to reference</InlineComboboxEmpty>
+
+            {fields.map((item) => (
+              <InlineComboboxItem
+                key={item.key}
+                className="gap-2"
+                value={item.text}
+                keywords={[item.key]}
+                onClick={() => onSelectItem(editor, item, "")}
+              >
+                <MoreHorizontalIcon className="text-muted-foreground" />
+                {item.text}
+              </InlineComboboxItem>
+            ))}
+          </InlineComboboxGroup>
+
+          {/* Non-interactive footer (combobox keyboard nav skips plain children). */}
+          <div className="mt-1 flex items-center gap-2 border-t px-3 py-2 text-sm text-muted-foreground">
+            <HelpCircleIcon className="size-4 shrink-0" />
+            Learn about mentions
+          </div>
+        </InlineComboboxContent>
+      </InlineCombobox>
+
+      {props.children}
+    </PlateElement>
+  );
+};

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -3,10 +3,9 @@
    producing invalid HTML and React hydration errors. */
 import { useState } from "react";
 
-import { getMultiSelectColor } from "@/components/ui/form-option-item-constants";
-import { CheckIcon, ChevronDownIcon } from "@/components/ui/icons";
+import { CheckCheckIcon, CheckIcon, ChevronDownIcon } from "@/components/ui/icons";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { useFormIsDark, useReanchorThemeProps } from "@/hooks/use-form-theme";
+import { useReanchorThemeProps } from "@/hooks/use-form-theme";
 import { cn } from "@/lib/utils";
 
 interface MultiSelectOption {
@@ -50,9 +49,6 @@ export const MultiSelect = ({
 
   // PopoverContent portals to body, losing .bf-themed CSS vars — re-anchor theme on the popup.
   const themeReanchor = useReanchorThemeProps();
-  // Chip colors follow the form's mode, not the app's global `.dark` (the trigger lives in the
-  // editor canvas; the dropdown re-anchors via themeReanchor but neither strips the app `.dark`).
-  const isDark = useFormIsDark();
 
   // Roving focus across options: adds listbox-style ArrowUp/Down + Home/End; Tab still works natively.
   const handleOptionsKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -102,17 +98,10 @@ export const MultiSelect = ({
           >
             <div className="flex flex-1 flex-wrap gap-1">
               {selectedOptions.length > 0 ? (
-                selectedOptions.map((opt) => {
-                  const colorIndex = options.findIndex((o) => o.value === opt.value);
-                  const color = getMultiSelectColor(colorIndex, isDark);
-                  return (
+                selectedOptions.map((opt) => (
                     <span
                       key={opt.value}
-                      className={cn(
-                        "inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium",
-                        color.bg,
-                        color.text,
-                      )}
+                      className="inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-900"
                     >
                       {opt.label}
                       <button
@@ -127,12 +116,13 @@ export const MultiSelect = ({
                         ×
                       </button>
                     </span>
-                  );
-                })
+                  ))
               ) : (
                 <span className="text-foreground/70">{placeholder}</span>
               )}
             </div>
+            {/* Double-tick marks this as a multi-select (vs a single-pick dropdown). */}
+            <CheckCheckIcon className="size-4 shrink-0 text-muted-foreground" />
             <ChevronDownIcon
               className={cn(
                 "size-4 shrink-0 text-muted-foreground transition-transform",
@@ -145,30 +135,27 @@ export const MultiSelect = ({
       <PopoverContent
         align="start"
         sideOffset={4}
-        // Figma dropdown (25632:9452): 8px row gap, elevation-xl, every option as its colored chip.
-        className={cn("w-(--anchor-width) gap-2 p-1 elevation-xl", themeReanchor.className)}
+        // Neutral full-width option rows (normal multi-select), elevation-xl popup.
+        className={cn("w-(--anchor-width) gap-0.5 p-1 elevation-xl", themeReanchor.className)}
         style={themeReanchor.style}
         onKeyDown={handleOptionsKeyDown}
       >
-        {options.map((opt, idx) => {
+        {options.map((opt) => {
           const isSelected = value.includes(opt.value);
-          const color = getMultiSelectColor(idx, isDark);
           return (
             <button
               key={opt.value}
               type="button"
               data-mselect-option
               className={cn(
-                // Content-hugging colored chip (cell-primitive); checkmark marks selection. No focus
-                // ring — a subtle outline-offset highlight marks keyboard focus instead.
-                "flex h-7 cursor-pointer items-center gap-1.5 self-start rounded-[8px] px-1.5 text-sm font-medium outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-                color.bg,
-                color.text,
+                // Normal-select rows: neutral, checkmark marks selection, hover/selected tint.
+                "flex h-8 w-full cursor-pointer items-center justify-between rounded-[8px] px-2 text-sm outline-none hover:bg-accent focus-visible:bg-accent",
+                isSelected && "bg-accent font-medium",
               )}
               onClick={() => toggleOption(opt.value)}
             >
               <span>{opt.label}</span>
-              {isSelected && <CheckIcon className="size-3.5 shrink-0" />}
+              {isSelected && <CheckIcon className="size-4 shrink-0" />}
             </button>
           );
         })}

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -99,24 +99,24 @@ export const MultiSelect = ({
             <div className="flex flex-1 flex-wrap gap-1">
               {selectedOptions.length > 0 ? (
                 selectedOptions.map((opt) => (
-                    <span
-                      key={opt.value}
-                      className="inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-900"
+                  <span
+                    key={opt.value}
+                    className="inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-900"
+                  >
+                    {opt.label}
+                    <button
+                      type="button"
+                      className="ml-1 inline-flex size-3 items-center justify-center rounded-full hover:bg-black/10"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleOption(opt.value);
+                      }}
+                      aria-label={`Remove ${opt.label}`}
                     >
-                      {opt.label}
-                      <button
-                        type="button"
-                        className="ml-1 inline-flex size-3 items-center justify-center rounded-full hover:bg-black/10"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          toggleOption(opt.value);
-                        }}
-                        aria-label={`Remove ${opt.label}`}
-                      >
-                        ×
-                      </button>
-                    </span>
-                  ))
+                      ×
+                    </button>
+                  </span>
+                ))
               ) : (
                 <span className="text-foreground/70">{placeholder}</span>
               )}

--- a/src/hooks/use-form-theme.ts
+++ b/src/hooks/use-form-theme.ts
@@ -1,21 +1,8 @@
 import { useMemo } from "react";
 import type { CSSProperties } from "react";
-import { useResolvedTheme } from "@/components/theme-provider";
 import { cn } from "@/lib/utils";
 import { useEditorTheme } from "@/contexts/editor-theme-context";
 import type { EditorThemeValue } from "@/contexts/editor-theme-context";
-
-/**
- * True when the FORM's resolved mode is dark (`customization.mode`), falling back to the app
- * theme only when the form has no customization. Use on form-preview surfaces that must follow
- * the form theme rather than the app's global `.dark` (e.g. chips/badges that would otherwise
- * pick up `dark:` variants from the app's <html.dark>).
- */
-export const useFormIsDark = (): boolean => {
-  const appTheme = useResolvedTheme();
-  const formMode = useEditorTheme().customization?.mode;
-  return (formMode ?? appTheme) === "dark";
-};
 
 type UseFormThemeContextValueArgs = {
   themeVars: CSSProperties;

--- a/src/hooks/use-preview-form.ts
+++ b/src/hooks/use-preview-form.ts
@@ -310,46 +310,34 @@ export const useStepPreviewForm = ({
 
   // Auto-fill fields targeted by a "Set value" action. Apply only when the *computed*
   // value changes (not every render) so the respondent can still edit in between.
-  const appliedSetValuesRef = useRef<Record<string, string>>({});
+  // Values may be a string (scalar / single-choice) or string[] (multi-choice) — compared
+  // order-sensitively via a null-joined key, and cleared to the field's native empty shape.
+  const appliedSetValuesRef = useRef<Record<string, string | string[]>>({});
   useEffect(() => {
     if (!evaluation) return;
     const prev = appliedSetValuesRef.current;
     const next = evaluation.setValues;
     const onThisStep = (name: string) => fields.some((f) => f.name === name);
+    const isArrayField = (name: string) => Array.isArray(defaultValues[name]);
+    const key = (v: unknown) => (Array.isArray(v) ? v.join(" ") : v == null ? "" : String(v));
+    const emptyFor = (name: string): string | string[] => (isArrayField(name) ? [] : "");
     // Apply changed set-values (only this step's fields live in this form instance;
-    // cross-step targets are applied by their own step when it mounts).
+    // cross-step targets are applied by their own step when it mounts). A clearValue ("")
+    // onto a multi-choice field becomes [] so the array shape is preserved.
     for (const [name, val] of Object.entries(next)) {
-      if (prev[name] !== val && onThisStep(name)) form.setFieldValue(name, val);
+      if (!onThisStep(name) || key(prev[name]) === key(val)) continue;
+      form.setFieldValue(name, val === "" && isArrayField(name) ? [] : val);
     }
     // Clear an auto-fill when its condition stops matching — but only if the field still holds
     // the value we forced. If the respondent has since edited it, keep their correction.
     for (const name of Object.keys(prev)) {
-      // normalize current value to a string, mirroring the engine's asString (arrays join, nullish → "")
-      const cur = form.getFieldValue(name);
-      const curStr = Array.isArray(cur) ? cur.join(", ") : cur == null ? "" : String(cur);
-      if (!(name in next) && onThisStep(name) && curStr === prev[name]) {
-        form.setFieldValue(name, "");
+      if (name in next || !onThisStep(name)) continue;
+      if (key(form.getFieldValue(name)) === key(prev[name])) {
+        form.setFieldValue(name, emptyFor(name));
       }
     }
     appliedSetValuesRef.current = { ...next };
-  }, [evaluation, fields, form]);
-
-  // "Move to next field": when a passing rule targets a field rendered on this step, scroll it
-  // into view and focus it. Tracked by ref so it fires only when the target changes, never
-  // stealing focus on every keystroke while the same rule keeps passing.
-  const focusedFieldRef = useRef<string | null>(null);
-  useEffect(() => {
-    const target = evaluation?.focusField ?? null;
-    if (target === focusedFieldRef.current) return;
-    focusedFieldRef.current = target;
-    if (!target || !fields.some((f) => f.name === target)) return; // not on this step
-    // escape interpolated values — names with quotes/special chars would otherwise throw SyntaxError
-    const el = document.querySelector<HTMLElement>(
-      `#${CSS.escape(formName)} [name="${CSS.escape(target)}"]`,
-    );
-    el?.scrollIntoView({ behavior: "smooth", block: "center" });
-    el?.focus();
-  }, [evaluation, fields, formName]);
+  }, [evaluation, fields, form, defaultValues]);
 
   return {
     form: form as unknown as AppForm,

--- a/src/lib/editor/resolve-mentions.test.ts
+++ b/src/lib/editor/resolve-mentions.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { fieldsBefore, formatMentionValue, hasMention, resolveMentions } from "./resolve-mentions";
+
+const ctx = (values: Record<string, unknown>, labels: Record<string, string> = {}) => ({
+  getValue: (name: string) => values[name],
+  getLabel: (name: string) => labels[name],
+});
+
+describe("resolveMentions", () => {
+  it("returns a single text run for plain text nodes", () => {
+    const runs = resolveMentions([{ text: "Hello there" }], ctx({}));
+    expect(runs).toEqual([{ kind: "text", text: "Hello there" }]);
+  });
+
+  it("resolves a filled mention to its live value", () => {
+    const nodes = [
+      { text: "hi , " },
+      { type: "mention", fieldName: "name", value: "Name", children: [{ text: "" }] },
+      { text: " !" },
+    ];
+    const runs = resolveMentions(nodes, ctx({ name: "Ada" }));
+    expect(runs).toEqual([
+      { kind: "text", text: "hi , " },
+      { kind: "value", text: "Ada" },
+      { kind: "text", text: " !" },
+    ]);
+  });
+
+  it("falls back to the referenced field label when the value is empty", () => {
+    const nodes = [{ type: "mention", fieldName: "name", value: "Name", children: [{ text: "" }] }];
+    const runs = resolveMentions(nodes, ctx({}, { name: "Enter Your Name" }));
+    expect(runs).toEqual([{ kind: "placeholder", text: "Enter Your Name" }]);
+  });
+
+  it("falls back to the stored display value when the field was deleted", () => {
+    const nodes = [
+      { type: "mention", fieldName: "gone", value: "Old Field", children: [{ text: "" }] },
+    ];
+    const runs = resolveMentions(nodes, ctx({}));
+    expect(runs).toEqual([{ kind: "placeholder", text: "Old Field" }]);
+  });
+
+  it("joins array values (multi-choice answers)", () => {
+    const nodes = [
+      { type: "mention", fieldName: "tools", value: "Tools", children: [{ text: "" }] },
+    ];
+    const runs = resolveMentions(nodes, ctx({ tools: ["Vim", "VSCode"] }));
+    expect(runs).toEqual([{ kind: "value", text: "Vim, VSCode" }]);
+  });
+
+  it("treats zero as a real answer, not empty", () => {
+    const nodes = [
+      { type: "mention", fieldName: "score", value: "Score", children: [{ text: "" }] },
+    ];
+    const runs = resolveMentions(nodes, ctx({ score: 0 }));
+    expect(runs).toEqual([{ kind: "value", text: "0" }]);
+  });
+});
+
+describe("formatMentionValue", () => {
+  it("returns empty string for null/undefined/empty", () => {
+    expect(formatMentionValue(null)).toBe("");
+    expect(formatMentionValue(undefined)).toBe("");
+    expect(formatMentionValue("")).toBe("");
+    expect(formatMentionValue([])).toBe("");
+  });
+});
+
+describe("hasMention", () => {
+  it("detects a mention anywhere in the children", () => {
+    expect(hasMention([{ text: "a" }, { type: "mention", fieldName: "x" }])).toBe(true);
+    expect(hasMention([{ text: "a" }])).toBe(false);
+    expect(hasMention(undefined)).toBe(false);
+  });
+});
+
+describe("fieldsBefore", () => {
+  const fields = [{ name: "a" }, { name: "b" }, { name: "c" }];
+
+  it("returns every field when there is no cutoff", () => {
+    expect(fieldsBefore(fields, null)).toEqual(fields);
+  });
+
+  it("returns only fields preceding the cutoff (excludes self and later)", () => {
+    expect(fieldsBefore(fields, "b")).toEqual([{ name: "a" }]);
+  });
+
+  it("returns every field when the cutoff is not found", () => {
+    expect(fieldsBefore(fields, "z")).toEqual(fields);
+  });
+});

--- a/src/lib/editor/resolve-mentions.ts
+++ b/src/lib/editor/resolve-mentions.ts
@@ -1,0 +1,84 @@
+// Field-mention (`@`) token resolution. Pure + framework-free so it unit-tests in isolation
+// and runs the same in preview and the published form. See docs/plans/2026-06-15-field-mention-tokens-design.md.
+
+/** Plate node type of an inserted field mention (extends @platejs/mention's `mention`). */
+export const MENTION_TYPE = "mention";
+
+/** A resolved label/content fragment: literal text, a live answer, or a faint placeholder. */
+export type MentionRun =
+  | { kind: "text"; text: string }
+  | { kind: "value"; text: string }
+  | { kind: "placeholder"; text: string };
+
+export interface ResolveMentionsCtx {
+  /** Current answer for a field `name` (from the live merged form values). */
+  getValue: (fieldName: string) => unknown;
+  /** Display label for a field `name`, looked up fresh so renames stay in sync. */
+  getLabel: (fieldName: string) => string | undefined;
+}
+
+/** A serializable subset of a Plate label child — narrow enough to cross the RSC server-fn
+ * boundary (no `unknown` index signature, unlike platejs `Value`). Carries text, marks, and
+ * mention metadata (`type:"mention"` + `key`/`fieldName`/`value`). */
+export interface LabelTokenNode {
+  text?: string;
+  type?: string;
+  value?: string;
+  fieldName?: string;
+  key?: string;
+  children?: LabelTokenNode[];
+  [prop: string]: string | number | boolean | LabelTokenNode[] | undefined;
+}
+
+/** Coerce an answer to display text. Arrays join with ", "; empty/blank → "". `0` stays "0". */
+export const formatMentionValue = (value: unknown): string => {
+  if (value == null) return "";
+  if (Array.isArray(value)) {
+    return value
+      .filter((v) => v != null && v !== "")
+      .map((v) => String(v))
+      .join(", ");
+  }
+  return String(value);
+};
+
+/** True when any child is a mention node — gates the slow structured render path. */
+export const hasMention = (nodes: unknown): boolean =>
+  Array.isArray(nodes) && nodes.some((n) => (n as LabelTokenNode)?.type === MENTION_TYPE);
+
+/** Walk label/content children → runs, swapping mentions for live answers (or a faint
+ * placeholder when unanswered/deleted). */
+export const resolveMentions = (
+  nodes: ReadonlyArray<LabelTokenNode> | undefined,
+  ctx: ResolveMentionsCtx,
+): MentionRun[] => {
+  const runs: MentionRun[] = [];
+  for (const node of nodes ?? []) {
+    if (node?.type === MENTION_TYPE) {
+      const fieldName = node.fieldName ?? node.key ?? "";
+      const text = formatMentionValue(ctx.getValue(fieldName));
+      if (text) {
+        runs.push({ kind: "value", text });
+      } else {
+        runs.push({
+          kind: "placeholder",
+          text: ctx.getLabel(fieldName) ?? node.value ?? fieldName,
+        });
+      }
+    } else if (typeof node?.text === "string") {
+      runs.push({ kind: "text", text: node.text });
+    }
+  }
+  return runs;
+};
+
+/** Fields preceding `cutoffName` in document order (excludes the field itself and any after).
+ * `null` cutoff or an unknown name → every field. */
+export const fieldsBefore = <T extends { name: string }>(
+  fields: ReadonlyArray<T>,
+  cutoffName: string | null,
+): T[] => {
+  if (!cutoffName) return [...fields];
+  const idx = fields.findIndex((f) => f.name === cutoffName);
+  return idx === -1 ? [...fields] : fields.slice(0, idx);
+};

--- a/src/lib/editor/transform-plate-for-preview.ts
+++ b/src/lib/editor/transform-plate-for-preview.ts
@@ -1,6 +1,8 @@
 import type { Value } from "platejs";
 import type { OptionLabelStyle } from "@/components/ui/form-option-item-constants";
 import { extractFileUploadFields } from "@/lib/form-schema/file-upload-types";
+import { hasMention } from "@/lib/editor/resolve-mentions";
+import type { LabelTokenNode } from "@/lib/editor/resolve-mentions";
 import { normalizeOptionNodes } from "@/lib/editor/normalize-option-nodes";
 import {
   ALLOWED_LABEL_TYPES,
@@ -134,13 +136,18 @@ const createSegments = (nodes: Value): PreviewSegment[] => {
    * mark consumed, pop from static buffer if present. Returns {labelText,labelNode} or null. */
   const lookBackForLabel = (
     i: number,
-  ): { labelText: string; labelNode: Record<string, unknown> } | null => {
+  ): {
+    labelText: string;
+    labelNode: Record<string, unknown>;
+    labelNodes?: LabelTokenNode[];
+  } | null => {
     if (i <= 0) return null;
     const prev = nodes[i - 1];
     const prevType = prev.type;
     if (!ALLOWED_LABEL_TYPES.has(prevType)) return null;
 
-    const labelText = extractTextContent(prev.children as Array<{ text?: string }>);
+    const children = prev.children as Array<{ text?: string }>;
+    const labelText = extractTextContent(children);
     consumedIndices.add(i - 1);
 
     // Pop label from static buffer if it was the most-recently pushed item.
@@ -148,7 +155,15 @@ const createSegments = (nodes: Value): PreviewSegment[] => {
       staticBuffer.pop();
     }
 
-    return { labelText, labelNode: prev as Record<string, unknown> };
+    // Carry raw children only when a mention token is present — keeps the plain-text fast
+    // path for every ordinary label.
+    const labelNodes = hasMention(children) ? (children as unknown as LabelTokenNode[]) : undefined;
+
+    return {
+      labelText,
+      labelNode: prev as Record<string, unknown>,
+      ...(labelNodes ? { labelNodes } : {}),
+    };
   };
 
   let i = 0;
@@ -207,6 +222,7 @@ const createSegments = (nodes: Value): PreviewSegment[] => {
           fieldType: INPUT_TYPE_TO_FIELD_TYPE[nodeType] as PlateFormField["fieldType"],
           label: labelText || undefined,
           labelType: label?.labelNode.type as string | undefined,
+          ...(label?.labelNodes ? { labelNodes: label.labelNodes } : {}),
           placeholder: placeholder || undefined,
           required: isRequired,
           minLength,
@@ -252,6 +268,7 @@ const createSegments = (nodes: Value): PreviewSegment[] => {
           fieldType: "Matrix",
           label: labelText || undefined,
           labelType: label?.labelNode.type as string | undefined,
+          ...(label?.labelNodes ? { labelNodes: label.labelNodes } : {}),
           required: isRequired,
           rows,
           columns,
@@ -312,6 +329,7 @@ const createSegments = (nodes: Value): PreviewSegment[] => {
           fieldType,
           label: fieldLabel || undefined,
           labelType: label?.labelNode.type as string | undefined,
+          ...(label?.labelNodes ? { labelNodes: label.labelNodes } : {}),
           required: isRequired,
           options,
           ...(shuffle ? { shuffle } : {}),

--- a/src/lib/editor/transform-plate-to-form.ts
+++ b/src/lib/editor/transform-plate-to-form.ts
@@ -1,5 +1,6 @@
 import type { Value } from "platejs";
 import type { OptionLabelStyle } from "@/components/ui/form-option-item-constants";
+import type { LabelTokenNode } from "@/lib/editor/resolve-mentions";
 import type {
   DecimalSeparator,
   NumberFormatType,
@@ -53,6 +54,9 @@ export type PlateFormField =
       fieldType: "Input";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       placeholder?: string;
       required?: boolean;
       minLength?: number;
@@ -69,6 +73,9 @@ export type PlateFormField =
       fieldType: "Textarea";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       placeholder?: string;
       required?: boolean;
       minLength?: number;
@@ -85,6 +92,9 @@ export type PlateFormField =
       fieldType: "Email";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       placeholder?: string;
       required?: boolean;
       isFieldArray?: boolean;
@@ -100,6 +110,9 @@ export type PlateFormField =
       fieldType: "Phone";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       placeholder?: string;
       required?: boolean;
       isFieldArray?: boolean;
@@ -115,6 +128,9 @@ export type PlateFormField =
       fieldType: "Number";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       placeholder?: string;
       required?: boolean;
       min?: number;
@@ -137,6 +153,9 @@ export type PlateFormField =
       fieldType: "Link";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       placeholder?: string;
       required?: boolean;
       isFieldArray?: boolean;
@@ -150,6 +169,9 @@ export type PlateFormField =
       fieldType: "Date";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       placeholder?: string;
       required?: boolean;
       isFieldArray?: boolean;
@@ -163,6 +185,9 @@ export type PlateFormField =
       fieldType: "Time";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       placeholder?: string;
       required?: boolean;
       /** Railway/24-hour time entry (default 12-hour AM/PM). */
@@ -178,6 +203,9 @@ export type PlateFormField =
       fieldType: "FileUpload";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       required?: boolean;
       accept?: string;
       maxFileSize?: number;
@@ -191,6 +219,9 @@ export type PlateFormField =
       fieldType: "Checkbox";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       required?: boolean;
       options: { value: string; label: string; image?: string }[];
       /** Leading marker style for the option group (Labels submenu). Default: native control. */
@@ -208,6 +239,9 @@ export type PlateFormField =
       fieldType: "MultiChoice";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       required?: boolean;
       options: { value: string; label: string; image?: string }[];
       /** Leading marker style for the option group (Labels submenu). Default: letters. */
@@ -225,6 +259,9 @@ export type PlateFormField =
       fieldType: "Ranking";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       required?: boolean;
       options: { value: string; label: string; image?: string }[];
       /** Randomize initial option order in the live form. */
@@ -236,6 +273,9 @@ export type PlateFormField =
       fieldType: "LinearScale";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       required?: boolean;
       /** Scale start, end, and increment — the live form renders a button per step. */
       min: number;
@@ -252,6 +292,9 @@ export type PlateFormField =
       fieldType: "Rating";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       required?: boolean;
       /** Number of stars shown (default 5, configurable via the block menu). */
       starCount?: number;
@@ -262,6 +305,9 @@ export type PlateFormField =
       fieldType: "Signature";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       required?: boolean;
     }
   | {
@@ -270,6 +316,9 @@ export type PlateFormField =
       fieldType: "Matrix";
       label?: string;
       labelType?: string;
+      /** Raw label children — present only when the label contains `@`-mention tokens, so
+       * the renderer can resolve them against live answers (see resolve-mentions). */
+      labelNodes?: LabelTokenNode[];
       required?: boolean;
       /** Grid rows (the sub-questions) and columns (the answer scale). The
        * answer is a record keyed by row `value` → column `value` (single) or

--- a/src/lib/logic/engine.test.ts
+++ b/src/lib/logic/engine.test.ts
@@ -68,30 +68,33 @@ describe("evaluate — visibility", () => {
     expect(evaluate(ruleset([hide, show]), { country: "DE" }, fields).visibility.vat).toBe(false);
   });
 
-  it("applies elseActions (Else Do) when the condition fails", () => {
+  it("a hidden field's value no longer satisfies another rule's condition (no ghost conditions)", () => {
+    // Rule A hides `extra` when country=US. Rule B shows `vat` when extra is not empty.
+    // With extra filled but hidden, vat must NOT be revealed — the hidden value is masked.
     const rs = ruleset([
       {
-        id: "r",
+        id: "hideExtra",
         stepId: "s1",
         when: {
           combinator: "all",
-          children: [{ source: "country", operator: "equals", value: "DE" }],
+          children: [{ source: "country", operator: "equals", value: "US" }],
         },
+        actions: [{ kind: "hide", target: "extra" }],
+      },
+      {
+        id: "showVat",
+        stepId: "s1",
+        when: { combinator: "all", children: [{ source: "extra", operator: "isNotEmpty" }] },
         actions: [{ kind: "show", target: "vat" }],
-        elseActions: [{ kind: "show", target: "extra" }],
       },
     ]);
-    // country=DE → Do branch: vat shown, extra (else-show-target) stays hidden-by-default
-    const pass = evaluate(rs, { country: "DE" }, fields);
-    expect(pass.visibility.vat).toBe(true);
-    expect(pass.visibility.extra).toBe(false);
-    // country=FR → Else Do branch: extra shown, vat stays hidden-by-default
-    const fail = evaluate(rs, { country: "FR" }, fields);
-    expect(fail.visibility.vat).toBe(false);
-    expect(fail.visibility.extra).toBe(true);
+    // extra filled + visible (country DE) → vat shown.
+    expect(evaluate(rs, { country: "DE", extra: "x" }, fields).visibility.vat).toBe(true);
+    // extra filled but hidden (country US) → masked → vat stays hidden.
+    expect(evaluate(rs, { country: "US", extra: "x" }, fields).visibility.vat).toBe(false);
   });
 
-  it("setValue auto-fills a target only on the active branch", () => {
+  it("setValue auto-fills a target when its condition passes, and is absent otherwise", () => {
     const rs = ruleset([
       {
         id: "r",
@@ -101,11 +104,79 @@ describe("evaluate — visibility", () => {
           children: [{ source: "country", operator: "equals", value: "DE" }],
         },
         actions: [{ kind: "setValue", target: "vat", value: "36" }],
-        elseActions: [{ kind: "setValue", target: "vat", value: "0" }],
       },
     ]);
     expect(evaluate(rs, { country: "DE" }, fields).setValues.vat).toBe("36");
-    expect(evaluate(rs, { country: "FR" }, fields).setValues.vat).toBe("0");
+    expect(evaluate(rs, { country: "FR" }, fields).setValues.vat).toBeUndefined();
+  });
+
+  it("setValue can write an array (multi-choice target), and an empty array is a no-op", () => {
+    const arr = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "DE" }],
+        },
+        actions: [{ kind: "setValue", target: "extra", value: ["a", "b"] }],
+      },
+    ]);
+    expect(evaluate(arr, { country: "DE" }, fields).setValues.extra).toEqual(["a", "b"]);
+
+    const empty = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "DE" }],
+        },
+        actions: [{ kind: "setValue", target: "extra", value: [] }],
+      },
+    ]);
+    expect(evaluate(empty, { country: "DE" }, fields).setValues.extra).toBeUndefined();
+  });
+
+  it("clearValue resets a target to empty when its condition passes", () => {
+    const rs = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "DE" }],
+        },
+        actions: [{ kind: "clearValue", target: "vat" }],
+      },
+    ]);
+    expect(evaluate(rs, { country: "DE" }, fields).setValues.vat).toBe("");
+    expect(evaluate(rs, { country: "FR" }, fields).setValues.vat).toBeUndefined();
+  });
+
+  it("setValue with a blank value is a no-op (use clearValue to reset)", () => {
+    const rs = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: { combinator: "all", children: [{ source: "country", operator: "isNotEmpty" }] },
+        actions: [{ kind: "setValue", target: "vat", value: "" }],
+      },
+    ]);
+    expect(evaluate(rs, { country: "DE" }, fields).setValues.vat).toBeUndefined();
+  });
+
+  it("an empty / incomplete condition group makes the rule a no-op (does not fire)", () => {
+    const rs = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: { combinator: "all", children: [] },
+        actions: [{ kind: "hide", target: "vat" }],
+      },
+    ]);
+    // Empty group must NOT vacuously pass — vat stays visible.
+    expect(evaluate(rs, { country: "DE" }, fields).visibility.vat).toBe(true);
   });
 
   it("ignores action targets that are not known fields (no stray visibility keys)", () => {
@@ -209,6 +280,43 @@ describe("evaluate — required, hideSubmit, redirect", () => {
     expect(evaluate(rs, { country: "DE" }, fields).effectiveRequired.extra).toBe(true);
   });
 
+  it("optional action relaxes a base-required field when its condition passes", () => {
+    const rs = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [{ source: "country", operator: "equals", value: "DE" }],
+        },
+        actions: [{ kind: "optional", target: "vat" }], // vat is base-required
+      },
+    ]);
+    expect(evaluate(rs, { country: "FR" }, fields).effectiveRequired.vat).toBe(true);
+    expect(evaluate(rs, { country: "DE" }, fields).effectiveRequired.vat).toBe(false);
+  });
+
+  it("optional wins over require deterministically, regardless of rule order", () => {
+    const require: Rule = {
+      id: "req",
+      stepId: "s1",
+      when: { combinator: "all", children: [{ source: "country", operator: "isNotEmpty" }] },
+      actions: [{ kind: "require", target: "extra" }],
+    };
+    const optional: Rule = {
+      id: "opt",
+      stepId: "s1",
+      when: { combinator: "all", children: [{ source: "country", operator: "isNotEmpty" }] },
+      actions: [{ kind: "optional", target: "extra" }],
+    };
+    expect(
+      evaluate(ruleset([require, optional]), { country: "DE" }, fields).effectiveRequired.extra,
+    ).toBe(false);
+    expect(
+      evaluate(ruleset([optional, require]), { country: "DE" }, fields).effectiveRequired.extra,
+    ).toBe(false);
+  });
+
   it("hideSubmit and redirect react to conditions", () => {
     const rs = ruleset([
       {
@@ -277,64 +385,6 @@ describe("evaluate — fail-closed orphans", () => {
   });
 });
 
-describe("evaluate — moveToNext (focusField)", () => {
-  it("focusField is the target of a passing Move-to-next-field action, else null", () => {
-    const rs = ruleset([
-      {
-        id: "r",
-        stepId: "s1",
-        when: {
-          combinator: "all",
-          children: [{ source: "country", operator: "equals", value: "DE" }],
-        },
-        actions: [{ kind: "moveToNext", target: "vat" }],
-      },
-    ]);
-    expect(evaluate(rs, { country: "DE" }, fields).focusField).toBe("vat");
-    expect(evaluate(rs, { country: "FR" }, fields).focusField).toBeNull();
-  });
-
-  it("ignores Move-to-next-field targets that are not known fields", () => {
-    const rs = ruleset([
-      {
-        id: "r",
-        stepId: "s1",
-        when: { combinator: "all", children: [{ source: "country", operator: "isNotEmpty" }] },
-        actions: [{ kind: "moveToNext", target: "ghost" }],
-      },
-    ]);
-    expect(evaluate(rs, { country: "DE" }, fields).focusField).toBeNull();
-  });
-
-  it("last passing Move-to-next-field wins (document order)", () => {
-    const move = (id: string, target: string): Rule => ({
-      id,
-      stepId: "s1",
-      when: { combinator: "all", children: [{ source: "country", operator: "isNotEmpty" }] },
-      actions: [{ kind: "moveToNext", target }],
-    });
-    const rs = ruleset([move("r1", "vat"), move("r2", "extra")]);
-    expect(evaluate(rs, { country: "DE" }, fields).focusField).toBe("extra");
-  });
-
-  it("uses the Else branch's Move-to-next-field when the condition fails", () => {
-    const rs = ruleset([
-      {
-        id: "r",
-        stepId: "s1",
-        when: {
-          combinator: "all",
-          children: [{ source: "country", operator: "equals", value: "DE" }],
-        },
-        actions: [{ kind: "moveToNext", target: "vat" }],
-        elseActions: [{ kind: "moveToNext", target: "extra" }],
-      },
-    ]);
-    expect(evaluate(rs, { country: "DE" }, fields).focusField).toBe("vat");
-    expect(evaluate(rs, { country: "FR" }, fields).focusField).toBe("extra");
-  });
-});
-
 describe("evaluate — setValue is never spontaneous (the prefill footgun)", () => {
   // Mirrors the reported confusion: "When Short Answer contains 'baskar' → Set it to 'vijayabaskar'".
   const rs = ruleset([
@@ -367,6 +417,50 @@ describe("evaluate — setValue is never spontaneous (the prefill footgun)", () 
     // applied. The engine is correct — the rule is self-referential, which is what causes the
     // value to look 'stuck/prefilled' once a persisted draft seeds it.
     expect(evaluate(rs, { extra: "vijayabaskar" }, fields).setValues.extra).toBe("vijayabaskar");
+  });
+
+  // Self-CANCELLING guard ("set X while X is empty"): applying the value falsifies the guard, so a
+  // pure engine would drop it, the client would clear it, and the rule would re-fire — flicker.
+  // The engine latches the value: keep reporting it while the rest of the guard holds and the
+  // target still carries exactly that value.
+  describe("self-cancelling prefill latches (no set→clear→set flicker)", () => {
+    const selfRs = ruleset([
+      {
+        id: "r",
+        stepId: "s1",
+        when: {
+          combinator: "all",
+          children: [
+            { source: "short", operator: "isNotEmpty" },
+            { source: "long", operator: "isEmpty" },
+          ],
+        },
+        actions: [{ kind: "setValue", target: "long", value: "Hello world this" }],
+      },
+    ]);
+    const f: EngineField[] = [{ name: "short" }, { name: "long" }];
+
+    it("fills on the first pass while the target is still empty", () => {
+      expect(evaluate(selfRs, { short: "x", long: "" }, f).setValues.long).toBe("Hello world this");
+    });
+
+    it("stays latched once filled (guard now fails, but the value holds)", () => {
+      expect(evaluate(selfRs, { short: "x", long: "Hello world this" }, f).setValues.long).toBe(
+        "Hello world this",
+      );
+    });
+
+    it("releases when the rest of the guard stops holding", () => {
+      expect(
+        evaluate(selfRs, { short: "", long: "Hello world this" }, f).setValues.long,
+      ).toBeUndefined();
+    });
+
+    it("does not latch a respondent's own edit (only the exact set value)", () => {
+      expect(
+        evaluate(selfRs, { short: "x", long: "my own answer" }, f).setValues.long,
+      ).toBeUndefined();
+    });
   });
 });
 
@@ -416,10 +510,16 @@ describe("evaluate — full operator × action matrix (text field)", () => {
       absent: (r) => r.setValues.tgt === undefined,
     },
     {
-      name: "move to next field",
-      action: { kind: "moveToNext", target: "tgt" },
-      present: (r) => r.focusField === "tgt",
-      absent: (r) => r.focusField === null,
+      name: "make optional",
+      action: { kind: "optional", target: "tgt" },
+      present: (r) => r.effectiveRequired.tgt === false,
+      absent: (r) => r.effectiveRequired.tgt === false, // tgt has no base-required, so optional is a no-op either way
+    },
+    {
+      name: "clear value",
+      action: { kind: "clearValue", target: "tgt" },
+      present: (r) => r.setValues.tgt === "",
+      absent: (r) => r.setValues.tgt === undefined,
     },
     {
       name: "jump to step",
@@ -541,25 +641,5 @@ describe("evaluate — full operator × action matrix (text field)", () => {
         fieldsX,
       ).visibility.tgt,
     ).toBe(false);
-  });
-
-  // Else branch: the action fires when the condition FAILS instead of passes.
-  it("Else action fires on the failing branch for every operator", () => {
-    for (const o of OPERATORS) {
-      const rs = ruleset([
-        {
-          id: "r",
-          stepId: "s1",
-          when: {
-            combinator: "all",
-            children: [{ source: "x", operator: o.op, value: o.operand }],
-          },
-          actions: [],
-          elseActions: [{ kind: "setValue", target: "tgt", value: "ELSE" }],
-        },
-      ]);
-      expect(evaluate(rs, { x: o.fail }, matrixFields).setValues.tgt).toBe("ELSE"); // fails → Else
-      expect(evaluate(rs, { x: o.pass }, matrixFields).setValues.tgt).toBeUndefined(); // passes → no Else
-    }
   });
 });

--- a/src/lib/logic/engine.ts
+++ b/src/lib/logic/engine.ts
@@ -1,7 +1,6 @@
-import { applyOperator } from "./operators";
+import { applyOperator, asString } from "./operators";
 import { THANK_YOU_STEP } from "./types";
 import type {
-  Action,
   Condition,
   ConditionGroup,
   EngineField,
@@ -11,6 +10,21 @@ import type {
 } from "./types";
 
 const isGroup = (node: Condition | ConditionGroup): node is ConditionGroup => "combinator" in node;
+
+/** A set-value with no content (blank string or empty array) is a no-op — use clearValue to reset. */
+const isBlankSetValue = (v: string | string[]): boolean =>
+  Array.isArray(v) ? v.length === 0 : v === "";
+
+/** Membership-insensitive equality for set-value latch checks (arrays compared as sets). */
+const sameSetValue = (a: unknown, b: string | string[]): boolean => {
+  if (Array.isArray(b)) {
+    const arr = Array.isArray(a) ? a.map(String) : [];
+    if (arr.length !== b.length) return false;
+    const set = new Set(arr);
+    return b.every((x) => set.has(x));
+  }
+  return asString(a) === b;
+};
 
 const evalCondition = (
   cond: Condition,
@@ -27,6 +41,8 @@ const evalGroup = (
   answers: Record<string, unknown>,
   knownNames: Set<string>,
 ): boolean => {
+  // An empty / incomplete group never fires — no vacuous truth for `all`.
+  if (group.children.length === 0) return false;
   const results = group.children.map((child) =>
     isGroup(child)
       ? evalGroup(child, answers, knownNames)
@@ -39,21 +55,137 @@ const evalGroup = (
 const collectShowTargets = (rules: Rule[]): Set<string> => {
   const set = new Set<string>();
   for (const rule of rules) {
-    for (const action of [...rule.actions, ...(rule.elseActions ?? [])]) {
+    for (const action of rule.actions) {
       if (action.kind === "show") set.add(action.target);
     }
   }
   return set;
 };
 
-/** The action list a rule contributes for the current answers: "Do" when it passes,
- * "Else Do" when it doesn't. */
-const activeActions = (
-  rule: Rule,
-  answers: Record<string, unknown>,
+/** Every field name referenced as a condition source across all rules (recurses groups). */
+const collectConditionSources = (rules: Rule[]): Set<string> => {
+  const sources = new Set<string>();
+  const walk = (node: Condition | ConditionGroup): void => {
+    if (isGroup(node)) node.children.forEach(walk);
+    else sources.add(node.source);
+  };
+  for (const rule of rules) walk(rule.when);
+  return sources;
+};
+
+/** Targets of show/hide actions — the only fields whose masking can shift another rule's outcome. */
+const collectHideShowTargets = (rules: Rule[]): Set<string> => {
+  const set = new Set<string>();
+  for (const rule of rules) {
+    for (const action of rule.actions) {
+      if (action.kind === "show" || action.kind === "hide") set.add(action.target);
+    }
+  }
+  return set;
+};
+
+/** Accumulated effect of every rule whose `when` passes for a given answer snapshot. */
+interface Accumulated {
+  passingShow: Set<string>;
+  passingHide: Set<string>;
+  requiredByAction: Set<string>;
+  optionalByAction: Set<string>;
+  setValues: Record<string, string | string[]>;
+  hideSubmit: boolean;
+  redirectUrl: string | null;
+}
+
+const accumulate = (
+  rules: Rule[],
+  snapshot: Record<string, unknown>,
   knownNames: Set<string>,
-): Action[] =>
-  evalGroup(rule.when, answers, knownNames) ? rule.actions : (rule.elseActions ?? []);
+): Accumulated => {
+  const acc: Accumulated = {
+    passingShow: new Set(),
+    passingHide: new Set(),
+    requiredByAction: new Set(),
+    optionalByAction: new Set(),
+    setValues: {},
+    hideSubmit: false,
+    redirectUrl: null,
+  };
+  for (const rule of rules) {
+    const passes = evalGroup(rule.when, snapshot, knownNames);
+    for (const action of rule.actions) {
+      if (!passes) {
+        // Self-CANCELLING set-value latch: a guard like "set X while X is empty" is falsified the
+        // moment the value lands, so a pure pass/fail would drop it — the client then clears it and
+        // the rule re-fires forever (flicker). Keep the value while the rest of the guard would
+        // still pass with the target emptied AND the target already carries exactly that value (so
+        // a respondent's own edit is never latched). Positive self-refs ("set X while X contains Y")
+        // pass outright above and never reach here.
+        if (
+          action.kind === "setValue" &&
+          !isBlankSetValue(action.value) &&
+          knownNames.has(action.target) &&
+          sameSetValue(snapshot[action.target], action.value) &&
+          evalGroup(rule.when, { ...snapshot, [action.target]: undefined }, knownNames)
+        ) {
+          acc.setValues[action.target] = action.value;
+        }
+        continue;
+      }
+      // Only known fields are tracked, so orphaned targets never leak stray keys.
+      if (action.kind === "show" && knownNames.has(action.target))
+        acc.passingShow.add(action.target);
+      else if (action.kind === "hide" && knownNames.has(action.target))
+        acc.passingHide.add(action.target);
+      else if (action.kind === "require" && knownNames.has(action.target))
+        acc.requiredByAction.add(action.target);
+      else if (action.kind === "optional" && knownNames.has(action.target))
+        acc.optionalByAction.add(action.target);
+      else if (
+        action.kind === "setValue" &&
+        knownNames.has(action.target) &&
+        !isBlankSetValue(action.value)
+      )
+        acc.setValues[action.target] = action.value; // blank value is a no-op; document order, last wins
+      else if (action.kind === "clearValue" && knownNames.has(action.target))
+        acc.setValues[action.target] = ""; // reset to empty
+      else if (action.kind === "hideSubmit") acc.hideSubmit = true;
+      else if (action.kind === "redirect") acc.redirectUrl = action.url;
+    }
+  }
+  return acc;
+};
+
+/** Visibility precedence: hide wins over show; show-targeted fields default hidden, all else visible. */
+const computeVisibility = (
+  acc: Accumulated,
+  fields: ReadonlyArray<EngineField>,
+  showTargets: Set<string>,
+): Record<string, boolean> => {
+  const visibility: Record<string, boolean> = {};
+  for (const field of fields) {
+    if (acc.passingHide.has(field.name)) visibility[field.name] = false;
+    else if (acc.passingShow.has(field.name)) visibility[field.name] = true;
+    else visibility[field.name] = !showTargets.has(field.name);
+  }
+  return visibility;
+};
+
+/** A hidden field reads as "no answer" so it can't drive other rules (no ghost conditions). */
+const maskHidden = (
+  answers: Record<string, unknown>,
+  visibility: Record<string, boolean>,
+  fields: ReadonlyArray<EngineField>,
+): Record<string, unknown> => {
+  const masked: Record<string, unknown> = { ...answers };
+  for (const field of fields) {
+    if (visibility[field.name] === false) masked[field.name] = undefined;
+  }
+  return masked;
+};
+
+const sameVisibility = (a: Record<string, boolean>, b: Record<string, boolean>): boolean => {
+  for (const key in a) if (a[key] !== b[key]) return false;
+  return true;
+};
 
 /** Pure, isomorphic evaluation of a ruleset against current answers. */
 export const evaluate = (
@@ -64,53 +196,46 @@ export const evaluate = (
   const knownNames = new Set(fields.map((f) => f.name));
   const showTargets = collectShowTargets(ruleset.rules);
 
-  // Collect which targets a *passing* rule shows/hides/requires. Only known fields
-  // are tracked, so orphaned action targets never leak stray keys into the result.
-  const passingShow = new Set<string>();
-  const passingHide = new Set<string>();
-  const requiredByAction = new Set<string>();
-  const setValues: Record<string, string> = {};
-  let focusField: string | null = null;
-  let hideSubmit = false;
-  let redirectUrl: string | null = null;
-
-  for (const rule of ruleset.rules) {
-    for (const action of activeActions(rule, answers, knownNames)) {
-      if (action.kind === "show" && knownNames.has(action.target)) passingShow.add(action.target);
-      else if (action.kind === "hide" && knownNames.has(action.target))
-        passingHide.add(action.target);
-      else if (action.kind === "require" && knownNames.has(action.target))
-        requiredByAction.add(action.target);
-      else if (action.kind === "setValue" && knownNames.has(action.target))
-        setValues[action.target] = action.value; // document order, last wins
-      else if (action.kind === "moveToNext" && knownNames.has(action.target))
-        focusField = action.target; // document order, last wins
-      else if (action.kind === "hideSubmit") hideSubmit = true;
-      else if (action.kind === "redirect") redirectUrl = action.url;
+  // Iterate to a stable visibility: a field hidden by one pass is masked in the next, so its
+  // value stops satisfying downstream conditions. Bounded by field count (no infinite loop).
+  let snapshot = answers;
+  let acc = accumulate(ruleset.rules, snapshot, knownNames);
+  let visibility = computeVisibility(acc, fields, showTargets);
+  // The loop only matters when a show/hide-toggled field is itself a condition source; otherwise
+  // masking can't change any outcome, so a single pass is already exact — skip the re-accumulation.
+  const hideShowTargets = collectHideShowTargets(ruleset.rules);
+  const conditionSources = collectConditionSources(ruleset.rules);
+  const needsConvergence = [...hideShowTargets].some((name) => conditionSources.has(name));
+  if (needsConvergence) {
+    for (let i = 0; i < fields.length; i++) {
+      const nextSnapshot = maskHidden(answers, visibility, fields);
+      const nextAcc = accumulate(ruleset.rules, nextSnapshot, knownNames);
+      const nextVis = computeVisibility(nextAcc, fields, showTargets);
+      snapshot = nextSnapshot;
+      acc = nextAcc;
+      if (sameVisibility(visibility, nextVis)) {
+        visibility = nextVis;
+        break;
+      }
+      visibility = nextVis;
     }
   }
 
-  // Visibility precedence: a passing hide always wins over a passing show
-  // (deterministic, order-independent, fail-safe — hidden fields are stripped server-side).
-  // Default: show-targeted fields start hidden; everything else starts visible.
-  const visibility: Record<string, boolean> = {};
-  for (const field of fields) {
-    if (passingHide.has(field.name)) visibility[field.name] = false;
-    else if (passingShow.has(field.name)) visibility[field.name] = true;
-    else visibility[field.name] = !showTargets.has(field.name);
-  }
-
+  // Optional wins over require and over the field's base-required flag.
   const effectiveRequired: Record<string, boolean> = {};
   for (const field of fields) {
     const authored = field.required === true;
     effectiveRequired[field.name] =
-      visibility[field.name] && (authored || requiredByAction.has(field.name));
+      visibility[field.name] &&
+      (authored || acc.requiredByAction.has(field.name)) &&
+      !acc.optionalByAction.has(field.name);
   }
 
   const resolveJump = (fromStep: string): string | null => {
     for (const rule of ruleset.rules) {
       if (rule.stepId !== fromStep) continue;
-      const jump = activeActions(rule, answers, knownNames).find((a) => a.kind === "jump");
+      if (!evalGroup(rule.when, snapshot, knownNames)) continue;
+      const jump = rule.actions.find((a) => a.kind === "jump");
       if (jump && jump.kind === "jump") return jump.toStep;
     }
     return null;
@@ -120,10 +245,9 @@ export const evaluate = (
     visibility,
     effectiveRequired,
     computedValues: {},
-    setValues,
-    focusField,
-    hideSubmit,
-    redirectUrl,
+    setValues: acc.setValues,
+    hideSubmit: acc.hideSubmit,
+    redirectUrl: acc.redirectUrl,
     resolveJump,
   };
 };

--- a/src/lib/logic/extract-ruleset.test.ts
+++ b/src/lib/logic/extract-ruleset.test.ts
@@ -89,6 +89,85 @@ describe("extractRuleset", () => {
     expect(rules[0].when.children).toHaveLength(0);
   });
 
+  it("drops a malformed / unsupported legacy action and flags the block", () => {
+    const value = [
+      { type: "formLabel", id: "q", children: [{ text: "Q" }] },
+      { type: "formInput", children: [{ text: "" }] },
+      {
+        type: "logicBlock",
+        id: "lbLegacy",
+        when: { combinator: "all", children: [{ source: "q", operator: "isNotEmpty" }] },
+        // moveToNext was removed from the action model; setValue/show are kept.
+        actions: [
+          { kind: "moveToNext", target: "q" },
+          { kind: "show", target: "q" },
+        ],
+        children: [{ text: "" }],
+      },
+    ] as unknown as Value;
+    const { rules, orphanedRefs } = extractRuleset(value);
+    expect(rules[0].actions).toEqual([{ kind: "show", target: "q" }]);
+    expect(orphanedRefs).toContain("lbLegacy");
+  });
+
+  it("drops a setValue/require action that targets a repeatable field and flags it", () => {
+    const value = [
+      { type: "formLabel", id: "emails", children: [{ text: "Emails" }] },
+      { type: "formEmail", isFieldArray: true, children: [{ text: "" }] },
+      { type: "formLabel", id: "q", children: [{ text: "Q" }] },
+      { type: "formInput", children: [{ text: "" }] },
+      {
+        type: "logicBlock",
+        id: "lbArr",
+        when: { combinator: "all", children: [{ source: "q", operator: "isNotEmpty" }] },
+        actions: [{ kind: "setValue", target: "emails", value: "x" }],
+        children: [{ text: "" }],
+      },
+    ] as unknown as Value;
+    const { rules, orphanedRefs } = extractRuleset(value);
+    expect(rules[0].actions).toHaveLength(0); // string-into-array write dropped
+    expect(orphanedRefs).toContain("emails");
+  });
+
+  it("keeps a setValue whose value is an array targeting a multi-choice field", () => {
+    const value = [
+      { type: "formLabel", id: "q", children: [{ text: "Q" }] },
+      { type: "formInput", children: [{ text: "" }] },
+      { type: "formLabel", id: "tools", children: [{ text: "Tools" }] },
+      { type: "formOptionItem", variant: "checkbox", children: [{ text: "Figma" }] },
+      { type: "formOptionItem", variant: "checkbox", children: [{ text: "Sketch" }] },
+      {
+        type: "logicBlock",
+        id: "lbArr",
+        when: { combinator: "all", children: [{ source: "q", operator: "isNotEmpty" }] },
+        actions: [{ kind: "setValue", target: "tools", value: ["figma", "sketch"] }],
+        children: [{ text: "" }],
+      },
+    ] as unknown as Value;
+    const { rules, orphanedRefs } = extractRuleset(value);
+    expect(rules[0].actions).toEqual([
+      { kind: "setValue", target: "tools", value: ["figma", "sketch"] },
+    ]);
+    expect(orphanedRefs).not.toContain("tools");
+  });
+
+  it("treats a malformed `when` group as empty (rule no-ops) and flags the block", () => {
+    const value = [
+      { type: "formLabel", id: "q", children: [{ text: "Q" }] },
+      { type: "formInput", children: [{ text: "" }] },
+      {
+        type: "logicBlock",
+        id: "lbBad",
+        when: { combinator: "sometimes", children: "nope" },
+        actions: [{ kind: "hide", target: "q" }],
+        children: [{ text: "" }],
+      },
+    ] as unknown as Value;
+    const { rules, orphanedRefs } = extractRuleset(value);
+    expect(rules[0].when).toEqual({ combinator: "all", children: [] });
+    expect(orphanedRefs).toContain("lbBad");
+  });
+
   it("returns an empty ruleset for content with no logic blocks", () => {
     const value = [
       { type: "formLabel", id: "q", children: [{ text: "Q" }] },

--- a/src/lib/logic/extract-ruleset.ts
+++ b/src/lib/logic/extract-ruleset.ts
@@ -1,7 +1,8 @@
 import type { Value } from "platejs";
+import * as v from "valibot";
 import { transformPlateForPreview } from "@/lib/editor/transform-plate-for-preview";
 import { THANK_YOU_STEP } from "./types";
-import type { ConditionGroup, LogicBlockNode, Rule, Ruleset } from "./types";
+import type { Action, ConditionGroup, Rule, Ruleset } from "./types";
 
 const FIRST_STEP_ID = "step-0";
 
@@ -9,6 +10,52 @@ interface FieldMeta {
   name: string;
   isFieldArray: boolean;
 }
+
+// --- Schema: validate persisted logicBlock nodes instead of trusting raw casts. ---
+const OperatorSchema = v.picklist([
+  "equals",
+  "notEquals",
+  "contains",
+  "notContains",
+  "greaterThan",
+  "lessThan",
+  "greaterThanOrEqual",
+  "lessThanOrEqual",
+  "isEmpty",
+  "isNotEmpty",
+]);
+
+const ConditionSchema = v.object({
+  source: v.string(),
+  operator: OperatorSchema,
+  value: v.optional(v.string()),
+});
+
+const GroupSchema: v.GenericSchema<ConditionGroup> = v.object({
+  combinator: v.picklist(["all", "any"]),
+  children: v.array(v.lazy(() => v.union([ConditionSchema, GroupSchema]))),
+});
+
+const ActionSchema = v.variant("kind", [
+  v.object({ kind: v.literal("show"), target: v.string() }),
+  v.object({ kind: v.literal("hide"), target: v.string() }),
+  v.object({ kind: v.literal("require"), target: v.string() }),
+  v.object({ kind: v.literal("optional"), target: v.string() }),
+  v.object({
+    kind: v.literal("setValue"),
+    target: v.string(),
+    value: v.union([v.string(), v.array(v.string())]), // string → scalar/single-choice; array → multi-choice
+  }),
+  v.object({ kind: v.literal("clearValue"), target: v.string() }),
+  v.object({ kind: v.literal("jump"), toStep: v.string() }),
+  v.object({ kind: v.literal("hideSubmit") }),
+  v.object({ kind: v.literal("redirect"), url: v.string() }),
+]);
+
+/** Value/required actions corrupt or misbehave on repeatable (array) fields, so they're dropped. */
+const ARRAY_INCOMPATIBLE = new Set(["setValue", "clearValue", "require", "optional"]);
+
+const EMPTY_GROUP: ConditionGroup = { combinator: "all", children: [] };
 
 /** Build name → isFieldArray map + step-id set via the canonical preview transform. */
 const collectFields = (content: Value): Map<string, FieldMeta> => {
@@ -52,6 +99,40 @@ const sanitizeGroup = (
   return { combinator: group.combinator, children };
 };
 
+/** Validate + sanitize a block's action list: drop malformed/legacy actions and field-target
+ * actions that don't resolve (unknown field, or array-incompatible on a repeatable). */
+const sanitizeActions = (
+  rawActions: unknown,
+  blockId: string,
+  fields: Map<string, FieldMeta>,
+  orphans: Set<string>,
+): Action[] => {
+  const actions: Action[] = [];
+  for (const raw of Array.isArray(rawActions) ? rawActions : []) {
+    const parsed = v.safeParse(ActionSchema, raw);
+    if (!parsed.success) {
+      orphans.add(blockId); // malformed or unsupported (e.g. legacy moveToNext)
+      continue;
+    }
+    const action = parsed.output;
+    if (action.kind === "jump" || action.kind === "hideSubmit" || action.kind === "redirect") {
+      actions.push(action);
+      continue;
+    }
+    const meta = fields.get(action.target);
+    if (!meta) {
+      orphans.add(action.target);
+      continue;
+    }
+    if (meta.isFieldArray && ARRAY_INCOMPATIBLE.has(action.kind)) {
+      orphans.add(action.target);
+      continue;
+    }
+    actions.push(action);
+  }
+  return actions;
+};
+
 export const extractRuleset = (content: Value): Ruleset => {
   const fields = collectFields(content);
   const stepIds = new Set<string>([FIRST_STEP_ID]);
@@ -67,25 +148,28 @@ export const extractRuleset = (content: Value): Ruleset => {
       continue;
     }
     if (type !== "logicBlock") continue;
-    const lb = node as unknown as LogicBlockNode;
+    const lb = node as { id?: unknown; when?: unknown; actions?: unknown };
+    const id = typeof lb.id === "string" ? lb.id : "";
+
+    const whenParsed = v.safeParse(GroupSchema, lb.when);
+    if (!whenParsed.success && lb.when !== undefined) orphans.add(id || "logicBlock");
+    const when = whenParsed.success ? whenParsed.output : EMPTY_GROUP;
+
     rules.push({
-      id: lb.id,
+      id,
       stepId: currentStep,
-      when: sanitizeGroup(lb.when ?? { combinator: "all", children: [] }, fields, orphans),
-      actions: lb.actions ?? [],
-      elseActions: lb.elseActions,
+      when: sanitizeGroup(when, fields, orphans),
+      actions: sanitizeActions(lb.actions, id || "logicBlock", fields, orphans),
     });
   }
 
-  // Flag orphaned action targets / jump targets (both Do and Else Do branches).
+  // Flag orphaned jump targets (need the full step-id set, so this runs after the pass).
   for (const rule of rules) {
-    for (const action of [...rule.actions, ...(rule.elseActions ?? [])]) {
+    for (const action of rule.actions) {
       if (action.kind === "jump") {
         if (action.toStep !== THANK_YOU_STEP && !stepIds.has(action.toStep)) {
           orphans.add(action.toStep);
         }
-      } else if (action.kind !== "hideSubmit" && action.kind !== "redirect") {
-        if (!fields.has(action.target)) orphans.add(action.target);
       }
     }
   }

--- a/src/lib/logic/operators.test.ts
+++ b/src/lib/logic/operators.test.ts
@@ -74,6 +74,38 @@ describe("applyOperator", () => {
     expect(applyOperator("isEmpty", [], undefined)).toBe(true);
   });
 
+  it("treats boolean false as empty and true as filled (consent/toggle fields)", () => {
+    expect(applyOperator("isEmpty", false, undefined)).toBe(true);
+    expect(applyOperator("isNotEmpty", false, undefined)).toBe(false);
+    expect(applyOperator("isEmpty", true, undefined)).toBe(false);
+    expect(applyOperator("isNotEmpty", true, undefined)).toBe(true);
+  });
+
+  it("contains/notContains use strict membership for array answers (no substring leakage)", () => {
+    // "ed" must NOT match the element "red"; only whole-element membership counts.
+    expect(applyOperator("contains", ["red"], "ed")).toBe(false);
+    expect(applyOperator("contains", ["red"], "red")).toBe(true);
+    // cross-boundary join must not match.
+    expect(applyOperator("contains", ["blue", "green"], "ue, gr")).toBe(false);
+    expect(applyOperator("notContains", ["red"], "ed")).toBe(true);
+    // text (non-array) answers keep substring semantics.
+    expect(applyOperator("contains", "vijayabaskar", "baskar")).toBe(true);
+  });
+
+  it("a missing/blank operand never matches an operand-requiring operator (incomplete condition is no-op)", () => {
+    expect(applyOperator("contains", "anything", "")).toBe(false);
+    expect(applyOperator("contains", "anything", undefined)).toBe(false);
+    expect(applyOperator("equals", "anything", "")).toBe(false);
+    expect(applyOperator("notEquals", "anything", "")).toBe(false);
+    expect(applyOperator("notContains", "anything", "")).toBe(false);
+    expect(applyOperator("greaterThan", "5", "")).toBe(false);
+  });
+
+  it("compares unpadded times chronologically (H:MM normalized to HH:MM)", () => {
+    expect(applyOperator("greaterThan", "14:30", "9:15")).toBe(true);
+    expect(applyOperator("lessThan", "9:15", "14:30")).toBe(true);
+  });
+
   it("compares single-choice and numeric scale/rating answers as scalars", () => {
     // Single option / dropdown answers are the chosen option string.
     expect(applyOperator("equals", "Premium", "Premium")).toBe(true);

--- a/src/lib/logic/operators.ts
+++ b/src/lib/logic/operators.ts
@@ -3,17 +3,39 @@ import type { OperatorId } from "./types";
 const isEmptyValue = (value: unknown): boolean => {
   if (value === null || value === undefined) return true;
   if (typeof value === "string") return value.trim() === "";
+  // Consent/toggle: an unchecked boolean (false) is "empty"; checked (true) is filled.
+  if (typeof value === "boolean") return value === false;
   if (Array.isArray(value)) return value.every((v) => isEmptyValue(v));
   // Matrix answers are a row→column record; `{}` (or all-empty rows) means unanswered.
   if (typeof value === "object") return Object.values(value).every((v) => isEmptyValue(v));
   return false;
 };
 
-const asString = (value: unknown): string => {
+/** Coerce an answer to a comparison string: arrays join with ", ", nullish → "". */
+export const asString = (value: unknown): string => {
   if (value === null || value === undefined) return "";
   if (Array.isArray(value)) return value.join(", ");
   return String(value);
 };
+
+/** Operand-requiring operators are a no-op when the author left the operand blank. */
+const OPERATORS_NEEDING_OPERAND = new Set<OperatorId>([
+  "equals",
+  "notEquals",
+  "contains",
+  "notContains",
+  "greaterThan",
+  "lessThan",
+  "greaterThanOrEqual",
+  "lessThanOrEqual",
+]);
+
+/** Membership test for array (multi-select) answers — whole-element match, never substring. */
+const arrayContains = (answer: unknown[], operand: string | undefined): boolean =>
+  answer.map((v) => asString(v)).includes(asString(operand));
+
+/** Pad an unpadded `H:MM` time to `HH:MM` so lexicographic order is chronological. */
+const normalizeForCompare = (s: string): string => (/^\d:\d{2}$/.test(s) ? `0${s}` : s);
 
 /** Pure predicate for one condition. Numeric comparisons coerce; bad numbers → false. */
 export const applyOperator = (
@@ -21,6 +43,10 @@ export const applyOperator = (
   answer: unknown,
   operand: string | undefined,
 ): boolean => {
+  // Incomplete condition (blank operand) on an operand-requiring operator never matches.
+  if (OPERATORS_NEEDING_OPERAND.has(operator) && (operand === undefined || operand === "")) {
+    return false;
+  }
   switch (operator) {
     case "isEmpty":
       return isEmptyValue(answer);
@@ -31,9 +57,13 @@ export const applyOperator = (
     case "notEquals":
       return asString(answer) !== asString(operand);
     case "contains":
-      return asString(answer).includes(asString(operand));
+      return Array.isArray(answer)
+        ? arrayContains(answer, operand)
+        : asString(answer).includes(asString(operand));
     case "notContains":
-      return !asString(answer).includes(asString(operand));
+      return Array.isArray(answer)
+        ? !arrayContains(answer, operand)
+        : !asString(answer).includes(asString(operand));
     case "greaterThan":
     case "lessThan":
     case "greaterThanOrEqual":
@@ -48,8 +78,8 @@ export const applyOperator = (
       // chronological for ISO dates (YYYY-MM-DD) and zero-padded times (HH:MM).
       // A numeric/non-numeric mismatch is non-comparable → false.
       if (aIsNum !== bIsNum) return false;
-      const sa = asString(answer);
-      const sb = asString(operand);
+      const sa = normalizeForCompare(asString(answer));
+      const sb = normalizeForCompare(asString(operand));
       switch (operator) {
         case "greaterThan":
           return aIsNum ? a > b : sa > sb;

--- a/src/lib/logic/types.ts
+++ b/src/lib/logic/types.ts
@@ -29,12 +29,15 @@ export interface ConditionGroup {
   children: Array<Condition | ConditionGroup>;
 }
 
+/** Actions come in opposite pairs (show/hide, require/optional, setValue/clearValue) so the
+ * Else branch is unnecessary — the inverse condition drives the opposite action. */
 export type Action =
   | { kind: "show"; target: string } // field name
   | { kind: "hide"; target: string }
   | { kind: "require"; target: string }
-  | { kind: "setValue"; target: string; value: string } // auto-fill a field
-  | { kind: "moveToNext"; target: string } // focus/scroll to a field
+  | { kind: "optional"; target: string } // force not-required (wins over require + base-required)
+  | { kind: "setValue"; target: string; value: string | string[] } // auto-fill a field (array → multi-choice)
+  | { kind: "clearValue"; target: string } // reset a field to empty
   | { kind: "jump"; toStep: string } // step id, or the sentinel THANK_YOU_STEP
   | { kind: "hideSubmit" }
   | { kind: "redirect"; url: string };
@@ -45,10 +48,8 @@ export interface Rule {
   /** id of the step that physically contains this logic block — drives jump timing */
   stepId: string;
   when: ConditionGroup;
-  /** actions applied when `when` passes ("Do") */
+  /** actions applied when `when` passes */
   actions: Action[];
-  /** actions applied when `when` does NOT pass ("Else Do") */
-  elseActions?: Action[];
 }
 
 export interface Ruleset {
@@ -73,10 +74,8 @@ export interface EvaluationResult {
   effectiveRequired: Record<string, boolean>;
   /** Wave 2 — always {} in Wave 1 */
   computedValues: Record<string, never>;
-  /** fieldName → value to auto-fill (from a passing "Set value" action) */
-  setValues: Record<string, string>;
-  /** field to focus/scroll to from a passing "Move to next field" action (last wins), else null */
-  focusField: string | null;
+  /** fieldName → value to write (Set value); "" / [] reset (Clear value). Arrays target multi-choice. */
+  setValues: Record<string, string | string[]>;
   hideSubmit: boolean;
   redirectUrl: string | null;
   /** first matching jump rule tied to `fromStep`, else null (caller falls through) */
@@ -89,6 +88,5 @@ export interface LogicBlockNode {
   id: string;
   when: ConditionGroup;
   actions: Action[];
-  elseActions?: Action[];
   children: [{ text: "" }];
 }

--- a/src/lib/server-fn/public-form-view-rsc.impl.tsx
+++ b/src/lib/server-fn/public-form-view-rsc.impl.tsx
@@ -201,6 +201,11 @@ export const renderStepComponent = async (segments: PreviewSegment[]) => {
             if (field.fieldType === "Button") {
               return <Field key={item.key} fieldId={field.id} field={field} />;
             }
+            // Labels with `@`-mention tokens must resolve against live answers, so the whole
+            // field (label + input) renders client-side via the Field slot — see FieldSlot.
+            if ("labelNodes" in field && field.labelNodes) {
+              return <Field key={item.key} fieldId={field.id} field={field} />;
+            }
             const { label, required, labelType } = getFieldLabelProps(field);
             // Group fields lack a single labelable control; role=group + aria-labelledby so AT
             // announces the group label. Mirrors PreviewInputShell.

--- a/src/lib/templates/sanitize-content.test.ts
+++ b/src/lib/templates/sanitize-content.test.ts
@@ -80,9 +80,9 @@ it("strips logic redirect actions", async () => {
   expect(block.actions).toEqual([{ kind: "show", target: "a" }]);
 });
 
-// Real LogicBlockNode shape (src/lib/logic/types.ts): actions/elseActions live directly
-// on the node, items are flat { kind, ... }. Strip redirects from both keys.
-it("strips redirect actions from a real-shaped logicBlock node (incl. elseActions)", async () => {
+// Real LogicBlockNode shape (src/lib/logic/types.ts): actions live directly on the node,
+// items are flat { kind, ... }. Strip redirect actions.
+it("strips redirect actions from a real-shaped logicBlock node", async () => {
   const node: LogicBlockNode = {
     type: "logicBlock",
     id: "lb-1",
@@ -91,14 +91,9 @@ it("strips redirect actions from a real-shaped logicBlock node (incl. elseAction
       { kind: "show", target: "newsletter" },
       { kind: "redirect", url: "https://author.example/thanks" },
     ],
-    elseActions: [
-      { kind: "redirect", url: "https://author.example/bye" },
-      { kind: "hide", target: "newsletter" },
-    ],
     children: [{ text: "" }],
   };
   const result = await sanitizeTemplateContent([node], { copyAsset: async () => "unused" });
   const block = result.content[0] as any;
   expect(block.actions).toEqual([{ kind: "show", target: "newsletter" }]);
-  expect(block.elseActions).toEqual([{ kind: "hide", target: "newsletter" }]);
 });

--- a/src/lib/templates/sanitize-content.ts
+++ b/src/lib/templates/sanitize-content.ts
@@ -45,13 +45,11 @@ const processNode = async (
   assetUrls: string[],
 ): Promise<Record<string, unknown> | null> => {
   // Strip logic redirect actions (author-environment-specific).
-  for (const key of ["actions", "elseActions"]) {
-    const actions = node[key];
-    if (Array.isArray(actions)) {
-      node[key] = actions.filter(
-        (a) => !(a && typeof a === "object" && (a as { kind?: string }).kind === "redirect"),
-      );
-    }
+  const actions = node.actions;
+  if (Array.isArray(actions)) {
+    node.actions = actions.filter(
+      (a) => !(a && typeof a === "object" && (a as { kind?: string }).kind === "redirect"),
+    );
   }
 
   for (const field of ASSET_FIELDS) {

--- a/src/routes/-components/landing-editor.tsx
+++ b/src/routes/-components/landing-editor.tsx
@@ -207,7 +207,7 @@ const LocalEditorApp = () => {
     savedDocs?.[0],
     resolvedAppTheme,
   );
-  // Include `customization` so useFormIsDark() can read the form's mode (matches editor-app/preview-mode).
+  // Include `customization` so theme consumers can read the form's mode (matches editor-app/preview-mode).
   const themeCtx = useMemo(
     () => ({ themeVars, hasCustomization, customization }),
     [themeVars, hasCustomization, customization],

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
@@ -111,13 +111,37 @@ export const PreviewModeContent = ({ doc, formId }: { doc: PreviewDoc; formId: s
           className={cn(
             hasCustomization && "bf-themed",
             effectiveTheme === "dark" ? "dark" : "bf-light",
-            "flex size-full flex-col overflow-hidden bg-background text-foreground transition-colors duration-300",
+            "relative flex size-full flex-col overflow-hidden bg-background text-foreground transition-colors duration-300",
           )}
           style={{
             ...(hasCustomization ? themeVars : undefined),
             viewTransitionName: "preview-content",
           }}
         >
+          {/* Scroll-fade overlays at the top/bottom edges of the preview (Figma light 26075-12467/12473, dark 26178-7606/7610).
+              Skip fullpage — it already has the cover gradient fade, so two would look odd. */}
+          {embedType !== "fullpage" &&
+            (() => {
+              const rgb = effectiveTheme === "dark" ? "19,19,19" : "255,255,255";
+              return (
+                <>
+                  <div
+                    aria-hidden
+                    className="pointer-events-none absolute inset-x-0 top-0 z-10 h-[150px]"
+                    style={{
+                      backgroundImage: `linear-gradient(180deg, rgba(${rgb},0.9) 0%, rgba(${rgb},0.62) 32.04%, rgba(${rgb},0.4) 68.23%, rgba(${rgb},0.08) 100%)`,
+                    }}
+                  />
+                  <div
+                    aria-hidden
+                    className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-[221px]"
+                    style={{
+                      backgroundImage: `linear-gradient(180deg, rgba(${rgb},0.08) 0%, rgba(${rgb},0.4) 14.68%, rgba(${rgb},0.62) 37.29%, rgba(${rgb},0.9) 51.38%)`,
+                    }}
+                  />
+                </>
+              );
+            })()}
           {embedType !== "fullpage" && (
             <EmbedPreviewSurface
               embedType={embedType}
@@ -221,14 +245,14 @@ const EmbedPreviewSurface = ({
               {/* Host-page content above the embed */}
               <div className="space-y-6">
                 <div className="flex items-center gap-4">
-                  <div className="size-14 shrink-0 rounded-full bg-muted" />
+                  <div className="size-14 shrink-0 rounded-full bg-[var(--color-gray-100)]" />
                   <div className="flex-1 space-y-2.5">
-                    <div className="h-3 w-2/5 rounded-full bg-muted" />
-                    <div className="h-3 w-1/3 rounded-full bg-muted" />
+                    <div className="h-3 w-2/5 rounded-full bg-[var(--color-gray-100)]" />
+                    <div className="h-3 w-1/3 rounded-full bg-[var(--color-gray-100)]" />
                   </div>
                 </div>
-                <div className="h-3 w-full rounded-full bg-muted" />
-                <div className="h-20 w-full rounded-2xl bg-muted" />
+                <div className="h-3 w-full rounded-full bg-[var(--color-gray-100)]" />
+                <div className="h-20 w-full rounded-2xl bg-[var(--color-gray-100)]" />
               </div>
 
               <div className="flex w-full justify-start">
@@ -277,8 +301,8 @@ const EmbedPreviewSurface = ({
 
               {/* Host-page content below the embed */}
               <div className="space-y-3">
-                <div className="h-3 w-3/5 rounded-full bg-muted" />
-                <div className="h-3 w-1/5 rounded-full bg-muted" />
+                <div className="h-3 w-3/5 rounded-full bg-[var(--color-gray-100)]" />
+                <div className="h-3 w-1/5 rounded-full bg-[var(--color-gray-100)]" />
               </div>
 
               {branding && <BrandingBadge />}
@@ -310,46 +334,47 @@ const EmbedPreviewSurface = ({
 };
 
 // Rich fake-webpage behind the popup, mirroring the Figma popup host mock.
+// Bars pin to neutral gray-100 (Figma skeleton); .bf-themed remaps --muted to the form tint, host chrome must stay neutral.
 const PopupHostSkeleton = () => {
   const authorRow = (
     <div className="flex items-center gap-3">
-      <div className="size-14 shrink-0 rounded-full bg-muted" />
+      <div className="size-14 shrink-0 rounded-full bg-[var(--color-gray-100)]" />
       <div className="flex-1 space-y-2">
-        <div className="h-3 w-3/4 rounded-full bg-muted" />
-        <div className="h-3 w-3/5 rounded-full bg-muted" />
+        <div className="h-3 w-3/4 rounded-full bg-[var(--color-gray-100)]" />
+        <div className="h-3 w-3/5 rounded-full bg-[var(--color-gray-100)]" />
       </div>
     </div>
   );
   return (
     <div className="space-y-8">
       <div className="flex items-center gap-4">
-        <div className="size-14 shrink-0 rounded-full bg-muted" />
+        <div className="size-14 shrink-0 rounded-full bg-[var(--color-gray-100)]" />
         <div className="flex-1 space-y-2.5">
-          <div className="h-3 w-2/5 rounded-full bg-muted" />
-          <div className="h-3 w-1/3 rounded-full bg-muted" />
+          <div className="h-3 w-2/5 rounded-full bg-[var(--color-gray-100)]" />
+          <div className="h-3 w-1/3 rounded-full bg-[var(--color-gray-100)]" />
         </div>
       </div>
 
       <div className="space-y-4">
-        <div className="h-3 w-full rounded-full bg-muted" />
-        <div className="h-3 w-full rounded-full bg-muted" />
-        <div className="h-20 w-full rounded-2xl bg-muted" />
+        <div className="h-3 w-full rounded-full bg-[var(--color-gray-100)]" />
+        <div className="h-3 w-full rounded-full bg-[var(--color-gray-100)]" />
+        <div className="h-20 w-full rounded-2xl bg-[var(--color-gray-100)]" />
       </div>
 
       <div className="space-y-3">
-        <div className="h-3 w-full rounded-full bg-muted" />
-        <div className="h-3 w-4/5 rounded-full bg-muted" />
-        <div className="h-3 w-full rounded-full bg-muted" />
+        <div className="h-3 w-full rounded-full bg-[var(--color-gray-100)]" />
+        <div className="h-3 w-4/5 rounded-full bg-[var(--color-gray-100)]" />
+        <div className="h-3 w-full rounded-full bg-[var(--color-gray-100)]" />
       </div>
 
       <div className="grid grid-cols-2 gap-6">
-        <div className="h-32 rounded-2xl bg-muted" />
-        <div className="h-32 rounded-2xl bg-muted" />
+        <div className="h-32 rounded-2xl bg-[var(--color-gray-100)]" />
+        <div className="h-32 rounded-2xl bg-[var(--color-gray-100)]" />
       </div>
 
       <div className="space-y-3">
-        <div className="h-3 w-4/5 rounded-full bg-muted" />
-        <div className="h-3 w-full rounded-full bg-muted" />
+        <div className="h-3 w-4/5 rounded-full bg-[var(--color-gray-100)]" />
+        <div className="h-3 w-full rounded-full bg-[var(--color-gray-100)]" />
       </div>
 
       <div className="grid grid-cols-2 gap-6">
@@ -358,9 +383,9 @@ const PopupHostSkeleton = () => {
       </div>
 
       <div className="space-y-3">
-        <div className="h-3 w-full rounded-full bg-muted" />
-        <div className="h-3 w-3/5 rounded-full bg-muted" />
-        <div className="h-3 w-[15%] rounded-full bg-muted" />
+        <div className="h-3 w-full rounded-full bg-[var(--color-gray-100)]" />
+        <div className="h-3 w-3/5 rounded-full bg-[var(--color-gray-100)]" />
+        <div className="h-3 w-[15%] rounded-full bg-[var(--color-gray-100)]" />
       </div>
     </div>
   );

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -1109,6 +1109,15 @@
   margin-bottom: var(--bf-field-gap) !important;
 }
 
+/* A block immediately preceding a logic block must contribute the full block-margin (28px) so the
+   logic block's -16px tuck (mt-[calc(12px - block-margin)]) nets the intended 12px gap. Paragraphs
+   and labels otherwise contribute only --bf-field-gap (10px), letting the tuck overlap the block
+   above. Specificity (0,6,0) > the paragraph/label rules above so it wins for those predecessors. */
+:not([data-bf-chrome]):not([data-bf-input]):has(> .slate-blockWrapper):has(+ * .slate-logicBlock)
+  > .slate-blockWrapper.flow-root {
+  margin-bottom: var(--bf-block-margin) !important;
+}
+
 /* Headings: block-margin above (section break) + tight below
    (binds to what they introduce). Notion-style asymmetry.
    Preview-side uses DESCENDANT not direct-child: in the editor-internal


### PR DESCRIPTION
## Summary

Field-mention (`@`) tokens in labels/descriptions that resolve to live answers (built on `@platejs/mention`), plus logic-engine support for multi-value set-values and an `optional` action.

This branch also applies the fixes from the `/code-review` pass.

### Review fixes
- **`LabelBody` conditional hook → crash (correctness).** `useStore` was called after an early return; removing a label's last `@`-mention flips `labelNodes` to `undefined`, changing the hook count and crashing the live preview. Moved the subscription into a `LabelBodyWithMentions` child that only mounts when `labelNodes && form`, so hook order is always stable. (`src/components/form-components/fields/shared.tsx`)
- **Duplicated `asString` coercion (maintainability).** The logic engine carried its own copy of the array→string coercion that mirrors `operators.ts`. Exported the canonical `asString` from `operators.ts` and imported it in `engine.ts` so the two can't drift. (`src/lib/logic/engine.ts`, `src/lib/logic/operators.ts`)
- **O(fields × rules) visibility convergence per keystroke (efficiency).** The fixpoint loop re-accumulated every rule up to `fields.length` times. It only matters when a show/hide-toggled field is itself a condition source; otherwise masking can't change any outcome. Added that guard so unrelated forms run a single pass. (`src/lib/logic/engine.ts`)

### Findings investigated and dismissed
- A reported set-value key collision was a **false positive** — the key function already joins arrays on a NUL byte (``), which rendered as a space in the diff viewer.
- `return clear` in `form-option-item-node.tsx` and `getClientRects()[0]` in `block-draggable.tsx` are both correctly handled (cleanup return / `rect ?` guard).

## Verification
- `pnpm exec tsc --noEmit` — clean
- `vitest run` on engine / operators / extract-ruleset / resolve-mentions — **116 passed**

## CI
Initial CI flagged two issues, both now fixed in a follow-up commit:
- **Format** — `multi-select.tsx` was left unformatted; ran `oxfmt`.
- **Lint (knip)** — removed the dead `useFormIsDark` export. The feature dropped `getMultiSelectColor`'s `isDark` argument and the dark chip palette (form-preview chips render neutral now), so nothing consumed the hook anymore.
