### PR TITLE
Editor: customize-sidebar, share/embed & form polish

### DIFF
--- a/src/components/elastic-slider/elastic-slider.tsx
+++ b/src/components/elastic-slider/elastic-slider.tsx
@@ -114,7 +114,11 @@ export const ElasticSlider = ({
           // --elastic-slider-tile-radius per row. Dark equivalents keep contrast on dark surfaces.
           "[--elastic-slider-tile-bg:var(--color-gray-300)] dark:[--elastic-slider-tile-bg:var(--color-gray-600)]",
           "[--elastic-slider-tile-radius:var(--elastic-slider-radius)]",
+          // Dot marks = gray/400 (Figma 25441-4850) — darker than the fill so they stay visible on it.
           "[--elastic-slider-hash:var(--color-gray-400)] dark:[--elastic-slider-hash:var(--color-gray-500)]",
+          // Line marks = gray/300 (Figma 25441-4645 stroke #E0E0E0, round cap) — matches the fill, so
+          // it reads on the track and blends into the filled tile, as in Figma. Token flips for dark.
+          "[--elastic-slider-line:var(--color-gray-300)]",
           "[--elastic-slider-handle:var(--color-gray-500)] dark:[--elastic-slider-handle:var(--color-gray-400)]",
           "[--elastic-slider-label:var(--muted-foreground)]",
           "[--elastic-slider-focus:var(--foreground)]",
@@ -205,7 +209,7 @@ const SliderHashMarks = ({ hashMarks }: { hashMarks: { pct: number; hidden: bool
       <div
         key={`hash-${pct}`}
         className={cn(
-          "absolute top-1/2 h-1.5 w-px -translate-x-1/2 -translate-y-1/2 rounded-full bg-(--elastic-slider-hash) rtl:translate-x-1/2",
+          "absolute top-1/2 h-1.5 w-px -translate-x-1/2 -translate-y-1/2 rounded-full bg-(--elastic-slider-line) rtl:translate-x-1/2",
           hidden && "opacity-0",
         )}
         style={{ left: `${pct}%` }}
@@ -303,7 +307,7 @@ const SliderLabels = ({ labelRef, valueRef, label, displayValue, endIcon }: Slid
       data-slot="elastic-slider-value"
       aria-hidden="true"
       className={cn(
-        "pointer-events-none absolute inset-e-3 top-1/2 inline-flex -translate-y-1/2 items-center font-mono text-sm/none font-medium transition-colors",
+        "pointer-events-none absolute inset-e-3 top-1/2 inline-flex -translate-y-1/2 items-center text-sm/none font-medium transition-colors",
         "text-(--elastic-slider-label) group-data-[active=true]/elastic-slider:text-(--elastic-slider-focus)",
       )}
     >

--- a/src/components/form-builder/embed-config-panel.tsx
+++ b/src/components/form-builder/embed-config-panel.tsx
@@ -184,7 +184,7 @@ export const selectTriggerCls =
  * Separate from `selectTriggerCls` so the embed panel's trigger stays unchanged.
  */
 export const selectTriggerFigmaCls =
-  "data-[size=default]:h-[24px] shrink-0 border-none bg-transparent shadow-none rounded-[5px] px-0 py-0 gap-1 w-auto text-[14px] leading-[1.15] text-gray-700 font-[450] font-case whitespace-nowrap [&_svg]:size-[10px] ";
+  "data-[size=default]:h-[24px] shrink-0 border-none bg-transparent shadow-none rounded-[5px] px-0 py-0 gap-1 w-auto text-[14px] leading-[1.15] text-gray-700 font-[450] font-case font-opsz-16 whitespace-nowrap [&_svg]:size-[10px] ";
 
 export const triggerLabels: Record<string, string> = {
   button: "On button click",

--- a/src/components/form-builder/share-summary-sidebar.tsx
+++ b/src/components/form-builder/share-summary-sidebar.tsx
@@ -1109,7 +1109,18 @@ const CustomDomainRow = ({
     () => (domains ?? []).filter((d) => d.status === "verified"),
     [domains],
   );
-  const hasDomains = verifiedDomains.length > 0;
+  // Always list the currently-assigned domain — even if it lost "verified" status or was deleted —
+  // so there's an unlink path (click it to deselect); else a stale customDomainId gets stranded.
+  const listedDomains = useMemo<{ id: string; domain: string }[]>(() => {
+    const base = verifiedDomains.map((d) => ({ id: d.id, domain: d.domain }));
+    if (!customDomainId || base.some((d) => d.id === customDomainId)) return base;
+    const assigned = (domains ?? []).find((d) => d.id === customDomainId);
+    return [
+      { id: customDomainId, domain: assigned?.domain ?? selectedDomainName ?? customDomainId },
+      ...base,
+    ];
+  }, [verifiedDomains, domains, customDomainId, selectedDomainName]);
+  const hasDomains = listedDomains.length > 0;
 
   const assignDomainMutation = useMutation({
     mutationFn: (domainId: string | null) =>
@@ -1167,7 +1178,7 @@ const CustomDomainRow = ({
                 {/* Single-select with toggle-off: the selected row shows a tick (SelectItem's built-in
                     indicator); clicking it again unlinks the domain so it's free for another form.
                     onValueChange doesn't fire on a same-value re-click, so deselect rides onClick. */}
-                {verifiedDomains.map((d) => (
+                {listedDomains.map((d) => (
                   <SelectItem
                     key={d.id}
                     value={d.id}

--- a/src/components/ui/color-picker.tsx
+++ b/src/components/ui/color-picker.tsx
@@ -278,7 +278,7 @@ export const ColorPicker = ({ label, value, onChange, className }: ColorPickerPr
             const normalized = raw.startsWith("#") ? raw : `#${raw}`;
             if (HEX_RE.test(normalized)) onChange(normalized);
           }}
-          className="w-[72px] bg-transparent text-right font-mono text-[13px] font-medium text-gray-700 uppercase tabular-nums outline-none"
+          className="w-[72px] bg-transparent text-right font-case text-[14px] leading-[1.15] font-[450] text-gray-700 uppercase tabular-nums outline-none font-opsz-16"
           maxLength={9}
         />
         <Popover>

--- a/src/components/ui/customize-sidebar.tsx
+++ b/src/components/ui/customize-sidebar.tsx
@@ -28,6 +28,7 @@ import { getHeaderMediaSetter } from "@/lib/editor/header-media-registry";
 import { useEditorColorMode } from "@/hooks/use-editor-color-mode";
 import { useEditorSidebar } from "@/hooks/use-editor-sidebar";
 import { useForm, useLocalForm } from "@/hooks/use-live-hooks";
+import { useMountEffect } from "@/hooks/use-mount-effect";
 import { FONT_REGISTRY } from "@/lib/theme/font-registry";
 import { OVERRIDABLE_TOKEN_NAMES, resolveEffectiveMode } from "@/lib/theme/generate-theme-css";
 import { loadGoogleFont } from "@/lib/theme/load-google-font";
@@ -92,8 +93,19 @@ const NumberRow = (props: React.ComponentProps<typeof StyleNumberInput>) => (
 // Figma radius variant (nodes 25441-4674 / 4850, 25446-4875): dot hash marks + a corner glyph in
 // the value slot. The glyph is LIVE — its corner radius scales with the row's value (square at 0,
 // full quarter-curve at max) and CSS-transitions between snap stops as you drag.
-const RadiusEndIcon = ({ value, max }: { value?: string; max: number }) => {
-  const n = Number.parseFloat(value ?? "") || 0;
+// `autoValue` = the radius the row renders at when unset (Auto) — i.e. the CSS var() fallback
+// (cover 0, logo 6, input/button 8). The glyph reflects that so Auto shows the real curve, not 0.
+const RadiusEndIcon = ({
+  value,
+  max,
+  autoValue = 0,
+}: {
+  value?: string;
+  max: number;
+  autoValue?: number;
+}) => {
+  const parsed = Number.parseFloat(value ?? "");
+  const n = Number.isFinite(parsed) ? parsed : autoValue;
   const r = (Math.min(Math.max(n, 0), max) / max) * 7;
   return (
     <span aria-hidden className="flex size-4 items-center justify-center text-gray-700">
@@ -366,7 +378,7 @@ export const CustomizeSidebar = ({ formId, isLocal }: CustomizeSidebarProps) => 
     editorColorMode,
   );
 
-  useEffect(() => () => setEditorColorMode(null), [setEditorColorMode]);
+  useMountEffect(() => () => setEditorColorMode(null));
   const activeFont = getValue("font");
 
   const cssKey = `${activeMode}:customCss`;
@@ -572,7 +584,7 @@ const AppearanceSection = ({
       unit="px"
       displayUnit=""
       markStyle="dot"
-      endIcon={<RadiusEndIcon value={customization.logoRadius} max={48} />}
+      endIcon={<RadiusEndIcon value={customization.logoRadius} max={48} autoValue={6} />}
       className={CONFIG_INPUT_CLS}
     />
     <ConfigRow label="Theme" surface="flat">
@@ -606,7 +618,7 @@ const CoverPickerButton = ({
       type="button"
       disabled={!onCoverChange}
       title={cover ? "Edit cover" : "Add cover"}
-      className="flex items-center gap-1.5 text-[14px] font-[450] text-gray-700 enabled:cursor-pointer disabled:cursor-default"
+      className="flex items-center gap-1.5 font-case text-[14px] leading-[1.15] font-[450] text-gray-700 font-opsz-16 enabled:cursor-pointer disabled:cursor-default"
     >
       {cover ? (
         <>
@@ -659,7 +671,7 @@ const LogoPickerButton = ({
       type="button"
       disabled={!onIconChange}
       title={logo ? "Edit logo" : "Add logo"}
-      className="flex items-center gap-1.5 text-[14px] font-[450] text-gray-700 enabled:cursor-pointer disabled:cursor-default"
+      className="flex items-center gap-1.5 font-case text-[14px] leading-[1.15] font-[450] text-gray-700 font-opsz-16 enabled:cursor-pointer disabled:cursor-default"
     >
       {logo ? (
         <>
@@ -870,7 +882,6 @@ const InputsSection = ({
         max={64}
         step={1}
         unit="px"
-        displayUnit=""
         className={CONFIG_INPUT_CLS}
       />
       <NumberRow
@@ -886,7 +897,7 @@ const InputsSection = ({
         unit="px"
         displayUnit=""
         markStyle="dot"
-        endIcon={<RadiusEndIcon value={customization.inputRadius} max={32} />}
+        endIcon={<RadiusEndIcon value={customization.inputRadius} max={32} autoValue={8} />}
         className={CONFIG_INPUT_CLS}
       />
       <NumberRow
@@ -900,7 +911,6 @@ const InputsSection = ({
         max={64}
         step={2}
         unit="px"
-        displayUnit=""
         className={CONFIG_INPUT_CLS}
       />
       <NumberRow
@@ -914,7 +924,6 @@ const InputsSection = ({
         max={32}
         step={1}
         unit="px"
-        displayUnit=""
         className={CONFIG_INPUT_CLS}
       />
     </div>
@@ -939,7 +948,6 @@ const ButtonsSection = ({
         max={400}
         step={4}
         unit="px"
-        displayUnit=""
         className={CONFIG_INPUT_CLS}
       />
       <NumberRow
@@ -953,7 +961,6 @@ const ButtonsSection = ({
         max={64}
         step={1}
         unit="px"
-        displayUnit=""
         className={CONFIG_INPUT_CLS}
       />
       <NumberRow
@@ -969,7 +976,7 @@ const ButtonsSection = ({
         unit="px"
         displayUnit=""
         markStyle="dot"
-        endIcon={<RadiusEndIcon value={customization.buttonRadius} max={32} />}
+        endIcon={<RadiusEndIcon value={customization.buttonRadius} max={32} autoValue={8} />}
         className={CONFIG_INPUT_CLS}
       />
       {/* Aligns ONLY the action button within the form column (--bf-button-justify), not the doc. */}

--- a/src/components/ui/style-controls.tsx
+++ b/src/components/ui/style-controls.tsx
@@ -106,7 +106,7 @@ export const StyleNumberInput = ({
           ? "[&_[data-slot=elastic-slider-label]]:inset-s-1.5 [&_[data-slot=elastic-slider-label]]:text-[14px] [&_[data-slot=elastic-slider-label]]:leading-[1.15] [&_[data-slot=elastic-slider-label]]:font-[400] [&_[data-slot=elastic-slider-label]]:text-muted-foreground"
           : "[&_[data-slot=elastic-slider-label]]:inset-s-2 [&_[data-slot=elastic-slider-label]]:text-base [&_[data-slot=elastic-slider-label]]:font-normal",
         bare
-          ? "[&_[data-slot=elastic-slider-value]]:inset-e-1.5 [&_[data-slot=elastic-slider-value]]:text-[14px] [&_[data-slot=elastic-slider-value]]:leading-[1.15] [&_[data-slot=elastic-slider-value]]:font-[450] [&_[data-slot=elastic-slider-value]]:text-gray-700 [&_[data-slot=elastic-slider-value]]:tabular-nums"
+          ? "[&_[data-slot=elastic-slider-value]]:inset-e-1.5 [&_[data-slot=elastic-slider-value]]:font-case [&_[data-slot=elastic-slider-value]]:text-[14px] [&_[data-slot=elastic-slider-value]]:leading-[1.15] [&_[data-slot=elastic-slider-value]]:font-[450] [&_[data-slot=elastic-slider-value]]:text-gray-700 [&_[data-slot=elastic-slider-value]]:tabular-nums [&_[data-slot=elastic-slider-value]]:font-opsz-16"
           : "[&_[data-slot=elastic-slider-value]]:inset-e-[11px] [&_[data-slot=elastic-slider-value]]:text-[13px] [&_[data-slot=elastic-slider-value]]:tabular-nums",
         className,
       )}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -692,6 +692,11 @@
   font-feature-settings: "case";
 }
 
+/* opsz 16 = Figma value-cell optical size (labels stay at axis-default 14). Re-binds wght so font-[450] still drives weight. */
+@utility font-opsz-16 {
+  font-variation-settings: "opsz" 16, "wght" var(--tw-font-weight, 450);
+}
+
 /* Canonical text-input box used by Input/Email/Number/Link/Textarea/Time/
    Phone/FileUpload field widgets. Matches the editor's form-field-node
    spec from Figma (gray/50 fill, 8px radius, hairline drop shadow) in both
@@ -1070,6 +1075,15 @@
 .bf-themed [data-bf-field-list] [data-slate-editor] *:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6),
 .bf-themed [data-bf-form-container] [data-slate-editor] *:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6) {
   font-size: inherit;
+}
+
+/* Line height: form body content (NOT headings/title). The Line-height control sets --bf-line-height,
+   but the text-* utilities pin every text element's line-height to 1.15, overriding the inherited
+   value on .bf-themed — so force the var on the leaf body text (editor + preview + public). Title +
+   header subtree keep their own (--bf-title-line-height). Unset = 1.15 (current default, no change). */
+.bf-themed [data-bf-field-list] *:not(h1, h2, h3, h4, h5, h6):not([data-bf-header]):not([data-bf-header] *),
+.bf-themed [data-bf-form-container] *:not(h1, h2, h3, h4, h5, h6):not([data-bf-header]):not([data-bf-header] *) {
+  line-height: var(--bf-line-height, 1.15);
 }
 
 /* Spacing tokens — adjust these to experiment with the form layout:


### PR DESCRIPTION
Merges the `dev` editor/customize work into `main` (21 commits).

## Highlights
- **Customize sidebar pass** — binary dropdowns → click-to-toggle (`ToggleSelect`), pill toggles, Figma typography (font-[420], 13px scope triggers), removed PRO badges, alignment moved to Buttons (button-scoped via `--bf-button-justify`).
- **Form/editor theme** — `editorColorMode` scopes the Colors light/dark + Theme toggle to the form preview only (no longer flips the whole app); shared `resolveEffectiveMode` helper.
- **Share/embed** — Embed/Popup/Full-page tabs match Figma; custom-domain row is a button when none configured and a dropdown with select/unlink when domains exist; Share button always shown (disabled until published); inline + popup "Made with Reform." branding; preview scroll-fade gradient no longer dims the form itself.
- **Recent fixes** — px units on size rows, radius glyph reflects the Auto default, body **line-height** now applies in editor/preview/public, branding toggle reads the live draft setting, sidebars use static imports (no lazy flash), Settings removed from the app sidebar (lives in the profile popup), share-tab→other-sidebar no longer pops the preview drawer.

## Verification
- `tsc --noEmit`, oxlint, knip, oxfmt — all clean (pre-commit + pre-push hooks passed, incl. tests).
- Code-reviewed the session diff (8-angle review); fixed the surfaced issues (stale custom-domain unlink, `useMountEffect` convention).