### PR TITLE
Form builder & share UI: Figma system-flat polish pass

### DIFF
--- a/src/components/editor/plugins/form-blocks-kit.tsx
+++ b/src/components/editor/plugins/form-blocks-kit.tsx
@@ -15,8 +15,11 @@ import { FormRatingElement } from "@/components/ui/form-rating-node";
 import { FormSignatureElement } from "@/components/ui/form-signature-node";
 import { FormOptionItemElement } from "@/components/ui/form-option-item-node";
 import {
+  findNextFocusTarget,
   findNextNonButtonPath,
+  findPrevFocusTarget,
   findPrevNonButtonPath,
+  goToFocusTarget,
   insertParagraphAfterPath,
   moveToPath,
 } from "@/components/editor/plugins/form-blocks-utils";
@@ -971,24 +974,15 @@ const NavigationPlugin = createPlatePlugin({
       event.nativeEvent.stopImmediatePropagation();
 
       const goPrev = event.key === "ArrowUp" || (event.key === "Tab" && event.shiftKey);
+      // Focus targets INCLUDE form buttons now (editable label) — Tab from the last field lands on
+      // the page's button(s) before crossing to the next page; goToFocusTarget focuses a button's
+      // native input or a field's Slate caret (matrix void → first/last input).
       const target = goPrev
-        ? findPrevNonButtonPath(editor, path)
-        : findNextNonButtonPath(editor, path);
+        ? findPrevFocusTarget(editor, path[0])
+        : findNextFocusTarget(editor, path[0]);
 
       if (target) {
-        moveToPath(editor, target);
-        editor.tf.focus();
-        // Matrix is a void node authored via native label inputs — land focus inside it
-        // (first input forward, last input on Shift+Tab) so Tab traverses the whole field.
-        const targetNode = editor.api.node(target)?.[0] as TElement | undefined;
-        if (targetNode?.type === "formMatrix") {
-          const dom = editor.api.toDOMNode(targetNode);
-          const fieldInputs = dom?.querySelectorAll("input");
-          if (fieldInputs && fieldInputs.length > 0) {
-            const input = goPrev ? fieldInputs[fieldInputs.length - 1] : fieldInputs[0];
-            setTimeout(() => input.focus(), 0);
-          }
-        }
+        goToFocusTarget(editor, target, goPrev);
         return;
       }
 

--- a/src/components/editor/plugins/form-blocks-utils.ts
+++ b/src/components/editor/plugins/form-blocks-utils.ts
@@ -58,6 +58,88 @@ export const findNextNonButtonPath = (editor: PlateEditor, currentPath: Path): P
   return null;
 };
 
+// ── Focus-target traversal: like findNext/PrevNonButtonPath but buttons ARE stops (their native
+// label input). Fields/content are Slate-caret stops. Used by Tab navigation so the editable
+// button blocks join the tab order. ──
+
+export type FocusTarget = { kind: "button" | "field"; path: Path };
+
+const isActionButton = (node: TElement | undefined): boolean =>
+  node?.type === "formButton" &&
+  ((node as Record<string, unknown>).buttonRole || "submit") !== "previous";
+
+// Next focusable target after currentIndex. Buttons traverse in document order (normalize keeps
+// Previous immediately before the action button, so forward = Previous → Submit/Next). From an
+// action button, same-page trailing content is skipped — only the next page (or a thank-you page)
+// is a stop, so the final Submit is the last tab stop unless a page follows it.
+export const findNextFocusTarget = (
+  editor: PlateEditor,
+  currentIndex: number,
+): FocusTarget | null => {
+  const children = editor.children as TElement[];
+  const fromAction = isActionButton(children[currentIndex]);
+  let crossedBreak = false;
+  for (let i = currentIndex + 1; i < children.length; i++) {
+    const node = children[i];
+    if (!node) continue;
+    if (node.type === "formHeader") continue;
+    if (node.type === "pageBreak") {
+      crossedBreak = true;
+      continue;
+    }
+    if (node.type === "formButton") return { kind: "button", path: [i] };
+    if (fromAction && !crossedBreak) continue; // trailing same-page content after Submit isn't a stop
+    return { kind: "field", path: [i] };
+  }
+  return null;
+};
+
+// Previous focusable target before currentIndex (buttons included).
+export const findPrevFocusTarget = (
+  editor: PlateEditor,
+  currentIndex: number,
+): FocusTarget | null => {
+  const children = editor.children as TElement[];
+  for (let i = currentIndex - 1; i >= 0; i--) {
+    const node = children[i];
+    if (!node) continue;
+    if (node.type === "formHeader") continue;
+    if (node.type === "pageBreak") continue;
+    if (node.type === "formButton") return { kind: "button", path: [i] };
+    return { kind: "field", path: [i] };
+  }
+  return null;
+};
+
+// Focus a target: button → its native label input (deferred so the editor's own focus settles
+// first); field → Slate caret, landing inside a matrix void node's first/last input like before.
+export const goToFocusTarget = (
+  editor: PlateEditor,
+  target: FocusTarget,
+  goPrev: boolean,
+): void => {
+  const node = editor.api.node(target.path)?.[0] as TElement | undefined;
+  if (target.kind === "button") {
+    const input = node ? editor.api.toDOMNode(node)?.querySelector("input") : null;
+    if (input instanceof HTMLInputElement) {
+      setTimeout(() => {
+        input.focus();
+        input.select();
+      }, 0);
+    }
+    return;
+  }
+  moveToPath(editor, target.path);
+  editor.tf.focus();
+  if (node?.type === "formMatrix") {
+    const inputs = editor.api.toDOMNode(node)?.querySelectorAll("input");
+    if (inputs && inputs.length > 0) {
+      const input = goPrev ? inputs[inputs.length - 1] : inputs[0];
+      setTimeout(() => input.focus(), 0);
+    }
+  }
+};
+
 export const insertParagraphAfterPath = (editor: PlateEditor, path: Path): Path => {
   const at = [path[0] + 1];
   editor.tf.insertNodes({ type: "p", children: [{ text: "" }] } as TElement, { at });

--- a/src/components/elastic-slider/elastic-slider.tsx
+++ b/src/components/elastic-slider/elastic-slider.tsx
@@ -42,6 +42,10 @@ export type ElasticSliderProps = {
   markStyle?: "line" | "dot";
   /** Replaces the right-side value text with an icon (e.g. the corner-radius glyph for Radius). */
   endIcon?: React.ReactNode;
+
+  /** Flat at rest: track fill + chrome (marks, fill, handle) hidden until hover/drag/keyboard-focus.
+   * Label + value stay visible, so the row reads like a plain ConfigRow until you interact (Figma). */
+  revealOnHover?: boolean;
 };
 
 export const ElasticSlider = ({
@@ -61,6 +65,7 @@ export const ElasticSlider = ({
   onAutoChange,
   markStyle = "line",
   endIcon,
+  revealOnHover = false,
 }: ElasticSliderProps) => {
   const shouldReduceMotion = useReducedMotion();
   const {
@@ -132,33 +137,48 @@ export const ElasticSlider = ({
           aria-valuenow={value}
           aria-valuetext={displayValue}
           className={cn(
-            "group/elastic-slider absolute inset-0 cursor-pointer touch-none overflow-hidden rounded-(--elastic-slider-radius) bg-(--elastic-slider-bg) outline-none select-none",
-            "data-[focus-visible=true]:ring-2 data-[focus-visible=true]:ring-ring/50 data-[focus-visible=true]:ring-offset-1 data-[focus-visible=true]:ring-offset-background",
+            "group/elastic-slider absolute inset-0 cursor-pointer touch-none overflow-hidden rounded-(--elastic-slider-radius) transition-colors outline-none select-none",
+            // revealOnHover: transparent at rest, gray track only on hover/drag/keyboard-focus (Figma).
+            revealOnHover
+              ? "bg-transparent hover:bg-(--elastic-slider-bg) data-[active=true]:bg-(--elastic-slider-bg) data-[focus-visible=true]:bg-(--elastic-slider-bg)"
+              : "bg-(--elastic-slider-bg)",
+            // No focus ring (not in Figma): the revealed gray track already signals keyboard focus.
             trackClassName,
           )}
           style={{ width: rubberWidth, x: rubberX }}
           {...handlers}
         >
-          {markStyle === "dot" ? (
-            <SliderDotMarks dotMarks={dotMarks} />
-          ) : (
-            <SliderHashMarks hashMarkCount={hashMarkCount} hashMarkPct={hashMarkPct} />
-          )}
+          <div
+            data-slot="elastic-slider-chrome"
+            className={cn(
+              "pointer-events-none absolute inset-0",
+              // Fade marks/fill/handle in together with the track bg (handle keeps its own opacity).
+              revealOnHover &&
+                "opacity-0 transition-opacity group-hover/elastic-slider:opacity-100 group-data-[active=true]/elastic-slider:opacity-100 group-data-[focus-visible=true]/elastic-slider:opacity-100",
+            )}
+          >
+            {markStyle === "dot" ? (
+              <SliderDotMarks dotMarks={dotMarks} />
+            ) : (
+              <SliderHashMarks hashMarkCount={hashMarkCount} hashMarkPct={hashMarkPct} />
+            )}
 
-          <m.div
-            data-slot="elastic-slider-fill"
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-y-0 inset-s-0 rounded-(--elastic-slider-tile-radius) bg-(--elastic-slider-tile-bg)"
-            style={{ width: fillWidth }}
-          />
+            <m.div
+              data-slot="elastic-slider-fill"
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-y-0 inset-s-0 rounded-(--elastic-slider-tile-radius) bg-(--elastic-slider-tile-bg)"
+              style={{ width: fillWidth }}
+            />
 
-          <SliderHandle
-            handleLeft={handleLeft}
-            handleOpacity={handleOpacity}
-            isActive={isActive}
-            valueDodge={valueDodge}
-            shouldReduceMotion={shouldReduceMotion}
-          />
+            <SliderHandle
+              handleLeft={handleLeft}
+              handleOpacity={handleOpacity}
+              isActive={isActive}
+              valueDodge={valueDodge}
+              shouldReduceMotion={shouldReduceMotion}
+              dimmed={isAuto}
+            />
+          </div>
 
           <SliderLabels
             labelRef={labelRef}
@@ -227,6 +247,8 @@ interface SliderHandleProps {
   isActive: boolean;
   valueDodge: boolean;
   shouldReduceMotion: boolean | null;
+  /** Auto/min state: handle is gray/300 (Figma), matching the fill tile color; gray/500 otherwise. */
+  dimmed: boolean;
 }
 
 // Figma Frame 1533208826: 2×12px rounded bar, always visible, riding the fill tile's right edge.
@@ -236,11 +258,15 @@ const SliderHandle = ({
   isActive,
   valueDodge,
   shouldReduceMotion,
+  dimmed,
 }: SliderHandleProps) => (
   <m.div
     data-slot="elastic-slider-handle"
     aria-hidden="true"
-    className="pointer-events-none absolute top-1/2 h-3 w-[2px] rounded-full bg-(--elastic-slider-handle)"
+    className={cn(
+      "pointer-events-none absolute top-1/2 h-3 w-[2px] rounded-full",
+      dimmed ? "bg-(--elastic-slider-tile-bg)" : "bg-(--elastic-slider-handle)",
+    )}
     style={{ left: handleLeft, y: "-50%" }}
     animate={{
       opacity: handleOpacity,

--- a/src/components/elastic-slider/use-elastic-slider.tsx
+++ b/src/components/elastic-slider/use-elastic-slider.tsx
@@ -503,9 +503,10 @@ export const useElasticSlider = ({
   }, [label, displayValue]);
 
   const valueDodge = percentage < dodge.left || percentage > dodge.right;
-  // Figma rest states: a faint 2px sliver at the left edge in Auto; fades when it would
-  // collide with the label or value text, fully visible in between.
-  const handleOpacity = isAuto ? 0.35 : valueDodge ? 0.15 : 1;
+  // Figma: in Auto the handle is a solid gray/300 sliver at the left edge (light color carries the
+  // "faint" look, not opacity); once a value is set it's gray/500 and fades only when it would
+  // collide with the label/value text (see `dimmed` in SliderHandle for the color switch).
+  const handleOpacity = isAuto ? 1 : valueDodge ? 0.15 : 1;
 
   const discreteSteps = (max - min) / step;
   const hashMarkCount = discreteSteps <= 10 ? discreteSteps - 1 : 9;

--- a/src/components/form-builder/embed-preview-mockup.tsx
+++ b/src/components/form-builder/embed-preview-mockup.tsx
@@ -141,6 +141,45 @@ const getBubblePos = (position: string, cw: number, ch: number) => {
   }
 };
 
+// Static embed (standard) preview — faithful to Figma node 26075-12773 (browser-frame skeleton).
+// The standard case is a flat skeleton (no morph), so exact px spacing beats the ratio-positioned
+// mockup: 10px frame padding, 8px dots (4px gap), 10px below dots, 7px between bar-groups + the block.
+// Tokens map 1:1 to Figma — bg-secondary=gray/100, bg-input=gray/300 (dots+block), bg-gray-200=gray/200 (bars).
+export const EmbedStandardPreview = () => (
+  <div className="overflow-hidden rounded-[12px] bg-secondary p-2.5">
+    <div className="flex gap-1">
+      <div className="size-2 rounded-full bg-input" />
+      <div className="size-2 rounded-full bg-input" />
+      <div className="size-2 rounded-full bg-input" />
+    </div>
+    <div className="mt-2.5 flex flex-col gap-[7px]">
+      <div className="flex flex-col gap-1.5">
+        <div className="h-1.5 w-[60px] max-w-full rounded-lg bg-gray-200" />
+        <div className="h-1.5 w-[224px] max-w-full rounded-lg bg-gray-200" />
+      </div>
+      <div className="h-20 w-[70px] rounded-lg bg-input" />
+      <div className="flex flex-col gap-1.5">
+        <div className="h-1.5 w-[185px] max-w-full rounded-lg bg-gray-200" />
+        <div className="h-1.5 w-[138px] max-w-full rounded-lg bg-gray-200" />
+      </div>
+    </div>
+  </div>
+);
+
+// Static full-page preview — faithful to Figma node 26068-6990. The page form is one block filling
+// the frame: 10px frame padding, 8px dots, 10px below dots, then a 244×128 gray-300 block (12px L/R/B
+// margins via mx/mb-0.5, radius 8). bg-input=gray/300 (dots+block), bg-secondary=gray/100 (frame).
+export const EmbedFullPagePreview = () => (
+  <div className="overflow-hidden rounded-[12px] bg-secondary p-2.5">
+    <div className="flex gap-1">
+      <div className="size-2 rounded-full bg-input" />
+      <div className="size-2 rounded-full bg-input" />
+      <div className="size-2 rounded-full bg-input" />
+    </div>
+    <div className="mx-0.5 mt-2.5 mb-0.5 h-32 rounded-lg bg-input" />
+  </div>
+);
+
 export const EmbedPreviewMockup = ({
   embedType = "fullpage",
   popupPosition = "bottom-right",
@@ -243,10 +282,10 @@ export const EmbedPreviewMockup = ({
   return (
     <div className="overflow-hidden rounded-[12px] bg-secondary">
       <div className="flex items-center gap-1 px-2.25 pt-2.5 pb-2">
-        <div className="flex gap-1.5">
-          <div className="size-1.5 rounded-full bg-input" />
-          <div className="size-1.5 rounded-full bg-input" />
-          <div className="size-1.5 rounded-full bg-input" />
+        <div className="flex gap-1">
+          <div className="size-2 rounded-full bg-input" />
+          <div className="size-2 rounded-full bg-input" />
+          <div className="size-2 rounded-full bg-input" />
         </div>
       </div>
 
@@ -255,41 +294,26 @@ export const EmbedPreviewMockup = ({
           {embedType === "standard" && (
             <motion.div
               key="standard-bg"
-              className="absolute inset-4 flex flex-col justify-between"
+              // top-0.5 (not inset-4 top): host copy sits ~28px below the container top, matching Figma's tight gap under the dots.
+              className="absolute inset-x-4 top-0.5 bottom-4 flex flex-col justify-between"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={FADE_TRANSITION}
             >
-              {/* Host-page copy above the embed. */}
+              {/* Host-page copy above the embed. Figma skeleton bars = solid gray-200 (#ededed). */}
               <div className="space-y-1.5">
-                <div className="h-1.5 w-1/4 rounded-full bg-input/70" />
-                <div className="h-1.5 w-[92%] rounded-full bg-input/50" />
+                <div className="h-1.5 w-1/4 rounded-full bg-gray-200" />
+                <div className="h-1.5 w-[92%] rounded-full bg-gray-200" />
               </div>
               {/* Host-page copy below the embed. */}
               <div className="space-y-1.5">
-                <div className="h-1.5 w-3/4 rounded-full bg-input/50" />
-                <div className="h-1.5 w-[56%] rounded-full bg-input/50" />
+                <div className="h-1.5 w-3/4 rounded-full bg-gray-200" />
+                <div className="h-1.5 w-[56%] rounded-full bg-gray-200" />
               </div>
             </motion.div>
           )}
-          {embedType === "popup" && (
-            <motion.div
-              key="popup-bg"
-              className="absolute inset-4 space-y-3 pt-2"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 0.2 }}
-              exit={{ opacity: 0 }}
-              transition={FADE_TRANSITION}
-            >
-              <div className="h-2.5 w-1/5 rounded-full bg-input" />
-              <div className="space-y-2">
-                <div className="h-2 w-full rounded-full bg-input" />
-                <div className="h-2 w-full rounded-full bg-input" />
-                <div className="h-2 w-3/4 rounded-full bg-input" />
-              </div>
-            </motion.div>
-          )}
+          {/* Figma popup mockup (node 25363-20471) is just the dots + the popup card — no host skeleton lines. */}
         </AnimatePresence>
 
         <AnimatePresence>

--- a/src/components/form-builder/form-settings-sidebar.tsx
+++ b/src/components/form-builder/form-settings-sidebar.tsx
@@ -19,9 +19,11 @@ export const FormSettingsSidebar = ({ formId, isLocal }: FormSettingsSidebarProp
       // [font-variation-settings:normal] un-pins the global opsz20/wght450 so font-weight utils + Figma optical size apply
       className="size-full animate-in border-none duration-200 ease-out [font-variation-settings:normal] slide-in-from-right-[40%]"
     >
-      <SidebarHeader className="shrink-0 gap-2.25 space-y-2 pt-2 pb-3 pl-1">
+      <SidebarHeader className="shrink-0 gap-2.25 space-y-2 pt-2 pr-2 pb-2 pl-4">
         <div className="flex items-center justify-between">
-          <h2 className="pl-2.5 text-base font-normal text-foreground">Settings</h2>
+          <h2 className="text-sm leading-[1.15] font-medium tracking-[0.14px] text-gray-800">
+            Settings
+          </h2>
           <Button
             variant="ghost-flat"
             size="icon-xs"

--- a/src/components/form-builder/form-settings-sidebar.tsx
+++ b/src/components/form-builder/form-settings-sidebar.tsx
@@ -23,13 +23,13 @@ export const FormSettingsSidebar = ({ formId, isLocal }: FormSettingsSidebarProp
         <div className="flex items-center justify-between">
           <h2 className="pl-2.5 text-base font-normal text-foreground">Settings</h2>
           <Button
-            variant="ghost"
+            variant="ghost-flat"
             size="icon-xs"
-            className="size-7 text-muted-foreground hover:text-foreground"
+            className="size-7 rounded-lg p-1.25 text-gray-800 hover:text-foreground"
             onClick={closeSidebar}
             aria-label="Close"
           >
-            <XIcon className="size-4" />
+            <XIcon className="size-4.5" />
           </Button>
         </div>
       </SidebarHeader>

--- a/src/components/form-builder/share-summary-sidebar.tsx
+++ b/src/components/form-builder/share-summary-sidebar.tsx
@@ -418,13 +418,13 @@ const ShareSidebarHeader = ({ isDraft, form, navigate, closeSidebar }: ShareSide
     <div className="flex items-center justify-between">
       <h2 className="pl-2.5 text-base text-foreground">Share</h2>
       <Button
-        variant="ghost"
+        variant="ghost-flat"
         size="icon-xs"
-        className="size-7 text-muted-foreground hover:text-foreground"
+        className="size-7 rounded-lg p-1.25 text-gray-800 hover:text-foreground"
         onClick={closeSidebar}
         aria-label="Close"
       >
-        <XIcon className="size-4" />
+        <XIcon className="size-4.5" />
       </Button>
     </div>
 

--- a/src/components/form-builder/share-summary-sidebar.tsx
+++ b/src/components/form-builder/share-summary-sidebar.tsx
@@ -1149,11 +1149,11 @@ const ShareSidebarFooter = ({
   <SidebarFooter className="flex-row gap-2 px-4 pt-0 pb-3.5">
     <CopyButton
       text={shareUrl}
-      variant="secondary"
+      variant="ghost-flat"
       size="sm"
       prefix={<LinkIcon className="size-4" />}
-      // Solid gray pill = equal visual weight to the dark primary Get Code (matched pair, both h-7/14px).
-      className="w-30 justify-center text-[14px] font-medium"
+      // ghost-flat = ghost minus the 1px border, so the box matches the border-none primary Get Code.
+      className="w-30 justify-center text-[14px] font-medium text-foreground"
     >
       Copy Link
     </CopyButton>

--- a/src/components/form-builder/share-summary-sidebar.tsx
+++ b/src/components/form-builder/share-summary-sidebar.tsx
@@ -38,7 +38,11 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { isValidUrl } from "@/lib/utils";
 import { startScopedViewTransition } from "@/lib/view-transition";
 import { EmbedCodeDialog, searchToFormValues, formValuesToSearch, tabs } from "./embed-section";
-import { EmbedPreviewMockup } from "./embed-preview-mockup";
+import {
+  EmbedFullPagePreview,
+  EmbedPreviewMockup,
+  EmbedStandardPreview,
+} from "./embed-preview-mockup";
 import type { FormSettings as FormSettingsType, PresentationMode } from "@/types/form-settings";
 
 // Memo'd at module scope so parent re-renders don't tear down subtrees. EmbedPreviewMockup takes only
@@ -557,6 +561,13 @@ const PRESENTATION_LABELS: Record<PresentationMode, string> = {
   "field-by-field": "One at a time",
 };
 
+// Popup bubble corner — drives the preview mockup's getCornerPos/getBubblePos.
+const POSITION_LABELS: Record<string, string> = {
+  "bottom-right": "Bottom right",
+  "bottom-left": "Bottom left",
+  center: "Center",
+};
+
 // Shared across all tabs: Question layout (presentation mode) + Show progress bar.
 const PresentationRows = ({
   docPresentationMode,
@@ -637,7 +648,6 @@ const ProRows = ({
   formSlug,
   onDomainAssigned,
   selectedDomainName,
-  analyticsHint = true,
 }: {
   docBranding: boolean;
   onBrandingChange: (value: boolean) => void;
@@ -649,8 +659,6 @@ const ProRows = ({
   formSlug: string | null | undefined;
   onDomainAssigned: (domainId: string | null, slug: string | null) => void;
   selectedDomainName: string | undefined;
-  /** Figma embed tab hides the Track-analytics info icon; Full Page shows it. */
-  analyticsHint?: boolean;
 }) => (
   <>
     <PreferenceRow label="Show branding">
@@ -664,14 +672,8 @@ const ProRows = ({
       </FeatureGate>
     </PreferenceRow>
 
-    <PreferenceRow
-      label="Track analytics"
-      hint={
-        analyticsHint ? (
-          <HintTooltip>Track form views, submissions, completion rates, and drop-offs.</HintTooltip>
-        ) : undefined
-      }
-    >
+    {/* Figma hides the Track-analytics info icon on every share tab — no hint here. */}
+    <PreferenceRow label="Track analytics">
       <FeatureGate requiredPlan="pro">
         <Switch
           aria-label="Track analytics"
@@ -728,18 +730,28 @@ const FullPagePreferences = ({
   activeSlug,
   handleDomainAssigned,
   selectedDomainName,
-  customization,
 }: FullPagePreferencesProps) => (
   <div className="flex flex-col gap-4 px-4 pt-3">
-    <MemoEmbedPreviewMockup key="fullpage" embedType="fullpage" customization={customization} />
+    <EmbedFullPagePreview />
 
-    <SidebarSection label="Preferences" collapsible={false} divider={false}>
-      <PresentationRows
-        docPresentationMode={docPresentationMode}
-        docProgressBar={docProgressBar}
-        onModeChange={handlePresentationModeChange}
-        onProgressBarChange={handleProgressBarChange}
-      />
+    {/* Figma full-page Appearance: Question layout, Transparent background, Show progress bar. */}
+    <SidebarSection label="Appearance" collapsible={false}>
+      <PreferenceRow label="Question layout">
+        <Select
+          value={docPresentationMode}
+          onValueChange={(v) => {
+            if (v) handlePresentationModeChange(v as PresentationMode);
+          }}
+        >
+          <SelectTrigger className={selectTriggerFigmaCls}>
+            {PRESENTATION_LABELS[docPresentationMode]}
+          </SelectTrigger>
+          <SelectContent align="end">
+            <SelectItem value="card">All at once</SelectItem>
+            <SelectItem value="field-by-field">One at a time</SelectItem>
+          </SelectContent>
+        </Select>
+      </PreferenceRow>
 
       <form.Field name="transparentBackground">
         {(field: AnyFieldApi) => (
@@ -754,6 +766,17 @@ const FullPagePreferences = ({
         )}
       </form.Field>
 
+      <PreferenceRow label="Show progress bar">
+        <Switch
+          aria-label="Show progress bar"
+          checked={docProgressBar}
+          onCheckedChange={handleProgressBarChange}
+          size="default"
+        />
+      </PreferenceRow>
+    </SidebarSection>
+
+    <SidebarSection label="Preferences" collapsible={false} divider={false}>
       <ProRows
         docBranding={docBranding}
         onBrandingChange={handleBrandingChange}
@@ -808,7 +831,7 @@ const PopupTab = ({
       }}
     </form.Subscribe>
 
-    <SidebarSection label="Preferences" collapsible={false}>
+    <SidebarSection label="Flow" collapsible={false}>
       <PresentationRows
         docPresentationMode={docPresentationMode}
         docProgressBar={docProgressBar}
@@ -891,6 +914,30 @@ const PopupTab = ({
         )}
       </form.Field>
 
+      <form.Field name="popupPosition">
+        {(field: AnyFieldApi) => (
+          <PreferenceRow label="Position">
+            <Select
+              value={field.state.value}
+              onValueChange={(v) => {
+                if (v) field.handleChange(v);
+              }}
+            >
+              <SelectTrigger className={selectTriggerFigmaCls}>
+                {POSITION_LABELS[field.state.value] ?? field.state.value}
+              </SelectTrigger>
+              <SelectContent align="end">
+                {Object.entries(POSITION_LABELS).map(([value, label]) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </PreferenceRow>
+        )}
+      </form.Field>
+
       <form.Field name="hideOnSubmit">
         {(field: AnyFieldApi) => (
           <PreferenceRow label="Hide on submit">
@@ -937,19 +984,9 @@ const EmbedTab = ({
   activeSlug,
   handleDomainAssigned,
   selectedDomainName,
-  customization,
 }: FullPagePreferencesProps) => (
   <div className="flex flex-col gap-4 px-4 pt-3">
-    <form.Subscribe selector={selectValues}>
-      {(values: ReturnType<typeof searchToFormValues>) => (
-        <MemoEmbedPreviewMockup
-          key="standard"
-          embedType="standard"
-          alignLeft={formFieldsToEmbedOptions(values).display.alignment === "left"}
-          customization={customization}
-        />
-      )}
-    </form.Subscribe>
+    <EmbedStandardPreview />
 
     <SidebarSection label="Appearance" collapsible={false}>
       <form.Field name="dynamicHeight">
@@ -1038,7 +1075,6 @@ const EmbedTab = ({
         formSlug={activeSlug}
         onDomainAssigned={handleDomainAssigned}
         selectedDomainName={selectedDomainName}
-        analyticsHint={false}
       />
     </SidebarSection>
   </div>

--- a/src/components/form-builder/share-summary-sidebar.tsx
+++ b/src/components/form-builder/share-summary-sidebar.tsx
@@ -1,14 +1,7 @@
 import type { AnyFieldApi } from "@tanstack/react-form";
 import { useForm as useTanstackForm } from "@tanstack/react-form";
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import {
-  CodeXmlIcon,
-  InfoIcon,
-  LinkIcon,
-  PlusIcon,
-  RocketIcon,
-  XIcon,
-} from "@/components/ui/icons";
+import { CodeXmlIcon, LinkIcon, PlusIcon, RocketIcon, XIcon } from "@/components/ui/icons";
 import { memo, useCallback, useMemo, useState } from "react";
 // eslint-disable-next-line react-doctor/no-flush-sync -- flushSync is required so the synchronous router navigation captures the field state update inside the same View Transition snapshot
 import { flushSync } from "react-dom";
@@ -414,9 +407,9 @@ interface ShareSidebarHeaderProps {
 }
 
 const ShareSidebarHeader = ({ isDraft, form, navigate, closeSidebar }: ShareSidebarHeaderProps) => (
-  <SidebarHeader className="shrink-0 gap-2.25 space-y-2 pt-2 pb-3 pl-1">
+  <SidebarHeader className="shrink-0 gap-2.25 space-y-2 pt-2 pr-2 pb-2 pl-4">
     <div className="flex items-center justify-between">
-      <h2 className="pl-2.5 text-base text-foreground">Share</h2>
+      <h2 className="text-sm leading-[1.15] font-medium tracking-[0.14px] text-gray-800">Share</h2>
       <Button
         variant="ghost-flat"
         size="icon-xs"
@@ -451,7 +444,6 @@ const ShareSidebarHeader = ({ isDraft, form, navigate, closeSidebar }: ShareSide
               // Scoped: only "preview-content" cross-fades; the app sidebar/header stay static.
               startScopedViewTransition(update);
             }}
-            className="pl-1"
           >
             <TabsList className="w-full">
               {tabs.map((tab) => (
@@ -606,13 +598,24 @@ const PresentationRows = ({
   </>
 );
 
+// Figma alert-circle (node 26068-6857): 14px glyph centered in a 16px frame, currentColor (gray-600).
+const FigInfoIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      transform="translate(0.9668 0.9668)"
+      d="M7.0332 0C10.9175 7.03683e-05 14.0663 3.1489 14.0664 7.0332C14.0663 10.9175 10.9175 14.0663 7.0332 14.0664C3.1489 14.0663 7.03703e-05 10.9175 0 7.0332C7.03529e-05 3.1489 3.1489 7.03509e-05 7.0332 0ZM7.0332 1C3.70119 1.00007 1.00007 3.70119 1 7.0332C1.00007 10.3652 3.70119 13.0663 7.0332 13.0664C10.3652 13.0663 13.0663 10.3652 13.0664 7.0332C13.0663 3.70119 10.3652 1.00007 7.0332 1ZM7.0332 6.02441C7.30928 6.02441 7.5331 6.24836 7.5332 6.52441V9.86523C7.5332 10.1414 7.30935 10.3652 7.0332 10.3652C6.75706 10.3652 6.5332 10.1414 6.5332 9.86523V6.52441C6.53331 6.24836 6.75713 6.02441 7.0332 6.02441ZM7.0332 3.42871C7.46865 3.42871 7.82221 3.78136 7.82227 4.2168C7.82227 4.65228 7.46868 5.00586 7.0332 5.00586C6.59777 5.00581 6.24512 4.65225 6.24512 4.2168C6.24517 3.78139 6.5978 3.42876 7.0332 3.42871Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 // Muted info icon with a tooltip — used by the preference rows for inline help.
 const HintTooltip = ({ children }: { children: React.ReactNode }) => (
   <Tooltip>
     <TooltipTrigger
       render={
         <span className="inline-flex text-muted-foreground">
-          <InfoIcon className="size-4" />
+          <FigInfoIcon className="size-4" />
         </span>
       }
     />
@@ -634,6 +637,7 @@ const ProRows = ({
   formSlug,
   onDomainAssigned,
   selectedDomainName,
+  analyticsHint = true,
 }: {
   docBranding: boolean;
   onBrandingChange: (value: boolean) => void;
@@ -645,6 +649,8 @@ const ProRows = ({
   formSlug: string | null | undefined;
   onDomainAssigned: (domainId: string | null, slug: string | null) => void;
   selectedDomainName: string | undefined;
+  /** Figma embed tab hides the Track-analytics info icon; Full Page shows it. */
+  analyticsHint?: boolean;
 }) => (
   <>
     <PreferenceRow label="Show branding">
@@ -661,7 +667,9 @@ const ProRows = ({
     <PreferenceRow
       label="Track analytics"
       hint={
-        <HintTooltip>Track form views, submissions, completion rates, and drop-offs.</HintTooltip>
+        analyticsHint ? (
+          <HintTooltip>Track form views, submissions, completion rates, and drop-offs.</HintTooltip>
+        ) : undefined
       }
     >
       <FeatureGate requiredPlan="pro">
@@ -917,9 +925,7 @@ const PopupTab = ({
 // Embed (standard iframe) tab — inline preview + Appearance + Preferences flat sections.
 const EmbedTab = ({
   form,
-  docPresentationMode,
   docProgressBar,
-  handlePresentationModeChange,
   handleProgressBarChange,
   docBranding,
   handleBrandingChange,
@@ -945,17 +951,26 @@ const EmbedTab = ({
       )}
     </form.Subscribe>
 
-    <SidebarSection label="Preferences" collapsible={false}>
-      <PresentationRows
-        docPresentationMode={docPresentationMode}
-        docProgressBar={docProgressBar}
-        onModeChange={handlePresentationModeChange}
-        onProgressBarChange={handleProgressBarChange}
-      />
-    </SidebarSection>
-
     <SidebarSection label="Appearance" collapsible={false}>
-      {/* Manual height collapses while Dynamic height is on, matching the Figma hidden-row state. */}
+      <form.Field name="dynamicHeight">
+        {(field: AnyFieldApi) => (
+          <PreferenceRow
+            label="Dynamic height"
+            hint={
+              <HintTooltip>Resize the embed automatically to fit the form's height.</HintTooltip>
+            }
+          >
+            <Switch
+              aria-label="Dynamic height"
+              checked={field.state.value}
+              onCheckedChange={field.handleChange}
+              size="default"
+            />
+          </PreferenceRow>
+        )}
+      </form.Field>
+
+      {/* Manual Height shows directly below Dynamic height while it's off (Figma order). */}
       <form.Subscribe selector={selectDynamicHeight}>
         {(dynamicHeight: boolean) =>
           dynamicHeight ? null : (
@@ -974,24 +989,6 @@ const EmbedTab = ({
           )
         }
       </form.Subscribe>
-
-      <form.Field name="dynamicHeight">
-        {(field: AnyFieldApi) => (
-          <PreferenceRow
-            label="Dynamic height"
-            hint={
-              <HintTooltip>Resize the embed automatically to fit the form's height.</HintTooltip>
-            }
-          >
-            <Switch
-              aria-label="Dynamic height"
-              checked={field.state.value}
-              onCheckedChange={field.handleChange}
-              size="default"
-            />
-          </PreferenceRow>
-        )}
-      </form.Field>
 
       <form.Field name="hideTitle">
         {(field: AnyFieldApi) => (
@@ -1018,6 +1015,15 @@ const EmbedTab = ({
           </PreferenceRow>
         )}
       </form.Field>
+
+      <PreferenceRow label="Show progress bar">
+        <Switch
+          aria-label="Show progress bar"
+          checked={docProgressBar}
+          onCheckedChange={handleProgressBarChange}
+          size="default"
+        />
+      </PreferenceRow>
     </SidebarSection>
 
     <SidebarSection label="Preferences" collapsible={false} divider={false}>
@@ -1032,6 +1038,7 @@ const EmbedTab = ({
         formSlug={activeSlug}
         onDomainAssigned={handleDomainAssigned}
         selectedDomainName={selectedDomainName}
+        analyticsHint={false}
       />
     </SidebarSection>
   </div>
@@ -1054,7 +1061,6 @@ const CustomDomainRow = ({
   orgId,
   formId,
   customDomainId,
-  formSlug,
   onDomainAssigned,
   selectedDomainName,
 }: CustomDomainRowProps) => {
@@ -1093,11 +1099,6 @@ const CustomDomainRow = ({
     [assignDomain],
   );
 
-  const displayUrl =
-    selectedDomainName && formSlug
-      ? `https://${selectedDomainName}/${formSlug}`
-      : (selectedDomainName ?? null);
-
   return (
     <div className="flex h-7 items-center gap-3">
       <span className="shrink-0 font-case text-[14px] font-normal text-muted-foreground">
@@ -1106,8 +1107,18 @@ const CustomDomainRow = ({
       <div className="flex min-w-0 flex-1 justify-end">
         <FeatureGate requiredPlan="pro">
           <Select value={customDomainId ?? ""} onValueChange={handleValueChange} disabled={!orgId}>
-            <SelectTrigger className="h-7 max-w-full gap-1.5 border-none bg-transparent px-0 py-0 text-[14px] font-medium text-foreground shadow-none">
-              <span className="truncate">{displayUrl ?? "Add domain"}</span>
+            <SelectTrigger
+              className="h-7 max-w-full gap-1.5 border-none bg-transparent px-0 py-0 text-[14px] font-medium shadow-none"
+              icon={selectedDomainName ? undefined : <span className="hidden" />}
+            >
+              {selectedDomainName ? (
+                <span className="truncate text-foreground">{selectedDomainName}</span>
+              ) : (
+                <span className="flex items-center gap-1.5 font-[450] text-gray-700">
+                  <PlusIcon className="size-4" />
+                  Add Domain
+                </span>
+              )}
             </SelectTrigger>
             <SelectContent align="end" alignItemWithTrigger={false}>
               <SelectItem value={ADD_DOMAIN_VALUE} className="text-primary">
@@ -1138,10 +1149,11 @@ const ShareSidebarFooter = ({
   <SidebarFooter className="flex-row gap-2 px-4 pt-0 pb-3.5">
     <CopyButton
       text={shareUrl}
-      variant="ghost"
+      variant="secondary"
       size="sm"
       prefix={<LinkIcon className="size-4" />}
-      className="w-30 justify-center text-[14px] font-medium text-foreground"
+      // Solid gray pill = equal visual weight to the dark primary Get Code (matched pair, both h-7/14px).
+      className="w-30 justify-center text-[14px] font-medium"
     >
       Copy Link
     </CopyButton>

--- a/src/components/form-builder/version-history-sidebar.tsx
+++ b/src/components/form-builder/version-history-sidebar.tsx
@@ -177,8 +177,8 @@ const RailNode = ({
     aria-pressed={active}
     onClick={onClick}
     className={cn(
-      "relative z-10 flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-full bg-gray-200 text-muted-foreground transition-colors hover:text-foreground",
-      active && "text-foreground",
+      "relative z-10 flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-full bg-gray-200 text-gray-800 transition-colors",
+      active && "bg-gray-300",
     )}
   >
     {icon}
@@ -281,7 +281,7 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
         >
           {/* Figma cell: 14px medium count title, 13px name w/ 16px avatar, leading-[1.15]. */}
           <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-            <p className="truncate text-sm leading-[1.15] font-medium text-foreground">
+            <p className="truncate text-sm leading-[1.15] font-medium tracking-[0.14px] text-gray-800">
               {version.version} Change{version.version === 1 ? "" : "s"}
             </p>
             <div className="flex min-w-0 items-center gap-1.5">
@@ -291,7 +291,7 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
                   {publisher.initial}
                 </AvatarFallback>
               </Avatar>
-              <span className="truncate text-[13px] leading-[1.15] font-normal tracking-[0.13px] text-muted-foreground">
+              <span className="truncate text-[13px] leading-[1.15] font-[420] tracking-[0.13px] text-gray-600">
                 {publisher.name}
               </span>
             </div>
@@ -311,7 +311,7 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
                   render={
                     <button
                       type="button"
-                      className="inline-flex size-7 cursor-pointer items-center justify-center rounded-lg bg-secondary text-muted-foreground hover:text-foreground"
+                      className="inline-flex size-7 cursor-pointer items-center justify-center rounded-lg bg-gray-300 p-1.25 text-muted-foreground"
                       onClick={stopPropagation}
                       onKeyDown={(e) => e.stopPropagation()}
                       aria-label="Version actions"
@@ -343,7 +343,7 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : (
-              <span className="text-[13px] leading-[1.15] font-medium tracking-[0.13px] text-muted-foreground">
+              <span className="text-[13px] leading-[1.15] font-medium tracking-[0.13px] text-gray-500">
                 {formatVersionTime(version.publishedAt)}
               </span>
             )}
@@ -360,8 +360,8 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
       // [font-variation-settings:normal] un-pins the global opsz20/wght450 so font-weight utils + Figma optical size apply
       className="size-full animate-in border-none duration-200 ease-out [font-variation-settings:normal] slide-in-from-right-[40%]"
     >
-      <SidebarHeader className="h-11 shrink-0 flex-row items-center justify-between border-b border-border py-2 pr-2 pl-4">
-        <h2 className="text-sm leading-[1.15] font-medium tracking-[0.14px] text-foreground">
+      <SidebarHeader className="h-11 shrink-0 flex-row items-center justify-between py-2 pr-2 pl-4">
+        <h2 className="text-sm leading-[1.15] font-medium tracking-[0.14px] text-gray-800">
           Version history
         </h2>
         <div className="flex items-center gap-1">
@@ -370,7 +370,7 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
               render={
                 <button
                   type="button"
-                  className="flex size-7 cursor-pointer items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors hover:bg-accent hover:text-foreground data-popup-open:bg-accent data-popup-open:text-foreground"
+                  className="flex size-7 cursor-pointer items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-secondary data-popup-open:bg-secondary"
                   aria-label="Filter versions"
                 />
               }
@@ -408,8 +408,8 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
         </div>
       </SidebarHeader>
 
-      <SidebarContent className="relative px-2 pt-2.5">
-        <div className="flex gap-1">
+      <SidebarContent className="relative pt-3 pr-2 pl-4">
+        <div className="flex">
           {/* Left timeline rail: live (current) at top, calendar (group by date) at bottom, chevron slides to the active row. */}
           <div
             ref={railRef}
@@ -418,7 +418,7 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
             {filteredList.length > 1 && (
               <div
                 aria-hidden
-                className="pointer-events-none absolute top-3 bottom-3 w-px bg-border/60"
+                className="pointer-events-none absolute top-3 bottom-3 w-px bg-gray-200"
               />
             )}
             <div className="flex h-8 items-center">
@@ -441,7 +441,7 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
             {indicator !== null && (
               <div
                 aria-hidden
-                className="pointer-events-none absolute left-1/2 z-10 flex size-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-200 text-foreground transition-[top] ease-out"
+                className="pointer-events-none absolute left-1/2 z-10 flex size-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-gray-200 text-gray-800 transition-[top] ease-out"
                 style={{ top: indicator.top, transitionDuration: `${indicator.duration}ms` }}
               >
                 <FigChevronDownIcon className="size-4" />
@@ -454,7 +454,7 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
             {groupByDate ? (
               groups.map((group) => (
                 <div key={group.label} className="flex flex-col gap-2">
-                  <p className="px-2.5 py-2 text-sm leading-[1.15] font-medium tracking-[0.14px] text-foreground">
+                  <p className="px-2.5 py-2 text-sm leading-[1.15] font-medium tracking-[0.14px] text-gray-800">
                     {group.label}
                   </p>
                   {group.items.map((version) => renderRow(version))}
@@ -462,7 +462,7 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
               ))
             ) : (
               <>
-                <p className="px-2.5 py-2 text-sm leading-[1.15] font-medium tracking-[0.14px] text-foreground">
+                <p className="px-2.5 py-2 text-sm leading-[1.15] font-medium tracking-[0.14px] text-gray-800">
                   Current Version
                 </p>
                 {filteredList.map((version) => renderRow(version))}

--- a/src/components/form-builder/version-history-sidebar.tsx
+++ b/src/components/form-builder/version-history-sidebar.tsx
@@ -311,7 +311,7 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
                   render={
                     <button
                       type="button"
-                      className="inline-flex size-7 cursor-pointer items-center justify-center rounded-lg bg-accent text-muted-foreground hover:text-foreground"
+                      className="inline-flex size-7 cursor-pointer items-center justify-center rounded-lg bg-secondary text-muted-foreground hover:text-foreground"
                       onClick={stopPropagation}
                       onKeyDown={(e) => e.stopPropagation()}
                       aria-label="Version actions"
@@ -397,9 +397,9 @@ export const VersionHistorySidebar = ({ formId }: VersionHistorySidebarProps) =>
             </DropdownMenuContent>
           </DropdownMenu>
           <Button
-            variant="ghost"
+            variant="ghost-flat"
             size="icon-xs"
-            className="size-7 rounded-lg text-muted-foreground hover:text-foreground"
+            className="size-7 rounded-lg p-1.25 text-gray-800 hover:text-foreground"
             onClick={closeSidebar}
             aria-label="Close"
           >

--- a/src/components/form-components/field-skeleton.tsx
+++ b/src/components/form-components/field-skeleton.tsx
@@ -1,7 +1,7 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import type { FieldType } from "./fields/shared";
 
-const InputSkeleton = () => <Skeleton className="h-7 w-full rounded-[8px]" />;
+const InputSkeleton = () => <Skeleton className="h-[30px] w-full rounded-[8px]" />;
 
 const TextareaSkeleton = () => <Skeleton className="h-24 w-full rounded-[8px]" />;
 

--- a/src/components/form-components/fields/EmailField.tsx
+++ b/src/components/form-components/fields/EmailField.tsx
@@ -40,7 +40,7 @@ const EmailField = ({ element, form, name }: FieldRendererProps<"Email">) => {
       <form.AppField name={fieldName}>
         {(f) => (
           <>
-            <f.Input {...inputProps} className="h-7 form-input pr-[8px] pl-[10px]" />
+            <f.Input {...inputProps} className="h-[30px] form-input pr-[8px] pl-[10px]" />
             <f.FieldError />
           </>
         )}
@@ -68,7 +68,7 @@ const EmailField = ({ element, form, name }: FieldRendererProps<"Email">) => {
             value={(f.state.value as string | undefined) ?? ""}
             fieldName={fieldName}
             store={store}
-            input={<f.Input {...inputProps} className="h-7 form-input pr-7 pl-[10px]" />}
+            input={<f.Input {...inputProps} className="h-[30px] form-input pr-7 pl-[10px]" />}
           />
           <f.FieldError />
         </>

--- a/src/components/form-components/fields/InputField.tsx
+++ b/src/components/form-components/fields/InputField.tsx
@@ -17,7 +17,7 @@ const InputField = ({ element, form, name }: FieldRendererProps<"Input">) => {
             autoComplete={guessAutocomplete(element)}
             aria-label={getAriaLabelFallback(element)}
             aria-labelledby={isArrayItem ? fieldLabelId(element.name) : getAriaLabelledBy(element)}
-            className="h-7 form-input pr-[8px] pl-[10px]"
+            className="h-[30px] form-input pr-[8px] pl-[10px]"
           />
           <f.FieldError />
         </>

--- a/src/components/form-components/fields/LinearScaleField.tsx
+++ b/src/components/form-components/fields/LinearScaleField.tsx
@@ -37,7 +37,7 @@ const LinearScaleField = ({ element, form }: FieldRendererProps<"LinearScale">) 
                       aria-label={stringValue}
                       onClick={() => f.handleChange(isSelected ? "" : stringValue)}
                       className={cn(
-                        "flex h-8 min-w-8 cursor-pointer items-center justify-center rounded-[8px] px-2 text-sm tabular-nums elevation-sm transition-colors",
+                        "flex h-8 min-w-8 cursor-pointer items-center justify-center rounded-[8px] px-2 text-[14px] tabular-nums elevation-sm transition-colors",
                         isSelected
                           ? "bg-primary text-primary-foreground"
                           : "bg-[var(--form-input-bg,var(--color-gray-50))] text-foreground hover:bg-secondary",

--- a/src/components/form-components/fields/LinkField.tsx
+++ b/src/components/form-components/fields/LinkField.tsx
@@ -16,7 +16,7 @@ const LinkField = ({ element, form, name }: FieldRendererProps<"Link">) => {
             inputMode="url"
             aria-label={getAriaLabelFallback(element)}
             aria-labelledby={isArrayItem ? fieldLabelId(element.name) : getAriaLabelledBy(element)}
-            className="h-7 form-input pr-[8px] pl-[10px]"
+            className="h-[30px] form-input pr-[8px] pl-[10px]"
           />
           <f.FieldError />
         </>

--- a/src/components/form-components/fields/MatrixField.tsx
+++ b/src/components/form-components/fields/MatrixField.tsx
@@ -101,7 +101,7 @@ const MatrixField = ({ element, form }: FieldRendererProps<"Matrix">) => {
                     )}
                     style={{ gridTemplateColumns }}
                   >
-                    <span role="rowheader" className="px-3 py-2 text-sm text-foreground">
+                    <span role="rowheader" className="px-3 py-2 text-[14px] text-foreground">
                       {row.label}
                     </span>
                     {columns.map((col) => {

--- a/src/components/form-components/fields/NumberField.tsx
+++ b/src/components/form-components/fields/NumberField.tsx
@@ -28,7 +28,7 @@ const NumberField = ({ element, form, name }: FieldRendererProps<"Number">) => {
               autoComplete="off"
               aria-label={getAriaLabelFallback(element)}
               aria-labelledby={ariaLabelledBy}
-              className="h-7 form-input pr-[8px] pl-[10px]"
+              className="h-[30px] form-input pr-[8px] pl-[10px]"
             />
             <f.FieldError />
           </>
@@ -48,7 +48,7 @@ const NumberField = ({ element, form, name }: FieldRendererProps<"Number">) => {
               inputMode="numeric"
               aria-label={getAriaLabelFallback(element)}
               aria-labelledby={ariaLabelledBy}
-              className="h-7 form-input pr-[8px] pl-[10px]"
+              className="h-[30px] form-input pr-[8px] pl-[10px]"
             />
             <f.FieldError />
           </>

--- a/src/components/form-components/form-preview-from-plate.tsx
+++ b/src/components/form-components/form-preview-from-plate.tsx
@@ -792,6 +792,7 @@ const FieldByFieldLayout = ({
                     questions={currentStepQuestions}
                     isLastStep={isLastStep}
                     autoActionButton
+                    branding={Boolean(settings?.branding)}
                   />
                 </m.div>
               </AnimatePresence>
@@ -880,6 +881,7 @@ const LinearLayout = ({
                 segments={currentStepSegments}
                 questions={currentStepQuestions}
                 isLastStep={isLastStep}
+                branding={Boolean(settings?.branding)}
               />
             </m.div>
           </AnimatePresence>

--- a/src/components/form-components/form-preview-from-plate.tsx
+++ b/src/components/form-components/form-preview-from-plate.tsx
@@ -19,7 +19,7 @@ import { FormLogicProvider } from "@/contexts/form-logic-context";
 import { buildFormLogic } from "@/lib/logic/build-form-logic";
 import { extractQuestionsForStep } from "@/lib/forms/extract-questions";
 import type { QuestionRef } from "@/lib/forms/extract-questions";
-import { DEFAULT_ICON } from "@/lib/config/app-config";
+import { APP_NAME, DEFAULT_ICON } from "@/lib/config/app-config";
 import { cn, DEFAULT_ICON_NAME, isHexColor, isValidUrl } from "@/lib/utils";
 import type { PublicFormSettings } from "@/types/form-settings";
 import { IconPickerPreview } from "@/components/icon-picker";
@@ -792,7 +792,8 @@ const FieldByFieldLayout = ({
                     questions={currentStepQuestions}
                     isLastStep={isLastStep}
                     autoActionButton
-                    branding={Boolean(settings?.branding)}
+                    // Popup uses the full-width footer bar below instead of the inline badge.
+                    branding={Boolean(settings?.branding) && !isPopup}
                   />
                 </m.div>
               </AnimatePresence>
@@ -800,9 +801,28 @@ const FieldByFieldLayout = ({
           )}
         </div>
       </div>
+      {isPopup && settings?.branding && <PopupBrandingBar />}
     </div>
   );
 };
+
+// Popup branding (Figma 26075-12633): a full-width footer BAR (gray/100 fill, centered) at the
+// popup's bottom edge — distinct from the inline submit-row badge used by embed/full-page.
+// "Made with " gray/600 (Inter) + the Timeless Serif italic "Reform." wordmark.
+const PopupBrandingBar = () => (
+  <div className="flex items-center justify-center bg-gray-100 px-2.5 py-[13px]">
+    <span
+      // Inline fontSize: the form's base size out-races Tailwind utilities (see FormBrandingBadge).
+      style={{ fontSize: "14px" }}
+      className="leading-[1.15] font-[420] tracking-[0.28px] text-gray-600"
+    >
+      Made with{" "}
+      <span className="[font-family:'Timeless_Serif',ui-serif,Georgia,serif] italic">
+        {APP_NAME}.
+      </span>
+    </span>
+  </div>
+);
 
 const LinearLayout = ({
   steps,
@@ -881,12 +901,14 @@ const LinearLayout = ({
                 segments={currentStepSegments}
                 questions={currentStepQuestions}
                 isLastStep={isLastStep}
-                branding={Boolean(settings?.branding)}
+                // Popup uses the full-width footer bar below instead of the inline submit-row badge.
+                branding={Boolean(settings?.branding) && !isPopup}
               />
             </m.div>
           </AnimatePresence>
         </LazyMotion>
       </div>
+      {isPopup && settings?.branding && <PopupBrandingBar />}
     </div>
   );
 };

--- a/src/components/form-components/step-form.tsx
+++ b/src/components/form-components/step-form.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeftIcon, ChevronRightIcon } from "@/components/ui/icons";
+import { APP_NAME } from "@/lib/config/app-config";
 import { TextSwap } from "@/components/transitions/text-swap";
 import { use, useMemo, useRef, useState } from "react";
 import { useFocusFirstField } from "@/hooks/use-focus-first-field";
@@ -21,6 +22,8 @@ interface StepFormProps {
   questions?: QuestionRef[];
   isLastStep: boolean;
   autoActionButton?: boolean;
+  /** Show the "Made with Reform." footer badge beside the final Submit (settings.branding). */
+  branding?: boolean;
 }
 
 // One step's form instance. Nav + data accumulation via StepFormContext.
@@ -30,6 +33,7 @@ export const StepForm = ({
   questions,
   isLastStep,
   autoActionButton = false,
+  branding = false,
 }: StepFormProps) => {
   const { totalSteps, goToPrevStep, canGoBack, isSubmitting, tracking } = useStepForm();
   const { t } = useTranslation();
@@ -59,6 +63,8 @@ export const StepForm = ({
   });
 
   const groupedItems = useMemo(() => groupSegmentsForRendering(segments), [segments]);
+  // Branding only rides the final Submit row (last step).
+  const showBranding = branding && isLastStep;
 
   const formRef = useRef<HTMLFormElement>(null);
   const [isTextareaFocused, setIsTextareaFocused] = useState(false);
@@ -146,7 +152,8 @@ export const StepForm = ({
         onKeyDownCapture={autoActionButton ? handleFieldByFieldKeyDown : undefined}
         onFocus={handleFormFocus}
         onBlur={autoActionButton ? handleTextareaFocusChange(false) : undefined}
-        className="focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+        // pb-7: 28px breathing room so the final Submit/branding row doesn't sit flush at the form's bottom edge.
+        className="pb-7 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
       >
         {groupedItems.map((item) => {
           if (item.type === "buttonGroup") {
@@ -160,27 +167,35 @@ export const StepForm = ({
             return (
               <div
                 key={groupKey}
-                className="flex w-full flex-row-reverse items-center justify-between"
+                className="flex w-full flex-col gap-2"
                 style={{ maxWidth: "var(--bf-input-width)" }}
               >
-                {actionButton && (
-                  <RenderStepButton
-                    field={actionButton}
-                    isSubmitting={isSubmitting}
-                    onPrevious={canGoBack ? goToPrevStep : undefined}
-                    hideSubmit={hideSubmit}
-                    grouped
-                  />
-                )}
-                {prevButton ? (
-                  <RenderStepButton
-                    field={prevButton}
-                    isSubmitting={isSubmitting}
-                    onPrevious={canGoBack ? goToPrevStep : undefined}
-                    grouped
-                  />
-                ) : (
-                  <div /> // Spacer for justify-between
+                <div className="flex w-full flex-row-reverse items-center justify-between">
+                  {actionButton && (
+                    <RenderStepButton
+                      field={actionButton}
+                      isSubmitting={isSubmitting}
+                      onPrevious={canGoBack ? goToPrevStep : undefined}
+                      hideSubmit={hideSubmit}
+                      grouped
+                    />
+                  )}
+                  {prevButton ? (
+                    <RenderStepButton
+                      field={prevButton}
+                      isSubmitting={isSubmitting}
+                      onPrevious={canGoBack ? goToPrevStep : undefined}
+                      grouped
+                    />
+                  ) : (
+                    <div /> // Spacer for justify-between
+                  )}
+                </div>
+                {/* Multi-step submit row is full (Prev + Submit) — branding sits right-aligned below. */}
+                {showBranding && (
+                  <div className="flex justify-end">
+                    <FormBrandingBadge />
+                  </div>
                 )}
               </div>
             );
@@ -216,6 +231,7 @@ export const StepForm = ({
                   onPrevious={canGoBack ? goToPrevStep : undefined}
                   hideSubmit={hideSubmit}
                   totalSteps={totalSteps}
+                  showBranding={showBranding}
                 />
               );
             }
@@ -282,6 +298,7 @@ export const StepForm = ({
                 to go back
               </span>
             )}
+            {showBranding && <FormBrandingBadge className="ms-auto" />}
           </div>
         )}
       </form.Form>
@@ -321,6 +338,22 @@ const groupSegmentsForRendering = (segments: PreviewSegment[]): GroupedSegment[]
   return result;
 };
 
+// Inline form-footer branding (Figma 25778-10461): "Made with Reform." — Inter gray/500 + the
+// Timeless Serif "Reform." wordmark. Renders beside the final Submit when settings.branding is on.
+const FormBrandingBadge = ({ className }: { className?: string }) => (
+  <span
+    // Inline fontSize: the form applies a base size via a non-layered rule that out-races Tailwind
+    // utilities (same reason the submit button pins fontSize inline). Figma = 14px.
+    style={{ fontSize: "14px" }}
+    className={`shrink-0 leading-[1.15] font-[420] tracking-[0.28px] text-gray-500 ${className ?? ""}`}
+  >
+    Made with{" "}
+    <span className="[font-family:'Timeless_Serif',ui-serif,Georgia,serif] italic">
+      {APP_NAME}.
+    </span>
+  </span>
+);
+
 // Step-form button. Previous uses onClick; Next/Submit use type="submit" to trigger validation.
 const RenderStepButton = ({
   field,
@@ -329,6 +362,7 @@ const RenderStepButton = ({
   grouped = false,
   totalSteps = 1,
   hideSubmit = false,
+  showBranding = false,
 }: {
   field: ButtonField;
   isSubmitting: boolean;
@@ -336,6 +370,7 @@ const RenderStepButton = ({
   grouped?: boolean;
   totalSteps?: number;
   hideSubmit?: boolean;
+  showBranding?: boolean;
 }) => {
   const { t } = useTranslation();
   const buttonRole = field.buttonRole || "submit";
@@ -409,11 +444,13 @@ const RenderStepButton = ({
   return grouped ? (
     submitButton
   ) : (
+    // Branding (Figma 25778-10461) rides the submit row right-aligned (justify-between).
     <div
-      className={`flex ${isMultiStep ? "justify-end" : "justify-start"}`}
+      className={`flex items-center ${showBranding ? "justify-between gap-3" : isMultiStep ? "justify-end" : "justify-start"}`}
       style={{ maxWidth: "var(--bf-input-width)" }}
     >
       {submitButton}
+      {showBranding && <FormBrandingBadge />}
     </div>
   );
 };

--- a/src/components/ui/about-sidebar.tsx
+++ b/src/components/ui/about-sidebar.tsx
@@ -14,13 +14,13 @@ export const AboutSidebar = ({ onClose }: AboutSidebarProps) => (
     <div className="flex h-10 shrink-0 items-center justify-between border-b border-border/40 px-3">
       <span className="text-[13px]">About</span>
       <Button
-        variant="ghost"
+        variant="ghost-flat"
         size="icon"
-        className="size-7 text-muted-foreground hover:text-foreground"
+        className="size-7 rounded-lg p-1.25 text-gray-800 hover:text-foreground"
         onClick={onClose}
         aria-label="Close"
       >
-        <XIcon className="size-4" />
+        <XIcon className="size-4.5" />
       </Button>
     </div>
     <ScrollArea className="flex-1">

--- a/src/components/ui/app-header.tsx
+++ b/src/components/ui/app-header.tsx
@@ -40,6 +40,10 @@ interface AppHeaderProps {
   isDistractionHidden?: boolean;
 }
 
+// Header icon buttons (⋯, preview, edit): 28×28, 5px padding, 8px radius, gray-800 icon (Figma system-flat).
+// Color lives here so hover:text-foreground reaches the icon via currentColor — icons must NOT pin their own color.
+const HEADER_ICON_BUTTON_CLS = "size-7 rounded-lg p-1.25 text-gray-800 hover:text-foreground";
+
 export const AppHeader = ({ isDistractionHidden = false }: AppHeaderProps) => {
   const { formId, workspaceId } = useParams({ strict: false });
   const {
@@ -194,7 +198,7 @@ export const AppHeader = ({ isDistractionHidden = false }: AppHeaderProps) => {
     <>
       <header
         className={cn(
-          "group/header -z-10 flex h-10 w-full shrink-0 items-center justify-between bg-background px-2 text-[13px] transition-opacity duration-150 select-none",
+          "group/header -z-10 flex h-11 w-full shrink-0 items-center justify-between bg-background px-2 text-[13px] transition-opacity duration-150 select-none",
           isDistractionHidden && "pointer-events-none opacity-0",
         )}
       >
@@ -238,7 +242,7 @@ export const AppHeader = ({ isDistractionHidden = false }: AppHeaderProps) => {
 
         {/* Header stays constant — preview now lives in its own full-page drawer, so the
             Share sidebar no longer collapses it to a "Preview" label or hides actions. */}
-        <div className="flex shrink-0 items-center gap-1">
+        <div className="flex shrink-0 items-center gap-2">
           {isDashboard && (
             <Button
               variant="ghost"
@@ -599,14 +603,14 @@ const LandingPageActions = ({
       <DropdownMenuTrigger
         render={
           <Button
-            variant="ghost"
+            variant="ghost-flat"
             size="sm"
-            className="h-7 w-[30px] rounded-lg px-1.5 text-gray-700 hover:text-foreground"
+            className={HEADER_ICON_BUTTON_CLS}
             aria-label="More options"
           />
         }
       >
-        <MoreHorizontalIcon className="size-[18px] text-gray-700" strokeWidth={1.5} />
+        <MoreHorizontalIcon className="size-[18px]" strokeWidth={1.5} />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-48" sideOffset={4}>
         <DropdownMenuItem onClick={() => onToggleEditorSidebar("about")}>
@@ -635,18 +639,15 @@ const LandingPageActions = ({
       <TooltipTrigger
         render={
           <Button
-            variant="ghost"
+            variant="ghost-flat"
             size="sm"
-            className={cn(
-              "h-7 w-[30px] rounded-lg px-1.5 text-gray-700 hover:text-foreground",
-              previewMode && "bg-accent/50 text-foreground",
-            )}
+            className={cn(HEADER_ICON_BUTTON_CLS, previewMode && "bg-secondary text-foreground")}
             onClick={onTogglePreview}
             aria-label={previewMode ? "Back to Editor" : "Preview Form"}
           />
         }
       >
-        <PlayIcon className="size-[18px] text-gray-700" />
+        <PlayIcon className="size-[18px]" />
       </TooltipTrigger>
       <TooltipContent side="bottom" align="end">
         <p>{previewMode ? "Back to Editor" : "Preview Form"}</p>
@@ -721,7 +722,7 @@ const FormBuilderHeaderActions = ({
   // Figma logged-in header: ⋯ · ▷ (preview) · Share · Publish. Customize/Settings/
   // Version history/Discard live in the ⋯ menu.
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-2">
       <DropdownMenu
         open={activeMenu === "main"}
         onOpenChange={(open) => onSetActiveMenu(open ? "main" : null)}
@@ -729,14 +730,14 @@ const FormBuilderHeaderActions = ({
         <DropdownMenuTrigger
           render={
             <Button
-              variant="ghost"
+              variant="ghost-flat"
               size="sm"
-              className="h-7 w-[30px] rounded-lg px-1.5 text-gray-700 hover:text-foreground aria-expanded:bg-secondary"
+              className={cn(HEADER_ICON_BUTTON_CLS, "aria-expanded:bg-secondary")}
               aria-label="More options"
             />
           }
         >
-          <MoreHorizontalIcon className="size-[18px] text-gray-700" strokeWidth={1.5} />
+          <MoreHorizontalIcon className="size-[18px]" strokeWidth={1.5} />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48" sideOffset={4}>
           {menuItems.map((item) => (
@@ -753,18 +754,18 @@ const FormBuilderHeaderActions = ({
           <TooltipTrigger
             render={
               <Button
-                variant="ghost"
+                variant="ghost-flat"
                 size="sm"
                 className={cn(
-                  "h-7 w-[30px] rounded-lg px-1.5 text-gray-700 hover:text-foreground",
-                  previewMode && "bg-accent/50 text-foreground",
+                  HEADER_ICON_BUTTON_CLS,
+                  previewMode && "bg-secondary text-foreground",
                 )}
                 onClick={onTogglePreview}
                 aria-label={previewMode ? "Back to Editor" : "Preview Form"}
               />
             }
           >
-            <PlayIcon className="size-[18px] text-gray-700" />
+            <PlayIcon className="size-[18px]" />
           </TooltipTrigger>
           <TooltipContent side="bottom" align="end">
             <p>{previewMode ? "Back to Editor" : "Preview Form"}</p>
@@ -786,13 +787,13 @@ const FormBuilderHeaderActions = ({
                   preload="intent"
                   aria-label="Edit form"
                   className={cn(
-                    buttonVariants({ variant: "ghost", size: "sm" }),
-                    "h-7 w-[30px] rounded-lg px-1.5 text-gray-700 hover:text-foreground",
+                    buttonVariants({ variant: "ghost-flat", size: "sm" }),
+                    HEADER_ICON_BUTTON_CLS,
                   )}
                 />
               }
             >
-              <PencilIcon className="size-[18px] text-gray-700" />
+              <PencilIcon className="size-[18px]" />
             </TooltipTrigger>
             <TooltipContent side="bottom" align="end">
               <p>Edit Form</p>
@@ -803,26 +804,14 @@ const FormBuilderHeaderActions = ({
       )}
 
       {canShare && (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="sm"
-                className="hidden rounded-lg px-2 text-[13px] font-medium tracking-[0.13px] text-gray-800 hover:text-foreground md:inline-flex"
-                onClick={onToggleShareSidebar}
-              />
-            }
-          >
-            Share
-          </TooltipTrigger>
-          <TooltipContent side="bottom" align="end">
-            <p>Share Form</p>
-            <p className="text-xs text-muted-foreground">
-              {formatForDisplay(HOTKEYS.TOGGLE_SHARE_SIDEBAR)}
-            </p>
-          </TooltipContent>
-        </Tooltip>
+        <Button
+          variant="ghost-flat"
+          size="sm"
+          className="hidden rounded-lg px-2 py-1.5 text-[14px] font-medium tracking-[0.14px] text-foreground hover:text-foreground md:inline-flex"
+          onClick={onToggleShareSidebar}
+        >
+          Share
+        </Button>
       )}
 
       {showPublish && (

--- a/src/components/ui/block-draggable.tsx
+++ b/src/components/ui/block-draggable.tsx
@@ -24,7 +24,6 @@ import {
   findPrevNonButtonPath,
   moveToPath,
 } from "@/components/editor/plugins/form-blocks-utils";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { FORM_INPUT_NODE_TYPES } from "@/lib/form-schema/form-field-constants";
 import { cn } from "@/lib/utils";
 
@@ -409,47 +408,34 @@ const Draggable = (props: PlateElementProps) => {
             }}
           >
             {!isFormButton && (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      variant="ghost-flat"
-                      size="icon"
-                      tabIndex={-1}
-                      className="flex h-7 w-6 items-center justify-center rounded-lg p-0 hover:bg-secondary"
-                      onClick={handleDeleteBlock}
-                      data-plate-prevent-deselect
-                      aria-label="Delete block"
-                    />
-                  }
-                >
-                  <BlockDeleteIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
-                </TooltipTrigger>
-                <TooltipContent>Delete block</TooltipContent>
-              </Tooltip>
+              <Button
+                variant="ghost-flat"
+                size="icon"
+                tabIndex={-1}
+                className="flex h-7 w-6 items-center justify-center rounded-lg p-0 hover:bg-secondary"
+                onClick={handleDeleteBlock}
+                data-plate-prevent-deselect
+                aria-label="Delete block"
+              >
+                <BlockDeleteIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
+              </Button>
             )}
 
             {!isFormButton && (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      variant="ghost-flat"
-                      size="icon"
-                      tabIndex={-1}
-                      className="flex h-7 w-6 items-center justify-center rounded-lg p-0 hover:bg-secondary"
-                      onClick={handleAddBlock}
-                      data-plate-prevent-deselect
-                    />
-                  }
-                >
-                  <BlockAddIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
-                </TooltipTrigger>
-                <TooltipContent>Add block below</TooltipContent>
-              </Tooltip>
+              <Button
+                variant="ghost-flat"
+                size="icon"
+                tabIndex={-1}
+                className="flex h-7 w-6 items-center justify-center rounded-lg p-0 hover:bg-secondary"
+                onClick={handleAddBlock}
+                data-plate-prevent-deselect
+                aria-label="Add block below"
+              >
+                <BlockAddIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
+              </Button>
             )}
 
-            {/* Drag Handle or Settings Gear - div to avoid nested button (Tooltip+Button inside) */}
+            {/* Drag Handle or Settings Gear — wrapper div carries the drag handleRef; DragHandle is its own button */}
             <div
               ref={isFormButton ? undefined : handleRef}
               className="size-auto cursor-grab"
@@ -662,31 +648,23 @@ const DragHandle = React.memo(function DragHandle({
   }, [resetPreview]);
 
   return (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <button
-            type="button"
-            tabIndex={-1}
-            className="flex h-7 w-6 items-center justify-center overflow-hidden rounded-lg p-0 hover:bg-secondary"
-            onClick={openBlockMenu}
-            onMouseDown={handleMouseDown}
-            onMouseEnter={handleMouseEnter}
-            onMouseUp={handleMouseUp}
-            data-plate-prevent-deselect
-          />
-        }
-      >
-        {isFormButton ? (
-          <SettingsIcon className="text-muted-foreground" />
-        ) : (
-          <BlockDragIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
-        )}
-      </TooltipTrigger>
-      <TooltipContent>
-        {isFormButton ? "Click for settings" : "Drag to move, Click to open menu"}
-      </TooltipContent>
-    </Tooltip>
+    <button
+      type="button"
+      tabIndex={-1}
+      className="flex h-7 w-6 items-center justify-center overflow-hidden rounded-lg p-0 hover:bg-secondary"
+      onClick={openBlockMenu}
+      onMouseDown={handleMouseDown}
+      onMouseEnter={handleMouseEnter}
+      onMouseUp={handleMouseUp}
+      data-plate-prevent-deselect
+      aria-label={isFormButton ? "Button settings" : "Drag to move or open block menu"}
+    >
+      {isFormButton ? (
+        <SettingsIcon className="text-muted-foreground" />
+      ) : (
+        <BlockDragIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
+      )}
+    </button>
   );
 });
 

--- a/src/components/ui/block-draggable.tsx
+++ b/src/components/ui/block-draggable.tsx
@@ -5,7 +5,7 @@ import {
   BlockMenuPlugin,
   BlockSelectionPlugin,
 } from "@platejs/selection/react";
-import { GripVerticalIcon, PlusIcon, SettingsIcon, TrashIcon } from "@/components/ui/icons";
+import { BlockAddIcon, BlockDeleteIcon, BlockDragIcon, SettingsIcon } from "@/components/ui/icons";
 import { getPluginByType, isType, KEYS } from "platejs";
 import type { TElement, TIdElement } from "platejs";
 import {
@@ -413,17 +413,17 @@ const Draggable = (props: PlateElementProps) => {
                 <TooltipTrigger
                   render={
                     <Button
-                      variant="ghost"
+                      variant="ghost-flat"
                       size="icon"
                       tabIndex={-1}
-                      className="flex size-auto items-center justify-center rounded-lg border-0 hover:bg-accent has-[>svg]:px-1 has-[>svg]:py-1.5"
+                      className="flex h-7 w-6 items-center justify-center rounded-lg p-0 hover:bg-secondary"
                       onClick={handleDeleteBlock}
                       data-plate-prevent-deselect
                       aria-label="Delete block"
                     />
                   }
                 >
-                  <TrashIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
+                  <BlockDeleteIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
                 </TooltipTrigger>
                 <TooltipContent>Delete block</TooltipContent>
               </Tooltip>
@@ -434,16 +434,16 @@ const Draggable = (props: PlateElementProps) => {
                 <TooltipTrigger
                   render={
                     <Button
-                      variant="ghost"
+                      variant="ghost-flat"
                       size="icon"
                       tabIndex={-1}
-                      className="flex size-auto items-center justify-center rounded-lg border-0 hover:bg-accent has-[>svg]:px-1 has-[>svg]:py-1.5"
+                      className="flex h-7 w-6 items-center justify-center rounded-lg p-0 hover:bg-secondary"
                       onClick={handleAddBlock}
                       data-plate-prevent-deselect
                     />
                   }
                 >
-                  <PlusIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
+                  <BlockAddIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
                 </TooltipTrigger>
                 <TooltipContent>Add block below</TooltipContent>
               </Tooltip>
@@ -668,7 +668,7 @@ const DragHandle = React.memo(function DragHandle({
           <button
             type="button"
             tabIndex={-1}
-            className="flex size-auto items-center justify-center overflow-hidden rounded-lg hover:bg-accent has-[>svg]:px-1 has-[>svg]:py-1.5"
+            className="flex h-7 w-6 items-center justify-center overflow-hidden rounded-lg p-0 hover:bg-secondary"
             onClick={openBlockMenu}
             onMouseDown={handleMouseDown}
             onMouseEnter={handleMouseEnter}
@@ -680,7 +680,7 @@ const DragHandle = React.memo(function DragHandle({
         {isFormButton ? (
           <SettingsIcon className="text-muted-foreground" />
         ) : (
-          <GripVerticalIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
+          <BlockDragIcon className="size-4 text-[#52525B] dark:text-muted-foreground" />
         )}
       </TooltipTrigger>
       <TooltipContent>

--- a/src/components/ui/block-menu.tsx
+++ b/src/components/ui/block-menu.tsx
@@ -22,6 +22,7 @@ import {
   PhotoIcon,
   RepeatIcon,
   RequiredFieldIcon,
+  ScaleAnchorIcon,
   SearchLineIcon,
   SelectionLimitIcon,
   ShuffleOptionsIcon,
@@ -2046,7 +2047,7 @@ const ScaleRangePanel = () => {
   }, [nodeMin, nodeMax]);
   return (
     <PanelBody>
-      <div className="flex items-center justify-between text-[14px] font-medium text-foreground">
+      <div className="flex items-center justify-between text-[14px] font-medium tracking-[0.21px] text-foreground">
         <span>Start</span>
         <span>End</span>
       </div>
@@ -2069,7 +2070,7 @@ const ScaleRangePanel = () => {
         }}
       />
       {/* Figma (25634-17867): the end labels show the slider bounds (-10 … 10), not the selection. */}
-      <div className="flex items-center justify-between text-[12px] text-muted-foreground tabular-nums">
+      <div className="flex items-center justify-between text-[12px] tracking-[0.24px] text-gray-700 tabular-nums">
         <span>{LINEAR_SCALE_BOUNDS.min}</span>
         <span>{LINEAR_SCALE_BOUNDS.max}</span>
       </div>
@@ -2100,9 +2101,23 @@ const ScaleStepPanel = () => {
     typeof rawStep === "number" && rawStep > 0 ? rawStep : LINEAR_SCALE_DEFAULTS.step;
   // Local state for smooth dragging (see ScaleRange); persist on release.
   const [step, setStep] = React.useState(nodeStep);
+  // Draft holds in-progress typing (incl. empty / below-min) so we don't fight the user mid-edit.
+  const [draft, setDraft] = React.useState<string | null>(null);
   React.useEffect(() => {
     setStep(nodeStep);
   }, [nodeStep]);
+
+  // Clamp to [stepMin, stepMax] and persist. Typed values hard-cap to stepMax (never > 10); min is
+  // enforced here so an interim empty/0 can be typed and settles up on blur.
+  const commitStep = (n: number) => {
+    const clamped = Math.max(LINEAR_SCALE_BOUNDS.stepMin, Math.min(LINEAR_SCALE_BOUNDS.stepMax, n));
+    setStep(clamped);
+    actions.setScaleStep(clamped);
+    setDraft(null);
+  };
+
+  const display = draft ?? String(step);
+
   return (
     <PanelBody>
       <div className="flex items-center gap-2.5">
@@ -2117,12 +2132,42 @@ const ScaleStepPanel = () => {
           onPointerDown={stopMouseEventPropagation}
           // base-ui hands back a bare number for a single-thumb slider (collision resolver treats
           // length-1 as non-range) but an array elsewhere — normalize both.
-          onValueChange={(value) => setStep(readSliderValue(value))}
+          onValueChange={(value) => {
+            setDraft(null);
+            setStep(readSliderValue(value));
+          }}
           onValueCommitted={(value) => actions.setScaleStep(readSliderValue(value))}
         />
-        <div className="flex w-12 items-center justify-center rounded-lg bg-(--color-gray-alpha-100) px-2 py-1.5 text-[14px] font-medium text-foreground tabular-nums">
-          {step}
-        </div>
+        <input
+          type="number"
+          aria-label="Scale step value"
+          min={LINEAR_SCALE_BOUNDS.stepMin}
+          max={LINEAR_SCALE_BOUNDS.stepMax}
+          value={display}
+          onClick={stopMouseEventPropagation}
+          onPointerDown={stopMouseEventPropagation}
+          onChange={(e) => {
+            const raw = e.target.value.replace(/[^0-9]/g, "");
+            if (raw === "") {
+              setDraft("");
+              return;
+            }
+            // Hard cap to stepMax so the box can never show a number greater than 10.
+            const n = Math.min(LINEAR_SCALE_BOUNDS.stepMax, Number.parseInt(raw, 10));
+            if (n >= LINEAR_SCALE_BOUNDS.stepMin) commitStep(n);
+            else setDraft(String(n));
+          }}
+          onBlur={() => {
+            const n = Number.parseInt(draft ?? String(step), 10);
+            commitStep(Number.isNaN(n) ? LINEAR_SCALE_BOUNDS.stepMin : n);
+          }}
+          onKeyDown={(e) => {
+            // Stop the menu from swallowing keystrokes (typeahead nav) so the box is typeable.
+            stopKeyEventPropagation(e);
+            if (e.key === "Enter") e.currentTarget.blur();
+          }}
+          className="w-12 [appearance:textfield] rounded-lg bg-(--color-gray-alpha-100) px-2 py-1.5 text-center text-[14px] font-medium text-foreground tabular-nums outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+        />
       </div>
     </PanelBody>
   );
@@ -2131,7 +2176,7 @@ const ScaleStepPanel = () => {
 // Linear scale "Add Anchor" (Figma 25634-16937 / 26153-13445): Left/Center/Right labels
 // rendered under the scale tiles (e.g. Bad … Good).
 const AddAnchor = () => (
-  <SubmenuRow icon={<ConditionalLogicIcon />} label="Add Anchor" view="scale-anchor" />
+  <SubmenuRow icon={<ScaleAnchorIcon />} label="Scale Anchor" view="scale-anchor" />
 );
 
 const ANCHOR_ROWS = [

--- a/src/components/ui/block-menu.tsx
+++ b/src/components/ui/block-menu.tsx
@@ -171,11 +171,14 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
   const [view, setView] = React.useState<string | null>(null);
   // Slide axis: panels enter from the trigger's chevron side (+1); back reverses (-1).
   const [direction, setDirection] = React.useState(1);
-  // Side the popup actually rendered on, frozen right after open. View morphs resize the popup
-  // and Base UI re-runs collision logic on every resize — without the lock a menu flipped above
-  // the anchor snaps below it when a shorter panel opens. Locking the side keeps the popup
-  // hugging the anchor (same gap), growing away from it.
+  // Side + align the popup actually rendered on, frozen right after open. View morphs resize the
+  // popup and Base UI re-runs collision logic on every resize — without the lock a menu flipped
+  // above the anchor snaps below it when a shorter panel opens. Locking BOTH axes keeps the popup
+  // hugging the anchor (same gap), growing away from it. Align must lock too: the drag handle sits
+  // in the left gutter, so collision flips align end→start to fit; without locking that flip the
+  // lock reverts align to the prop ("end") and the popup clips off the left edge.
   const [lockedSide, setLockedSide] = React.useState<"top" | "bottom" | null>(null);
+  const [lockedAlign, setLockedAlign] = React.useState<"start" | "center" | "end" | null>(null);
   const [bulkInsert, setBulkInsert] = React.useState<{ at: number; variant: string } | null>(null);
   const blockMenuTriggerRef = React.useRef<HTMLDivElement | null>(null);
 
@@ -202,6 +205,7 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
     setView(null);
     setBulkInsert(null);
     setLockedSide(null);
+    setLockedAlign(null);
   }
 
   const handlers = useBlockMenuFieldHandlers({
@@ -380,14 +384,16 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
     [view, changeView],
   );
 
-  // Read which side Base UI settled on one frame after open, then lock it for the session.
+  // Read which side + align Base UI settled on one frame after open (after collision flips), then
+  // lock both for the session so view-morph resizes can't re-flip the popup around the anchor.
   React.useEffect(() => {
     if (!isOpen) return;
     const raf = requestAnimationFrame(() => {
-      const side = document
-        .querySelector('[data-slot="dropdown-menu-content"]')
-        ?.getAttribute("data-side");
+      const el = document.querySelector('[data-slot="dropdown-menu-content"]');
+      const side = el?.getAttribute("data-side");
+      const align = el?.getAttribute("data-align");
       if (side === "top" || side === "bottom") setLockedSide(side);
+      if (align === "start" || align === "center" || align === "end") setLockedAlign(align);
     });
     return () => cancelAnimationFrame(raf);
   }, [isOpen]);
@@ -484,10 +490,10 @@ export const BlockMenu = ({ children }: { children: React.ReactNode }) => {
             anchor={virtualAnchor}
             className={themeReanchor.className}
             style={themeReanchor.style}
-            // Pre-lock: collision-aware placement off the click point. Locked: keep the settled
-            // side with avoidance off, so view morphs grow away from the anchor instead of
-            // flipping the popup around it.
-            align="end"
+            // Pre-lock: collision-aware placement off the click point (flips side AND align to fit).
+            // Locked: keep the settled side + align with avoidance off, so view morphs grow away
+            // from the anchor instead of flipping the popup around it.
+            align={lockedAlign ?? "end"}
             side={lockedSide ?? "bottom"}
             sideOffset={8}
             collisionAvoidance={
@@ -2018,7 +2024,7 @@ const NumberFieldMenu = () => (
 );
 
 // Linear scale "Scale" panel (Figma 25634-17867): dual-handle slider sets the scale's
-// Start/End within the allowed bounds; the values below echo the current selection.
+// Start/End within the allowed bounds; the end labels show those bounds (-10 … 10).
 const ScaleRange = () => (
   <SubmenuRow
     icon={<IconLinearScale className="text-foreground/80" />}
@@ -2062,9 +2068,10 @@ const ScaleRangePanel = () => {
           if (b > a) actions.setScaleRange(a, b);
         }}
       />
+      {/* Figma (25634-17867): the end labels show the slider bounds (-10 … 10), not the selection. */}
       <div className="flex items-center justify-between text-[12px] text-muted-foreground tabular-nums">
-        <span>{range[0]}</span>
-        <span>{range[1]}</span>
+        <span>{LINEAR_SCALE_BOUNDS.min}</span>
+        <span>{LINEAR_SCALE_BOUNDS.max}</span>
       </div>
     </PanelBody>
   );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -30,6 +30,9 @@ const buttonVariants = cva(buttonBaseClasses.join(" "), {
         "border-none bg-secondary text-secondary-foreground shadow-[0px_1px_1px_0px_rgba(0,0,0,0.06)] hover:bg-secondary/80 aria-expanded:bg-secondary",
       ghost:
         "hover:bg-secondary hover:text-secondary-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+      // ghost, minus the base 1px transparent border (no layout-shift concern — never gets a real border)
+      "ghost-flat":
+        "border-none hover:bg-secondary hover:text-secondary-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
       destructive:
         "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
       link: "text-primary underline-offset-4 hover:underline",

--- a/src/components/ui/customize-sidebar.tsx
+++ b/src/components/ui/customize-sidebar.tsx
@@ -426,7 +426,9 @@ const CustomizeSidebarHeader = ({ closeSidebar }: { closeSidebar: () => void }) 
   <SidebarHeader className="shrink-0 gap-2.25 space-y-2 pt-2 pr-2 pb-2 pl-4">
     <div className="flex items-center justify-between">
       {/* drop font-sans so the root's variation reset isn't re-pinned */}
-      <h2 className="text-base font-normal text-foreground">Customize</h2>
+      <h2 className="text-sm leading-[1.15] font-medium tracking-[0.14px] text-gray-800">
+        Customize
+      </h2>
       <Button
         variant="ghost-flat"
         size="icon-xs"

--- a/src/components/ui/customize-sidebar.tsx
+++ b/src/components/ui/customize-sidebar.tsx
@@ -368,7 +368,7 @@ export const CustomizeSidebar = ({ formId, isLocal }: CustomizeSidebarProps) => 
       <CustomizeSidebarHeader closeSidebar={closeSidebar} />
 
       <SidebarContent>
-        <div className="flex flex-col gap-4 px-4 pt-3 pb-3.5">
+        <div className="flex flex-col gap-5 px-4 pt-3 pb-3.5">
           <AppearanceSection
             customization={customization}
             coverImage={coverImage}

--- a/src/components/ui/customize-sidebar.tsx
+++ b/src/components/ui/customize-sidebar.tsx
@@ -6,7 +6,7 @@ import { ColorPicker } from "@/components/ui/color-picker";
 import {
   CaretDownIcon,
   DarkModeIcon,
-  ImageIcon,
+  ImageLineIcon,
   LightModeIcon,
   SelectChevronIcon,
   SystemModeIcon,
@@ -71,10 +71,11 @@ const SEMANTIC_COLOR_TOKENS = [
 const scopeTriggerCls =
   "h-auto gap-1 border-none bg-transparent p-0 text-[13px] font-normal text-foreground shadow-none data-[size=default]:h-auto [&>svg]:size-3.5";
 
-// Figma slider rows are rounded with a gray-100 track (the design's square rows are a designer
-// inconsistency — Size was the intended treatment). 6px label/value padding lives in the bare
-// styles; NumberRow's -mx-1.5 bleed cancels it so text stays flush with non-slider rows.
-const CONFIG_INPUT_CLS = "!border-0 bg-muted/60 !h-7";
+// Figma slider rows read like plain label rows at rest (flat, no box); the gray-100 rounded track +
+// hash marks reveal only on hover/drag/keyboard-focus (revealOnHover, set via `bare`). 6px label/value
+// padding lives in the bare styles; NumberRow's -mx-1.5 bleed cancels it so text stays flush with
+// non-slider rows. Track bg comes from --elastic-slider-bg (var(--muted)) — no always-on fill here.
+const CONFIG_INPUT_CLS = "!border-0 !h-7";
 
 // Numeric row (bare scrubber): track bleeds 6px past the text column (Figma row = column + 6px
 // each side) so labels/values align with ConfigRow rows while the rounded track extends beyond.
@@ -91,10 +92,10 @@ const RadiusEndIcon = ({ value, max }: { value?: string; max: number }) => {
   const n = Number.parseFloat(value ?? "") || 0;
   const r = (Math.min(Math.max(n, 0), max) / max) * 7;
   return (
-    <span aria-hidden className="flex size-4 items-center justify-center text-muted-foreground">
+    <span aria-hidden className="flex size-4 items-center justify-center text-gray-700">
       <span
-        className="block size-[9px] border-t-[1.5px] border-r-[1.5px] border-current transition-[border-radius] duration-200 ease-out"
-        style={{ borderTopRightRadius: `${r}px` }}
+        className="block size-[11px] border-t border-l border-current transition-[border-radius] duration-200 ease-out"
+        style={{ borderTopLeftRadius: `${r}px` }}
       />
     </span>
   );
@@ -422,18 +423,18 @@ export const CustomizeSidebar = ({ formId, isLocal }: CustomizeSidebarProps) => 
 };
 
 const CustomizeSidebarHeader = ({ closeSidebar }: { closeSidebar: () => void }) => (
-  <SidebarHeader className="shrink-0 gap-2.25 space-y-2 pt-2 pb-3 pl-1">
+  <SidebarHeader className="shrink-0 gap-2.25 space-y-2 pt-2 pr-2 pb-2 pl-4">
     <div className="flex items-center justify-between">
       {/* drop font-sans so the root's variation reset isn't re-pinned */}
-      <h2 className="pl-2.5 text-base font-normal text-foreground">Customize</h2>
+      <h2 className="text-base font-normal text-foreground">Customize</h2>
       <Button
-        variant="ghost"
+        variant="ghost-flat"
         size="icon-xs"
-        className="size-7 text-muted-foreground hover:text-foreground"
+        className="size-7 rounded-lg p-1.25 text-gray-800 hover:text-foreground"
         onClick={closeSidebar}
         aria-label="Close"
       >
-        <XIcon className="size-4" />
+        <XIcon className="size-4.5" />
       </Button>
     </div>
   </SidebarHeader>
@@ -461,7 +462,7 @@ const AppearanceSection = ({
   updateFields: (fields: Record<string, string | null>) => void;
   updateHeaderMedia?: (field: "icon" | "cover" | "iconColor", value: string | null) => void;
 }) => (
-  <SidebarSection label="Appearance" collapsible={false}>
+  <SidebarSection label="Appearance" collapsible="flat">
     <NumberRow
       label="Form width"
       value={customization.pageWidth}
@@ -573,7 +574,7 @@ const CoverPickerButton = ({
       type="button"
       disabled={!onCoverChange}
       title={cover ? "Edit cover" : "Add cover"}
-      className="flex items-center gap-1.5 text-[14px] font-medium text-foreground enabled:cursor-pointer disabled:cursor-default"
+      className="flex items-center gap-1.5 text-[14px] font-medium text-gray-700 enabled:cursor-pointer disabled:cursor-default"
     >
       {cover ? (
         <>
@@ -586,7 +587,7 @@ const CoverPickerButton = ({
         </>
       ) : (
         <>
-          <ImageIcon className="size-4" />
+          <ImageLineIcon className="size-4" />
           Upload
         </>
       )}
@@ -626,7 +627,7 @@ const LogoPickerButton = ({
       type="button"
       disabled={!onIconChange}
       title={logo ? "Edit logo" : "Add logo"}
-      className="flex items-center gap-1.5 text-[14px] font-medium text-foreground enabled:cursor-pointer disabled:cursor-default"
+      className="flex items-center gap-1.5 text-[14px] font-medium text-gray-700 enabled:cursor-pointer disabled:cursor-default"
     >
       {logo ? (
         <>
@@ -648,7 +649,7 @@ const LogoPickerButton = ({
         </>
       ) : (
         <>
-          <ImageIcon className="size-4" />
+          <ImageLineIcon className="size-4" />
           Upload
         </>
       )}
@@ -699,7 +700,7 @@ const TypographySection = ({
   return (
     <SidebarSection
       label="Typography"
-      collapsible={false}
+      collapsible="flat"
       headerRight={
         <div className="flex items-center gap-2">
           <ProBadge />
@@ -712,7 +713,7 @@ const TypographySection = ({
       }
     >
       {/* No hard Pro gate — free users can experiment; publish strips Pro keys (pro-publish-gate) */}
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-2">
         <ConfigRow label="Font" surface="flat">
           <Select value={fontValue} onValueChange={(v) => v && onFontChange(v)}>
             <SelectTrigger
@@ -814,7 +815,7 @@ const ColorsSection = ({
 }: ColorsSectionProps) => (
   <SidebarSection
     label="Colors"
-    collapsible={false}
+    collapsible="flat"
     className="!overflow-visible"
     headerRight={
       <div className="flex items-center gap-2">
@@ -823,7 +824,7 @@ const ColorsSection = ({
       </div>
     }
   >
-    <div className="relative isolate z-50 flex flex-col gap-1.5 overflow-visible">
+    <div className="relative isolate z-50 flex flex-col gap-2 overflow-visible">
       <DeferredColorPickers
         tokens={SEMANTIC_COLOR_TOKENS}
         customization={customization}
@@ -839,8 +840,8 @@ const InputsSection = ({
   updateScrubberField,
   resetScrubberField,
 }: ScrubberProps) => (
-  <SidebarSection label="Inputs" collapsible={false} headerRight={<ProBadge />}>
-    <div className="flex flex-col gap-1.5">
+  <SidebarSection label="Inputs" collapsible="flat" headerRight={<ProBadge />}>
+    <div className="flex flex-col gap-2">
       <NumberRow
         label="Input width"
         value={customization.inputWidth}
@@ -921,8 +922,8 @@ const ButtonsSection = ({
   updateScrubberField,
   resetScrubberField,
 }: ScrubberProps) => (
-  <SidebarSection label="Buttons" collapsible={false} headerRight={<ProBadge />}>
-    <div className="flex flex-col gap-1.5">
+  <SidebarSection label="Buttons" collapsible="flat" headerRight={<ProBadge />}>
+    <div className="flex flex-col gap-2">
       <NumberRow
         label="Width"
         value={customization.buttonWidth}
@@ -976,7 +977,7 @@ interface CustomCssSectionProps {
 }
 
 const CustomCssSection = ({ cssValue, handleCssChange, activeMode }: CustomCssSectionProps) => (
-  <SidebarSection label="Custom CSS" collapsible={false} divider={false} headerRight={<ProBadge />}>
+  <SidebarSection label="Custom CSS" collapsible="flat" divider={false} headerRight={<ProBadge />}>
     <div className="overflow-hidden rounded-lg bg-muted">
       <Textarea
         value={cssValue}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -88,7 +88,7 @@ export const DropdownMenuItem = ({
     data-inset={inset}
     data-variant={variant}
     className={cn(
-      "group/dropdown-menu-item relative flex h-[26px] cursor-default items-center gap-1.5 rounded-lg px-2 py-[5.5px] text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:ps-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+      "group/dropdown-menu-item relative flex h-[26px] cursor-default items-center gap-1.5 rounded-lg px-2 py-[5.5px] text-sm outline-hidden select-none focus:bg-secondary focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:ps-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
       className,
     )}
     {...props}
@@ -111,7 +111,7 @@ export const DropdownMenuSubTrigger = ({
     data-slot="dropdown-menu-sub-trigger"
     data-inset={inset}
     className={cn(
-      "flex h-[26px] cursor-default items-center gap-1.5 rounded-lg px-2 py-[5.5px] text-base outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+      "flex h-[26px] cursor-default items-center gap-1.5 rounded-lg px-2 py-[5.5px] text-base outline-hidden select-none focus:bg-secondary focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-popup-open:bg-secondary data-popup-open:text-accent-foreground data-open:bg-secondary data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
       className,
     )}
     {...props}
@@ -156,7 +156,7 @@ export const DropdownMenuCheckboxItem = ({
     data-slot="dropdown-menu-checkbox-item"
     data-inset={inset}
     className={cn(
-      "relative flex h-[26px] cursor-default items-center gap-1.5 rounded-lg py-[5.5px] ps-2 pe-8 text-base outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:ps-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+      "relative flex h-[26px] cursor-default items-center gap-1.5 rounded-lg py-[5.5px] ps-2 pe-8 text-base outline-hidden select-none focus:bg-secondary focus:text-accent-foreground focus:**:text-accent-foreground data-inset:ps-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
       className,
     )}
     checked={checked}
@@ -190,7 +190,7 @@ export const DropdownMenuRadioItem = ({
     data-slot="dropdown-menu-radio-item"
     data-inset={inset}
     className={cn(
-      "relative flex h-[26px] cursor-default items-center gap-1.5 rounded-lg py-[5.5px] ps-2 pe-8 text-base outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:ps-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+      "relative flex h-[26px] cursor-default items-center gap-1.5 rounded-lg py-[5.5px] ps-2 pe-8 text-base outline-hidden select-none focus:bg-secondary focus:text-accent-foreground focus:**:text-accent-foreground data-inset:ps-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
       className,
     )}
     {...props}

--- a/src/components/ui/form-button-node.tsx
+++ b/src/components/ui/form-button-node.tsx
@@ -2,6 +2,11 @@ import { CheckIcon, ChevronLeftIcon, ChevronRightIcon } from "@/components/ui/ic
 import type { PlateElementProps } from "platejs/react";
 import { PlateElement, useEditorRef, useEditorSelector } from "platejs/react";
 import * as React from "react";
+import {
+  findNextFocusTarget,
+  findPrevFocusTarget,
+  goToFocusTarget,
+} from "@/components/editor/plugins/form-blocks-utils";
 import { cn } from "@/lib/utils";
 
 export type ButtonRole = "next" | "previous" | "submit";
@@ -84,14 +89,29 @@ export const FormButtonElement = ({ children, ...props }: PlateElementProps) => 
     [writeLabel],
   );
 
-  const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
-    // Keep Plate's editor handlers off keys typed in the void node (incl. Backspace deleting it).
-    e.stopPropagation();
-    if (e.key === "Enter") {
-      e.preventDefault();
-      inputRef.current?.blur();
-    }
-  }, []);
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      // Keep Plate's editor handlers off keys typed in the void node (incl. Backspace deleting it).
+      e.stopPropagation();
+      if (e.key === "Enter") {
+        e.preventDefault();
+        inputRef.current?.blur();
+        return;
+      }
+      // Tab joins the button into the editor tab order: Previous → action button → next page.
+      // preventDefault always — the final Submit (no page after) has no target, so Tab just stays.
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const path = editor.api.findPath(element);
+        if (!path) return;
+        const target = e.shiftKey
+          ? findPrevFocusTarget(editor, path[0])
+          : findNextFocusTarget(editor, path[0]);
+        if (target) goToFocusTarget(editor, target, e.shiftKey);
+      }
+    },
+    [editor, element],
+  );
 
   // Stop pointer events from reaching Slate (cursor placement / block selection) so the input
   // focuses normally. Don't preventDefault — that would block focus.

--- a/src/components/ui/form-button-node.tsx
+++ b/src/components/ui/form-button-node.tsx
@@ -1,13 +1,8 @@
-import { CheckIcon, ChevronLeftIcon, ChevronRightIcon, SettingsIcon } from "@/components/ui/icons";
+import { CheckIcon, ChevronLeftIcon, ChevronRightIcon } from "@/components/ui/icons";
 import type { PlateElementProps } from "platejs/react";
 import { PlateElement, useEditorRef, useEditorSelector } from "platejs/react";
 import * as React from "react";
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 
 export type ButtonRole = "next" | "previous" | "submit";
 
@@ -57,125 +52,56 @@ export const FormButtonElement = ({ children, ...props }: PlateElementProps) => 
     (ed) => ed.children.some((node) => (node as { type?: string }).type === "pageBreak"),
     [],
   );
-  const [isOpen, setIsOpen] = React.useState(false);
 
   // Get label from element property (fallback to children for backwards compat)
   const label =
     (element.label as string) ??
     extractTextFromChildren(element.children as Array<{ text?: string }>);
 
-  // Local state for input - prevents re-render on every keystroke
+  // Inline-editable label: a native input (Slate ignores it — parent is contentEditable=false)
+  // edits element.label directly, the same property the transform reads first. Local state controls
+  // the input so it keeps the caret; synced back from the node on external changes (undo, etc.)
+  // while the input isn't focused.
+  const inputRef = React.useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = React.useState(label);
+  React.useEffect(() => {
+    if (document.activeElement !== inputRef.current) setInputValue(label);
+  }, [label]);
 
-  const displayText = label.trim() || placeholder;
-
-  const handleLabelChange = React.useCallback(
-    (newLabel: string) => {
+  const writeLabel = React.useCallback(
+    (next: string) => {
       const path = editor.api.findPath(element);
-      if (path) {
-        editor.tf.setNodes({ label: newLabel }, { at: path });
-      }
+      if (path) editor.tf.setNodes({ label: next }, { at: path });
     },
     [editor, element],
   );
 
-  const saveAndClose = React.useCallback(() => {
-    handleLabelChange(inputValue);
-    setIsOpen(false);
-  }, [handleLabelChange, inputValue]);
-
-  const buttonLabelId = React.useId();
-
-  const handlePopoverOpenChange = React.useCallback(
-    (open: boolean) => {
-      if (open) setInputValue(label);
-      setIsOpen(open);
+  const handleChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setInputValue(e.target.value);
+      writeLabel(e.target.value);
     },
-    [label],
+    [writeLabel],
   );
 
-  const handleGearMouseDown = React.useCallback((e: React.MouseEvent) => {
+  const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
+    // Keep Plate's editor handlers off keys typed in the void node (incl. Backspace deleting it).
+    e.stopPropagation();
+    if (e.key === "Enter") {
+      e.preventDefault();
+      inputRef.current?.blur();
+    }
+  }, []);
+
+  // Stop pointer events from reaching Slate (cursor placement / block selection) so the input
+  // focuses normally. Don't preventDefault — that would block focus.
+  const stopPointer = React.useCallback((e: React.SyntheticEvent) => e.stopPropagation(), []);
+
+  // Chrome (the py-2.5 gutter around the pill) shouldn't place a Slate caret on mousedown.
+  const handleChromeMouseDown = React.useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
   }, []);
-
-  const handleGearClick = React.useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsOpen(true);
-  }, []);
-
-  const handlePopoverMouseDown = React.useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-  }, []);
-
-  const handleInputChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value);
-  }, []);
-
-  const handleInputBlur = React.useCallback(() => {
-    handleLabelChange(inputValue);
-  }, [handleLabelChange, inputValue]);
-
-  const handleInputKeyDown = React.useCallback(
-    (e: React.KeyboardEvent) => {
-      e.stopPropagation();
-      if (e.key === "Enter") {
-        e.preventDefault();
-        saveAndClose();
-      }
-    },
-    [saveAndClose],
-  );
-
-  const handleInputMouseDown = React.useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-  }, []);
-
-  const handleInputClick = React.useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-  }, []);
-
-  const GearIcon = (
-    <Popover open={isOpen} onOpenChange={handlePopoverOpenChange}>
-      <PopoverTrigger
-        render={
-          <Button
-            variant="ghost-flat"
-            size="icon-sm"
-            className="size-7 rounded-lg p-1.25 opacity-0 group-hover:opacity-100"
-            aria-label="Button settings"
-            onMouseDown={handleGearMouseDown}
-            onClick={handleGearClick}
-          />
-        }
-      >
-        <SettingsIcon className="size-4.5 text-muted-foreground" />
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-64 border p-4"
-        side={isPrevious ? "right" : "left"}
-        align="start"
-        onMouseDown={handlePopoverMouseDown}
-      >
-        <div className="space-y-2">
-          <Label htmlFor={buttonLabelId} className="text-sm">
-            Button label
-          </Label>
-          <Input
-            id={buttonLabelId}
-            value={inputValue}
-            placeholder={placeholder}
-            onChange={handleInputChange}
-            onBlur={handleInputBlur}
-            onKeyDown={handleInputKeyDown}
-            onMouseDown={handleInputMouseDown}
-            onClick={handleInputClick}
-          />
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
 
   return (
     <PlateElement
@@ -185,35 +111,44 @@ export const FormButtonElement = ({ children, ...props }: PlateElementProps) => 
     >
       {/* Hidden children to maintain Slate structure */}
       <span className="hidden">{children}</span>
-      {/* Non-editable button visual - onMouseDown prevents cursor placement */}
       <div
         className={cn(
           "group inline-flex items-center gap-1 py-2.5",
           !isPrevious && isMultiStep && "ml-auto",
         )}
         contentEditable={false}
+        // presentation (not aria-hidden) keeps the inner input accessible while neutralizing the div.
         role="presentation"
-        aria-hidden="true"
-        onMouseDown={handleGearMouseDown}
+        onMouseDown={handleChromeMouseDown}
       >
-        {/* Gear icon on left when button is right-aligned (so button touches right edge) */}
-        {!isPrevious && isMultiStep && GearIcon}
-        <span
+        {/* <label> so a click anywhere on the pill (icons/padding) natively focuses the input;
+            stopPropagation (no preventDefault) lets that native focus through past the chrome guard. */}
+        <label
           data-bf-button={isPrevious ? undefined : ""}
+          onMouseDown={stopPointer}
           className={cn(
-            "inline-flex h-8 cursor-default items-center justify-center gap-1.5 rounded-lg px-2.5 text-sm transition-colors select-none",
+            "inline-flex h-8 cursor-text items-center justify-center gap-1.5 rounded-lg px-2.5 text-sm transition-colors select-none",
             isPrevious
               ? "border border-input bg-background text-foreground shadow-xs"
               : "bg-primary text-primary-foreground",
           )}
         >
           {isPrevious && <ChevronLeftIcon className="size-4" />}
-          <span>{displayText}</span>
+          <input
+            ref={inputRef}
+            value={inputValue}
+            placeholder={placeholder}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            onMouseDown={stopPointer}
+            onPointerDown={stopPointer}
+            onClick={stopPointer}
+            aria-label="Button label"
+            className="field-sizing-content min-w-[2ch] cursor-text bg-transparent text-center text-inherit outline-none placeholder:text-current/60"
+          />
           {buttonRole === "submit" && <CheckIcon className="size-4" />}
           {buttonRole === "next" && <ChevronRightIcon className="size-4" />}
-        </span>
-        {/* Gear icon on right when button is left-aligned (so button touches left edge) */}
-        {(isPrevious || !isMultiStep) && GearIcon}
+        </label>
       </div>
     </PlateElement>
   );

--- a/src/components/ui/form-button-node.tsx
+++ b/src/components/ui/form-button-node.tsx
@@ -141,16 +141,16 @@ export const FormButtonElement = ({ children, ...props }: PlateElementProps) => 
       <PopoverTrigger
         render={
           <Button
-            variant="ghost"
+            variant="ghost-flat"
             size="icon-sm"
-            className="size-7 opacity-0 group-hover:opacity-100"
+            className="size-7 rounded-lg p-1.25 opacity-0 group-hover:opacity-100"
             aria-label="Button settings"
             onMouseDown={handleGearMouseDown}
             onClick={handleGearClick}
           />
         }
       >
-        <SettingsIcon className="size-4 text-muted-foreground" />
+        <SettingsIcon className="size-4.5 text-muted-foreground" />
       </PopoverTrigger>
       <PopoverContent
         className="w-64 border p-4"

--- a/src/components/ui/form-button-node.tsx
+++ b/src/components/ui/form-button-node.tsx
@@ -99,15 +99,19 @@ export const FormButtonElement = ({ children, ...props }: PlateElementProps) => 
         return;
       }
       // Tab joins the button into the editor tab order: Previous → action button → next page.
-      // preventDefault always — the final Submit (no page after) has no target, so Tab just stays.
       if (e.key === "Tab") {
-        e.preventDefault();
         const path = editor.api.findPath(element);
         if (!path) return;
         const target = e.shiftKey
           ? findPrevFocusTarget(editor, path[0])
           : findNextFocusTarget(editor, path[0]);
-        if (target) goToFocusTarget(editor, target, e.shiftKey);
+        if (target) {
+          e.preventDefault();
+          goToFocusTarget(editor, target, e.shiftKey);
+        }
+        // No internal target (Tab forward off the final Submit, or a button with nothing focusable
+        // before it): leave preventDefault off so native Tab carries focus out to the surrounding
+        // UI instead of trapping it on the input (WCAG 2.1.2 — no keyboard trap).
       }
     },
     [editor, element],

--- a/src/components/ui/form-field-node.tsx
+++ b/src/components/ui/form-field-node.tsx
@@ -85,7 +85,7 @@ export const FormFieldElement = (allProps: PlateElementProps) => {
           "data-bf-input-fill": "true",
         }}
         className={cn(
-          "relative flex h-7 w-full cursor-text items-center gap-[4px] rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] px-[10px] text-sm caret-current elevation-sm",
+          "relative flex h-[30px] w-full cursor-text items-center gap-[4px] rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] px-[10px] text-sm caret-current elevation-sm",
           isSelected && focused && "ring-[3px] ring-ring/50",
         )}
         element={element}
@@ -121,7 +121,7 @@ export const FormFieldElement = (allProps: PlateElementProps) => {
               className="mt-2 flex items-center gap-2 select-none"
             >
               <div
-                className="relative flex h-7 flex-1 items-center gap-[4px] rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] px-[10px] text-sm elevation-sm"
+                className="relative flex h-[30px] flex-1 items-center gap-[4px] rounded-[8px] border-0 bg-[var(--form-input-bg,var(--color-gray-50))] px-[10px] text-sm elevation-sm"
                 aria-hidden="true"
               >
                 <span className="line-clamp-1 min-w-0 flex-1 break-all text-muted-foreground/50">

--- a/src/components/ui/form-header-node.tsx
+++ b/src/components/ui/form-header-node.tsx
@@ -728,9 +728,9 @@ export const CoverPickerContent = ({
           <TabsIndicator />
         </TabsList>
         <Button
-          variant="ghost"
+          variant="ghost-flat"
           size="icon"
-          className="shrink-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+          className="shrink-0 rounded-lg p-1.25 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
           onClick={() => {
             onCoverChange(null);
             onClose();
@@ -811,9 +811,9 @@ export const LogoPickerContent = ({
         <div className="flex items-center gap-2 px-3 pt-2 pb-1">
           <IconTabBar value={tab} onChange={setTab} />
           <Button
-            variant="ghost"
+            variant="ghost-flat"
             size="icon"
-            className="shrink-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+            className="shrink-0 rounded-lg p-1.25 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
             onClick={() => {
               onIconChange(null);
               onClose();
@@ -1169,9 +1169,9 @@ const HeaderIconPopoverContent = ({
       <div className="flex items-center gap-2 px-3 pt-2 pb-1">
         <IconTabBar value={iconTab} onChange={onIconTabChange} />
         <Button
-          variant="ghost"
+          variant="ghost-flat"
           size="icon"
-          className="shrink-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+          className="shrink-0 rounded-lg p-1.25 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
           onClick={() => {
             onIconChange(null);
             onClose();

--- a/src/components/ui/form-linear-scale-node.tsx
+++ b/src/components/ui/form-linear-scale-node.tsx
@@ -42,7 +42,7 @@ export const FormLinearScaleElement = ({ children, ...props }: PlateElementProps
             {values.map((value) => (
               <span
                 key={String(value)}
-                className="flex h-8 min-w-8 items-center justify-center rounded-[8px] bg-[var(--form-input-bg,var(--color-gray-50))] px-2 text-sm text-foreground tabular-nums elevation-sm"
+                className="flex h-8 min-w-8 items-center justify-center rounded-[8px] bg-[var(--form-input-bg,var(--color-gray-50))] px-2 text-[14px] text-foreground tabular-nums elevation-sm"
               >
                 {String(value)}
               </span>

--- a/src/components/ui/form-matrix-node.tsx
+++ b/src/components/ui/form-matrix-node.tsx
@@ -5,10 +5,10 @@ import { PlateElement, useEditorRef } from "platejs/react";
 import * as React from "react";
 
 import {
-  findNextNonButtonPath,
-  findPrevNonButtonPath,
+  findNextFocusTarget,
+  findPrevFocusTarget,
+  goToFocusTarget,
   insertParagraphAfterPath,
-  moveToPath,
 } from "@/components/editor/plugins/form-blocks-utils";
 import { BlockSelection } from "@/components/ui/block-selection";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -130,24 +130,16 @@ export const FormMatrixElement = ({ children, ...props }: PlateElementProps) => 
     const path = editor.api.findPath(element);
     if (!path) return;
     const goPrev = delta === -1;
+    // Focus targets include the page's buttons now; goToFocusTarget handles button inputs, the
+    // Slate caret, and landing inside a neighbouring matrix's own inputs.
     const target = goPrev
-      ? findPrevNonButtonPath(editor, path)
-      : findNextNonButtonPath(editor, path);
+      ? findPrevFocusTarget(editor, path[0])
+      : findNextFocusTarget(editor, path[0]);
     if (target) {
-      moveToPath(editor, target);
-      editor.tf.focus();
-      // If the neighbour is another matrix, land inside its inputs (mirrors NavigationPlugin).
-      const targetNode = editor.api.node(target)?.[0] as TElement | undefined;
-      if (targetNode?.type === "formMatrix") {
-        const fieldInputs = editor.api.toDOMNode(targetNode)?.querySelectorAll("input");
-        if (fieldInputs && fieldInputs.length > 0) {
-          const input = goPrev ? fieldInputs[fieldInputs.length - 1] : fieldInputs[0];
-          setTimeout(() => input.focus(), 0);
-        }
-      }
+      goToFocusTarget(editor, target, goPrev);
       return;
     }
-    // No next field (matrix is the last block before Submit) → create a new block after it.
+    // Nothing focusable after (shouldn't happen — pages always end in a button) → add a block.
     if (!goPrev) {
       const at = insertParagraphAfterPath(editor, path);
       setTimeout(() => {

--- a/src/components/ui/form-matrix-node.tsx
+++ b/src/components/ui/form-matrix-node.tsx
@@ -259,7 +259,7 @@ export const FormMatrixElement = ({ children, ...props }: PlateElementProps) => 
                   onPointerDown={(e) => e.stopPropagation()}
                   aria-label="Row label"
                   placeholder="Row"
-                  className="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/60"
+                  className="w-full bg-transparent text-[14px] text-foreground outline-none placeholder:text-muted-foreground/60"
                 />
               </div>
               {columns.map((col) => (

--- a/src/components/ui/form-option-item-node.tsx
+++ b/src/components/ui/form-option-item-node.tsx
@@ -13,8 +13,10 @@ import {
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import {
-  findNextNonButtonPath,
+  findNextFocusTarget,
+  findPrevFocusTarget,
   findPrevNonButtonPath,
+  goToFocusTarget,
   moveToPath,
 } from "@/components/editor/plugins/form-blocks-utils";
 import { BlockSelection } from "@/components/ui/block-selection";
@@ -298,13 +300,9 @@ const OptionChipsRow = ({ children, ...props }: PlateElementProps) => {
     const { start, end } = collect();
     if (start < 0) return;
     inputRef.current?.blur();
-    const target = goPrev
-      ? findPrevNonButtonPath(editor, [start])
-      : findNextNonButtonPath(editor, [end]);
-    if (target) {
-      moveToPath(editor, target);
-      editor.tf.focus();
-    }
+    // Focus targets include the page's buttons (editable label) now.
+    const target = goPrev ? findPrevFocusTarget(editor, start) : findNextFocusTarget(editor, end);
+    if (target) goToFocusTarget(editor, target, goPrev);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -395,6 +395,63 @@ export const PlusIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+/* ── Figma "system-flat" block-gutter controls (node 25578:9121), 16px verbatim ── */
+
+/** Block gutter: delete (outline bin). */
+export const BlockDeleteIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <g stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3.16699 4.33301L3.77041 12.9264C3.81945 13.6248 4.40033 14.1663 5.10046 14.1663H10.9002C11.6003 14.1663 12.1812 13.6248 12.2303 12.9264L12.8337 4.33301" />
+      <path d="M6.66699 7V10.8333" />
+      <path d="M9.33301 7V10.8333" />
+      <path d="M2.16699 3.83301H13.8337" />
+      <path d="M5.68262 3.72225C5.82008 2.56467 6.80495 1.66699 7.99955 1.66699C9.19415 1.66699 10.179 2.56467 10.3165 3.72225" />
+    </g>
+  </svg>
+);
+
+/** Block gutter: add (filled plus). */
+export const BlockAddIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M8 2.34977C8.35898 2.34977 8.65039 2.64118 8.65039 3.00016V7.34977H13C13.359 7.34977 13.6504 7.64118 13.6504 8.00016C13.6504 8.35915 13.359 8.65055 13 8.65055H8.65039V13.0002C8.65039 13.3591 8.35898 13.6506 8 13.6506C7.64101 13.6506 7.34961 13.3591 7.34961 13.0002V8.65055H3C2.64101 8.65055 2.34961 8.35915 2.34961 8.00016C2.34961 7.64118 2.64101 7.34977 3 7.34977H7.34961V3.00016C7.34961 2.64118 7.64101 2.34977 8 2.34977Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+/** Block gutter: drag handle (filled 2×3 dot grid). */
+export const BlockDragIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      transform="translate(4.25 1.75)"
+      d="M1.25 10C1.94036 10 2.5 10.5596 2.5 11.25C2.5 11.9404 1.94036 12.5 1.25 12.5C0.559644 12.5 4.49885e-08 11.9404 0 11.25C3.01764e-08 10.5596 0.559644 10 1.25 10ZM6.25 10C6.94036 10 7.5 10.5596 7.5 11.25C7.5 11.9404 6.94036 12.5 6.25 12.5C5.55964 12.5 5 11.9404 5 11.25C5 10.5596 5.55964 10 6.25 10ZM1.25 5C1.94036 5 2.5 5.55964 2.5 6.25C2.5 6.94036 1.94036 7.5 1.25 7.5C0.559644 7.5 4.49885e-08 6.94036 0 6.25C3.01764e-08 5.55964 0.559644 5 1.25 5ZM6.25 5C6.94036 5 7.5 5.55964 7.5 6.25C7.5 6.94036 6.94036 7.5 6.25 7.5C5.55964 7.5 5 6.94036 5 6.25C5 5.55964 5.55964 5 6.25 5ZM1.25 0C1.94036 3.01764e-08 2.5 0.559644 2.5 1.25C2.5 1.94036 1.94036 2.5 1.25 2.5C0.559644 2.5 1.27757e-08 1.94036 0 1.25C3.01764e-08 0.559644 0.559644 -1.407e-08 1.25 0ZM6.25 0C6.94036 3.01764e-08 7.5 0.559644 7.5 1.25C7.5 1.94036 6.94036 2.5 6.25 2.5C5.55964 2.5 5 1.94036 5 1.25C5 0.559644 5.55964 -1.407e-08 6.25 0Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 /* ── Figma "system-flat" block-menu icons (node 25458:16258), pulled verbatim ── */
 
 /** Required field marker — six-point asterisk. */
@@ -1386,6 +1443,24 @@ export const ImageIcon = (props: React.SVGProps<SVGSVGElement>) => (
       strokeLinecap="round"
       strokeWidth="var(--stroke-width)"
       strokeLinejoin="round"
+    />
+  </svg>
+);
+// Figma icon/line/image (node I25424:12047): filled "Union" photo-frame glyph (rounded rect + sun +
+// mountain), 14×13 path inset in a 16px box. Used for the Cover upload row. currentColor = gray/700.
+export const ImageLineIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      transform="translate(1 1.5)"
+      d="M11.5 0C12.8807 0 14 1.11929 14 2.5V10.5C14 11.8807 12.8807 13 11.5 13H2.5L2.24414 12.9873C0.983608 12.8592 0 11.7943 0 10.5V2.5C1.28853e-07 1.11929 1.11929 0 2.5 0H11.5ZM3.48828 12H11.5C12.3284 12 13 11.3284 13 10.5V8.93066C12.9948 8.92762 12.9886 8.9261 12.9834 8.92285L9.21582 6.55273L3.48828 12ZM2.5 1C1.67157 1 1 1.67157 1 2.5V10.5C1 11.1914 1.46822 11.7716 2.10449 11.9453C2.1199 11.9254 2.13646 11.9056 2.15527 11.8877L8.58398 5.77441L8.70215 5.67969C8.95196 5.51181 9.27083 5.4803 9.54883 5.5957L9.68359 5.66504L13 7.75098V2.5C13 1.67157 12.3284 1 11.5 1H2.5ZM4.25 2.5C5.2165 2.5 6 3.2835 6 4.25C6 5.2165 5.2165 6 4.25 6C3.2835 6 2.5 5.2165 2.5 4.25C2.5 3.2835 3.2835 2.5 4.25 2.5ZM4.25 3.5C3.83579 3.5 3.5 3.83579 3.5 4.25C3.5 4.66421 3.83579 5 4.25 5C4.66421 5 5 4.66421 5 4.25C5 3.83579 4.66421 3.5 4.25 3.5Z"
+      fill="currentColor"
     />
   </svg>
 );

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -531,6 +531,26 @@ export const CharacterLimitIcon = (props: React.SVGProps<SVGSVGElement>) => (
 );
 
 /** Add conditional logic — branching connector with two nodes. */
+// Figma system-flat "Scale Anchor" glyph (node 26153-13541): anchor — dot, stem, arc.
+export const ScaleAnchorIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M8 5.5C9.01253 5.5 9.83333 4.67919 9.83333 3.66667C9.83333 2.65415 9.01253 1.83333 8 1.83333C6.98747 1.83333 6.16667 2.65415 6.16667 3.66667C6.16667 4.67919 6.98747 5.5 8 5.5ZM8 5.5V14M12 8H14.1667C14.1667 11.4057 11.4057 14.1667 8 14.1667C4.59425 14.1667 1.83333 11.4057 1.83333 8H4"
+      stroke="currentColor"
+      strokeWidth="var(--stroke-width)"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 export const ConditionalLogicIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
     width="16"

--- a/src/components/ui/logic-block-node.tsx
+++ b/src/components/ui/logic-block-node.tsx
@@ -33,10 +33,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
-  findNextNonButtonPath,
-  findPrevNonButtonPath,
+  findNextFocusTarget,
+  findPrevFocusTarget,
+  goToFocusTarget,
   insertParagraphAfterPath,
-  moveToPath,
 } from "@/components/editor/plugins/form-blocks-utils";
 import { transformPlateForPreview } from "@/lib/editor/transform-plate-for-preview";
 import { operatorNeedsOperand, operatorsForFieldType, OPERATOR_LABELS } from "@/lib/logic/labels";
@@ -820,12 +820,12 @@ export const LogicBlockElement = (props: PlateElementProps) => {
       event.preventDefault();
       event.stopPropagation();
       const goPrev = event.key === "ArrowUp" || (isTab && event.shiftKey);
+      // Focus targets include the page's buttons (editable label) now.
       const target = goPrev
-        ? findPrevNonButtonPath(editor, path)
-        : findNextNonButtonPath(editor, path);
+        ? findPrevFocusTarget(editor, path[0])
+        : findNextFocusTarget(editor, path[0]);
       if (target) {
-        moveToPath(editor, target);
-        editor.tf.focus();
+        goToFocusTarget(editor, target, goPrev);
         return;
       }
       // No block below (logic block is last before the submit button) - create an

--- a/src/components/ui/logic-block-node.tsx
+++ b/src/components/ui/logic-block-node.tsx
@@ -376,7 +376,7 @@ const RowMenu = ({ items, ariaLabel }: { items: RowMenuItem[]; ariaLabel: string
       aria-label={ariaLabel}
       className="flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none hover:bg-secondary hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
     >
-      <MoreHorizontalIcon className="size-4" />
+      <MoreHorizontalIcon className="size-[18px]" />
     </DropdownMenuTrigger>
     <DropdownMenuContent align="end" className="w-[246px]">
       {items.map((item) => (

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -76,10 +76,13 @@ function PhoneInput({
         // both inner pieces stay transparent. Surface uses --form-input-bg (same as form-input util)
         // for theme consistency. [&]: bumps specificity past react-phone-number-input's defaults.
         className={cn(
+          // min-h (not fixed h): the inner pieces carry the themed --bf-input-height (via
+          // [data-bf-input-fill]); the wrapper hugs them so a customized input height grows the
+          // surface instead of overflowing it (overflow-hidden was clipping the text — #broken).
           "flex flex-row items-stretch overflow-hidden rounded-lg text-foreground elevation-sm dark:shadow-none [&]:bg-[var(--form-input-bg,var(--color-gray-50))]",
-          phoneInputSize === "sm" && "[&]:h-7",
-          phoneInputSize === "lg" && "[&]:h-9",
-          phoneInputSize === "default" && "[&]:h-8",
+          phoneInputSize === "sm" && "[&]:min-h-7",
+          phoneInputSize === "lg" && "[&]:min-h-9",
+          phoneInputSize === "default" && "[&]:min-h-8",
           props["aria-invalid"] &&
             "**:data-[slot=input-group]:ring-1 **:data-[slot=input-group]:ring-destructive",
           className,

--- a/src/components/ui/right-sidebar-resize-handle.tsx
+++ b/src/components/ui/right-sidebar-resize-handle.tsx
@@ -2,7 +2,7 @@ import type * as React from "react";
 import { useCallback, useRef } from "react";
 
 export const RIGHT_SIDEBAR_WIDTH_MIN = 280;
-export const RIGHT_SIDEBAR_WIDTH_DEFAULT = 340;
+export const RIGHT_SIDEBAR_WIDTH_DEFAULT = 304;
 export const RIGHT_SIDEBAR_WIDTH_MAX = 420;
 export const RIGHT_SIDEBAR_WIDTH_KEY = "right_sidebar_width";
 

--- a/src/components/ui/sidebar-section.tsx
+++ b/src/components/ui/sidebar-section.tsx
@@ -5,7 +5,8 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import { createContext, use } from "react";
+import { CaretDownIcon } from "@/components/ui/icons";
+import { createContext, use, useState } from "react";
 
 const SECTION_VALUE = "section";
 
@@ -18,14 +19,19 @@ const SidebarSectionResetContext = createContext(0);
 export const SidebarSectionResetProvider = SidebarSectionResetContext.Provider;
 
 // Figma system-flat header label scale; shared by both variants.
-const HEADER_LABEL_CLS = "truncate text-[13px] font-medium tracking-[0.13px] text-muted-foreground";
+// Figma section header (node 25424-12009): Inter Medium 13px, 0.13px tracking, gray/500 (#999).
+const HEADER_LABEL_CLS = "truncate text-[13px] font-medium tracking-[0.13px] text-gray-500";
 
 interface SidebarSectionProps {
   label: string;
   children: React.ReactNode;
   action?: React.ReactNode;
-  /** Collapsible Accordion (chevron caret, reset-key) vs flat header + divider. Default collapsible (back-compat). */
-  collapsible?: boolean;
+  /**
+   * `true` (default): collapsible Accordion, always-visible caret (back-compat).
+   * `false`: flat static header + divider.
+   * `"flat"`: flat header + divider, collapsible with a hover-only caret (Figma system-flat).
+   */
+  collapsible?: boolean | "flat";
   /** Right-aligned header slot (e.g. Typography "Title"/Colors "Light" scope selects). */
   headerRight?: React.ReactNode;
   /** Bottom border divider in the flat variant. Default true. */
@@ -52,7 +58,7 @@ export const SidebarSection = ({
   const resetKey = use(SidebarSectionResetContext);
 
   if (!collapsible) {
-    // Figma rhythm: 16px header→rows, 6px between rows, 16px pad + divider below.
+    // Figma rhythm: 16px header→rows, 8px between rows, 16px pad + divider below.
     return (
       <div className={cn("flex flex-col gap-4 pb-4", divider && "border-b border-border")}>
         <div className="flex min-h-[15px] items-center gap-3">
@@ -60,8 +66,25 @@ export const SidebarSection = ({
           {headerRight}
           {action}
         </div>
-        <div className={cn("flex flex-col gap-1.5", className)}>{children}</div>
+        <div className={cn("flex flex-col gap-2", className)}>{children}</div>
       </div>
+    );
+  }
+
+  if (collapsible === "flat") {
+    // key={resetKey} remounts on sidebar reopen → sections reset to initialOpen (all open).
+    return (
+      <FlatCollapsibleSection
+        key={resetKey}
+        label={label}
+        action={action}
+        headerRight={headerRight}
+        divider={divider}
+        initialOpen={initialOpen}
+        className={className}
+      >
+        {children}
+      </FlatCollapsibleSection>
     );
   }
 
@@ -87,5 +110,46 @@ export const SidebarSection = ({
         </AccordionContent>
       </AccordionItem>
     </Accordion>
+  );
+};
+
+// Flat header (Figma system-flat) that collapses on click; the 10px caret reveals on hover only
+// and points right when collapsed (node 25424-12987). Open by default.
+const FlatCollapsibleSection = ({
+  label,
+  children,
+  action,
+  headerRight,
+  divider = true,
+  initialOpen = true,
+  className,
+}: Pick<
+  SidebarSectionProps,
+  "label" | "children" | "action" | "headerRight" | "divider" | "initialOpen" | "className"
+>) => {
+  const [open, setOpen] = useState(initialOpen);
+  return (
+    <div className={cn("flex flex-col gap-4 pb-4", divider && "border-b border-border")}>
+      <div className="flex min-h-[15px] items-center gap-3">
+        <button
+          type="button"
+          aria-expanded={open}
+          onClick={() => setOpen((o) => !o)}
+          className="group/sec flex flex-1 cursor-pointer items-center gap-0.5 text-left"
+        >
+          <span className={HEADER_LABEL_CLS}>{label}</span>
+          <CaretDownIcon
+            aria-hidden
+            className={cn(
+              "size-2.5 shrink-0 text-gray-500 opacity-0 transition-[opacity,transform] group-hover/sec:opacity-100",
+              !open && "-rotate-90",
+            )}
+          />
+        </button>
+        {headerRight}
+        {action}
+      </div>
+      {open && <div className={cn("flex flex-col gap-2", className)}>{children}</div>}
+    </div>
   );
 };

--- a/src/components/ui/sidebar-section.tsx
+++ b/src/components/ui/sidebar-section.tsx
@@ -128,8 +128,10 @@ const FlatCollapsibleSection = ({
   "label" | "children" | "action" | "headerRight" | "divider" | "initialOpen" | "className"
 >) => {
   const [open, setOpen] = useState(initialOpen);
+  // Figma divider frame (node 25424-12791) = 8px tall, hairline centered → 4px above/below the line.
+  // Paired with the parent's 16px section gap, the line lands 20px from content and 20px from the next header.
   return (
-    <div className={cn("flex flex-col gap-4 pb-4", divider && "border-b border-border")}>
+    <div className={cn("flex flex-col gap-4 pb-5", divider && "border-b border-border")}>
       <div className="flex min-h-[15px] items-center gap-3">
         <button
           type="button"

--- a/src/components/ui/style-controls.tsx
+++ b/src/components/ui/style-controls.tsx
@@ -84,17 +84,20 @@ export const StyleNumberInput = ({
       onAutoChange={onAutoChange}
       markStyle={markStyle}
       endIcon={endIcon}
+      // bare = flush Figma customize rows: flat at rest, gray track revealed on hover/focus.
+      revealOnHover={bare}
       aria-label={isAuto ? `${label}: Auto` : `${label}: ${numValue}${shownUnit}`}
       className={cn(
         bare ? "h-7 [--elastic-slider-height:1.75rem]" : "h-[34px] [--elastic-slider-height:34px]",
-        "[--elastic-slider-bg:var(--background)]",
+        // Revealed track = Figma gray/100 (solid --muted) for bare rows; white for bordered scrubber.
+        bare ? "[--elastic-slider-bg:var(--muted)]" : "[--elastic-slider-bg:var(--background)]",
         // 6px inner padding (Figma): pairs with the -mx-1.5 bleed on sidebar rows so the label
         // column stays flush-aligned with non-slider rows while the track extends past it.
         bare
           ? "[&_[data-slot=elastic-slider-label]]:inset-s-1.5 [&_[data-slot=elastic-slider-label]]:text-[14px] [&_[data-slot=elastic-slider-label]]:font-normal [&_[data-slot=elastic-slider-label]]:text-muted-foreground"
           : "[&_[data-slot=elastic-slider-label]]:inset-s-2 [&_[data-slot=elastic-slider-label]]:text-base [&_[data-slot=elastic-slider-label]]:font-normal",
         bare
-          ? "[&_[data-slot=elastic-slider-value]]:inset-e-1.5 [&_[data-slot=elastic-slider-value]]:text-[14px] [&_[data-slot=elastic-slider-value]]:font-medium [&_[data-slot=elastic-slider-value]]:text-foreground [&_[data-slot=elastic-slider-value]]:tabular-nums"
+          ? "[&_[data-slot=elastic-slider-value]]:inset-e-1.5 [&_[data-slot=elastic-slider-value]]:text-[14px] [&_[data-slot=elastic-slider-value]]:font-medium [&_[data-slot=elastic-slider-value]]:text-gray-700 [&_[data-slot=elastic-slider-value]]:tabular-nums"
           : "[&_[data-slot=elastic-slider-value]]:inset-e-[11px] [&_[data-slot=elastic-slider-value]]:text-[13px] [&_[data-slot=elastic-slider-value]]:tabular-nums",
         className,
       )}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -9,8 +9,8 @@ import { cn } from "@/lib/utils";
 const switchVariants = cva(
   [
     "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2",
-    // unchecked states
-    "not-data-disabled:data-unchecked:focus-visible:shadow-3xs data-unchecked:bg-accent not-data-disabled:data-unchecked:hover:bg-popover-foreground not-data-disabled:data-unchecked:focus-visible:bg-accent not-data-disabled:data-unchecked:active:bg-card-foreground",
+    // unchecked states — stays bg-accent through hover/active; only a real toggle (→checked) changes color
+    "not-data-disabled:data-unchecked:focus-visible:shadow-3xs data-unchecked:bg-accent not-data-disabled:data-unchecked:focus-visible:bg-accent",
     // checked states
     "not-data-disabled:data-checked:focus-visible:shadow-3xs data-checked:bg-primary not-data-disabled:data-checked:hover:bg-primary/86 not-data-disabled:data-checked:focus-visible:bg-primary not-data-disabled:data-checked:active:bg-primary/74",
     // invalid state (self + Field context)

--- a/src/components/ui/toggle-node.tsx
+++ b/src/components/ui/toggle-node.tsx
@@ -15,7 +15,7 @@ export const ToggleElement = (props: PlateElementProps) => {
       <Button
         size="icon"
         variant="ghost"
-        className="absolute top-0 -left-0.5 size-6 cursor-pointer items-center justify-center rounded-md p-px text-muted-foreground transition-colors select-none hover:bg-accent [&_svg]:size-4"
+        className="absolute top-0 -left-0.5 size-6 cursor-pointer items-center justify-center rounded-md p-px text-muted-foreground transition-colors select-none hover:bg-secondary [&_svg]:size-4"
         contentEditable={false}
         {...buttonProps}
       >

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -339,7 +339,7 @@ const AuthLayout = () => {
   // lands in the authenticated chunk — public-form routes ($shortId, $slug, f/$formId) skip it.
   return (
     <HotkeysProvider defaultOptions={{ hotkey: { preventDefault: true } }}>
-      <SidebarProvider style={{ "--app-header-height": "40px" } as React.CSSProperties}>
+      <SidebarProvider style={{ "--app-header-height": "44px" } as React.CSSProperties}>
         <EditorHeaderVisibilityProvider enabled={isEditRoute}>
           <MinimalSidebarProvider>
             <AuthLayoutContent />
@@ -565,13 +565,13 @@ const AppSidebar = () => {
             onClose={closeInbox}
             headerLeft={
               <Button
-                variant="ghost"
+                variant="ghost-flat"
                 size="icon"
-                className="size-7 text-muted-foreground hover:text-foreground"
+                className="size-7 rounded-lg p-1.25 text-gray-800 hover:text-foreground"
                 onClick={closeInbox}
                 aria-label="Back"
               >
-                <ArrowLeftIcon className="size-4" />
+                <ArrowLeftIcon className="size-4.5" />
               </Button>
             }
           />
@@ -1297,13 +1297,13 @@ const InboxPanelBody = ({ onClose, headerLeft }: InboxPanelBodyProps) => {
             <h2 className="truncate pl-2.5 text-base text-foreground">Inbox</h2>
           </div>
           <Button
-            variant="ghost"
+            variant="ghost-flat"
             size="icon"
-            className="shrink-0 text-muted-foreground hover:text-foreground"
+            className="shrink-0 rounded-lg p-1.25 text-gray-800 hover:text-foreground"
             onClick={onClose}
             aria-label="Close"
           >
-            <XIcon className="size-4" />
+            <XIcon className="size-4.5" />
           </Button>
         </div>
       </SidebarHeader>

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
@@ -1,6 +1,6 @@
-import { APP_NAME, SPRITE_PATH } from "@/lib/config/app-config";
+import { SPRITE_PATH } from "@/lib/config/app-config";
 import { Link, useSearch } from "@tanstack/react-router";
-import { SparklesIcon, XIcon } from "@/components/ui/icons";
+import { XIcon } from "@/components/ui/icons";
 import { useState, useCallback, useMemo } from "react";
 import { PopoverContainerContext } from "@/components/ui/popover";
 import type { Value } from "platejs";
@@ -70,19 +70,19 @@ export const PreviewModeContent = ({ doc, formId }: { doc: PreviewDoc; formId: s
   const content = (doc?.content as Value) || [];
   // Preview shows what the user is about to publish — read the draft.
   const docSettings = doc?.draftSettings;
-  const previewSettings = useMemo<PublicFormSettings>(
-    () =>
-      buildPublicFormSettings(docSettings, {
-        branding: Boolean(docSettings?.branding ?? true),
-      }),
-    [docSettings],
-  );
 
   const search = useSearch({ strict: false });
+  // Share sidebar's "Show branding" toggle writes embedBranding; fall back to the saved setting.
+  // Feed it into previewSettings so the form's inline "Made with Reform." badge tracks the toggle live.
+  const branding = (search.embedBranding as boolean) ?? docSettings?.branding ?? true;
+  const previewSettings = useMemo<PublicFormSettings>(
+    () => buildPublicFormSettings(docSettings, { branding }),
+    [docSettings, branding],
+  );
+
   const embedType = (search.embedType as EmbedType) ?? "fullpage";
   const hideTitle = (search.embedHideTitle as boolean) ?? false;
   const transparentBackground = (search.embedTransparent as boolean) ?? false;
-  const branding = (search.embedBranding as boolean) ?? docSettings?.branding ?? true;
   const height = (search.embedHeight as number) ?? 558;
   const dynamicHeight = (search.embedDynamicHeight as boolean) ?? true;
   const popupPosition = (search.embedPopupPosition as string) ?? "bottom-right";
@@ -149,7 +149,6 @@ export const PreviewModeContent = ({ doc, formId }: { doc: PreviewDoc; formId: s
               dynamicHeight={dynamicHeight}
               height={height}
               dynamicWidth={dynamicWidth}
-              branding={branding}
               darkOverlay={darkOverlay}
               isPopupOpen={isPopupOpen}
               handleClosePopup={handleClosePopup}
@@ -174,7 +173,6 @@ export const PreviewModeContent = ({ doc, formId }: { doc: PreviewDoc; formId: s
               doc={doc}
               content={content}
               customization={customization}
-              branding={branding}
               formId={formId}
             />
           )}
@@ -199,7 +197,6 @@ type EmbedPreviewSurfaceProps = SharedPreviewProps & {
   dynamicHeight: boolean;
   height: number;
   dynamicWidth: boolean;
-  branding: boolean;
   darkOverlay: boolean;
   isPopupOpen: boolean;
   handleClosePopup: () => void;
@@ -215,7 +212,6 @@ const EmbedPreviewSurface = ({
   dynamicHeight,
   height,
   dynamicWidth,
-  branding,
   darkOverlay,
   isPopupOpen,
   handleClosePopup,
@@ -304,8 +300,6 @@ const EmbedPreviewSurface = ({
                 <div className="h-3 w-3/5 rounded-full bg-[var(--color-gray-100)]" />
                 <div className="h-3 w-1/5 rounded-full bg-[var(--color-gray-100)]" />
               </div>
-
-              {branding && <BrandingBadge />}
             </>
           )}
         </div>
@@ -323,7 +317,6 @@ const EmbedPreviewSurface = ({
             doc={doc}
             content={content}
             customization={customization}
-            branding={branding}
             showEmoji={showEmoji}
             formId={formId}
           />
@@ -398,7 +391,6 @@ type PopupPreviewOverlayProps = SharedPreviewProps & {
   handleOpenPopup: () => void;
   popupPosition: string;
   popupWidth: number;
-  branding: boolean;
   showEmoji: boolean;
 };
 
@@ -414,7 +406,6 @@ const PopupPreviewOverlay = ({
   doc,
   content,
   customization,
-  branding,
   showEmoji,
   formId,
 }: PopupPreviewOverlayProps) => {
@@ -488,16 +479,6 @@ const PopupPreviewOverlay = ({
               formId={formId}
             />
           </div>
-
-          {branding && (
-            <div className="flex shrink-0 justify-center border-t border-border bg-muted/60 py-3">
-              <div className="flex items-center gap-1.5 text-[12px] font-semibold text-muted-foreground">
-                <span>Made with</span>
-                <SparklesIcon className="size-3 fill-muted-foreground text-muted-foreground" />
-                <span className="text-foreground">{APP_NAME}</span>
-              </div>
-            </div>
-          )}
         </div>
       )}
 
@@ -540,7 +521,6 @@ const PopupPreviewOverlay = ({
 
 type FullpagePreviewSurfaceProps = SharedPreviewProps & {
   transparentBackground: boolean;
-  branding: boolean;
 };
 
 const FullpagePreviewSurface = ({
@@ -550,7 +530,6 @@ const FullpagePreviewSurface = ({
   doc,
   content,
   customization,
-  branding,
   formId,
 }: FullpagePreviewSurfaceProps) => {
   // Match FormPreviewFromPlate cover resolution: formHeader node is sole truth (legacy doc.cover may be stale). Only header-less forms fall back to doc.cover.
@@ -576,7 +555,6 @@ const FullpagePreviewSurface = ({
           "h-full min-h-0 w-full flex-1",
           previewSettings.presentationMode !== "field-by-field" &&
             "overflow-x-hidden overflow-y-auto",
-          previewSettings.presentationMode !== "field-by-field" && branding && "pb-16",
         )}
       >
         <FormPreviewFromPlate
@@ -592,7 +570,6 @@ const FullpagePreviewSurface = ({
           formId={formId}
         />
       </div>
-      {branding && <BrandingBadge />}
     </div>
   );
 };
@@ -630,13 +607,3 @@ const FieldByFieldCoverBackground = ({ cover }: { cover: string }) => {
     </>
   );
 };
-
-const BrandingBadge = () => (
-  <div className="absolute right-0 bottom-0 left-0 z-50 flex justify-center border-t border-border bg-muted/60 py-3 backdrop-blur">
-    <span className="flex items-center gap-1.5 text-[12px] font-semibold text-muted-foreground">
-      <span>Made with</span>
-      <SparklesIcon className="size-3 fill-muted-foreground text-muted-foreground" />
-      <span className="text-foreground">{APP_NAME}</span>
-    </span>
-  </div>
-);

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -931,9 +931,9 @@
 }
 
 /* Input fill metrics: unset fallbacks match the current literal classes
-   (h-7 = 1.75rem, rounded-[8px], px-[10px]) so unset = identical. */
+   (h-[30px], rounded-[8px], px-[10px]) so unset = identical. */
 .bf-themed [data-bf-input-fill] {
-  height: var(--bf-input-height, 1.75rem);
+  height: var(--bf-input-height, 30px);
   border-radius: var(--bf-input-radius, 8px);
   padding: var(--bf-input-padding, 0 10px);
 }


### PR DESCRIPTION
## Summary

A batch of form-builder and share/embed UI work matching the latest Figma system-flat designs, plus a couple of correctness/a11y fixes.

### Form builder — buttons & editor
- Button nodes are now **inline-editable** (native input on the pill), dropping the old gear + popover.
- Buttons **join the Tab order**; Tab traversal refactored onto shared `find{Next,Prev}FocusTarget` / `goToFocusTarget` helpers.
- Fix: don't **trap keyboard focus** on the final/first button — native Tab carries focus out when there's no in-editor target (WCAG 2.1.2).

### Forms — branding & metrics
- Inline "Made with Reform." branding beside Submit; popup uses a full-width footer bar (Figma 26075-12633 / 25778-10461).
- Input fill height 28px → **30px** across field renderers, skeleton, node, and the `--bf-input-height` fallback.
- Matrix/linear-scale labels + value tiles at 14px; scale step is now a **typeable number input** (clamped to bounds); "Add Anchor" → "Scale Anchor" with the Figma glyph.

### Editor chrome / share
- Block gutter: drop tooltips on delete/add/drag; block menu locks settled side **and** align so view-morphs don't flip the popup.
- Dropdown item focus/open tint accent → secondary.
- Share tabs match Figma system-flat; Copy Link / Get Code weight + border fixes; sidebar + header system-flat pass; switch/divider fixes.

## Test plan
- `pnpm exec tsc --noEmit` — clean.
- Pre-commit (fmt/lint/knip) and pre-push (typecheck/test) hooks pass.
- Manual: Tab through a multi-step form's fields and buttons; confirm focus exits the editor at the final Submit; edit button labels inline; type/clamp scale step.