### PR TITLE
Promote dev → main: prod image optimizer fix, theming, template thumbnails, inbox restyle

### DIFF
--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -1376,7 +1376,7 @@ const InboxPanelBody = ({ onClose, headerLeft }: InboxPanelBodyProps) => {
               <div className="flex flex-col gap-5 pt-1.5 pb-3.5">
                 {groupNotificationsByDay(notifications).map((group) => (
                   <div key={group.label} className="flex flex-col gap-2">
-                    <p className="pl-4 text-sm leading-[1.15] font-[450] tracking-[0.13px] text-gray-800">
+                    <p className="pl-4 text-sm leading-[1.15] font-[450] tracking-[0.13px] text-gray-500">
                       {group.label}
                     </p>
                     <div className="flex flex-col">
@@ -1390,26 +1390,18 @@ const InboxPanelBody = ({ onClose, headerLeft }: InboxPanelBodyProps) => {
                           <button
                             key={notification.id}
                             type="button"
-                            className="group flex flex-col gap-1.5 border-b border-gray-200 px-2 py-3 text-left transition-colors hover:rounded-[8px] hover:border-transparent hover:bg-gray-100"
+                            className="group flex w-full items-center gap-1.5 border-b border-gray-200 px-2 py-3 text-left transition-colors hover:rounded-[8px] hover:border-transparent hover:bg-gray-100"
                             onClick={() => void openNotification(notification)}
                             disabled={readingFormId === notification.formId}
                           >
-                            {/* Top: category + time — 13px / Medium 450 / gray-550. */}
-                            <div className="flex w-full items-center justify-between">
-                              <span className="flex items-center gap-1.5">
-                                <FileTextIcon className="size-3 shrink-0 text-[var(--color-gray-550)]" />
-                                <span className="text-sm leading-[1.15] font-[450] tracking-[0.13px] text-[var(--color-gray-550)]">
-                                  New submission
-                                </span>
-                              </span>
+                            {/* Message — 14px / Medium 450 / gray-800 / lh 1.5 (Figma 27015:15776). */}
+                            <span className="min-w-0 flex-1 text-base leading-[1.5] font-[450] tracking-[0.14px] text-gray-800">
+                              {notification.formTitle || "Untitled"}
+                            </span>
+                            {/* Right cluster — time (13px / gray-550) + unread dot / hover-clear (Figma 27015:15777). */}
+                            <span className="flex shrink-0 items-center gap-0.5">
                               <span className="text-sm leading-[1.15] font-[450] tracking-[0.13px] text-[var(--color-gray-550)]">
                                 {formatNotificationClock(notification.latestSubmissionAt)}
-                              </span>
-                            </div>
-                            {/* Body: message — 14px / Medium 450 / gray-700 / lh 1.5 — + unread dot or hover-clear. */}
-                            <div className="flex w-full items-end gap-4">
-                              <span className="min-w-0 flex-1 text-base leading-[1.5] font-[450] tracking-[0.14px] text-gray-700">
-                                {notification.formTitle || "Untitled"}
                               </span>
                               {isUnread ? (
                                 <span
@@ -1434,7 +1426,7 @@ const InboxPanelBody = ({ onClose, headerLeft }: InboxPanelBodyProps) => {
                                   <XIcon className="size-3" />
                                 </Button>
                               )}
-                            </div>
+                            </span>
                           </button>
                         );
                       })}

--- a/src/routes/_authenticated/dashboard.tsx
+++ b/src/routes/_authenticated/dashboard.tsx
@@ -638,12 +638,12 @@ const DashboardPage = () => {
           />
         </section>
 
-        {/* Recent Forms */}
+        {/* All Forms */}
         <section className="mt-10 space-y-5">
           <div className="flex items-center justify-between gap-3">
             {/* font-sans re-binds the wght axis so font-semibold renders 600 (Figma SemiBold), not the pinned 450. */}
             <h2 className="font-sans text-[15px] leading-[1.15] font-semibold tracking-[0.225px] text-gray-950">
-              Recent Forms
+              All Forms
             </h2>
             {!isLoading && orgForms.length > 0 && (
               <div className="flex items-center gap-2">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -126,6 +126,23 @@ const config = defineConfig({
             { path: "/api/cron/aggregate-analytics", schedule: "15 0 * * *" },
             { path: "/api/cron/purge-archived-forms", schedule: "30 0 * * *" },
           ],
+          // Provision Vercel's image optimizer (/_vercel/image) for Vercel-Blob covers/previews/
+          // avatars. Unlike Next.js, Nitro/TanStack Start doesn't enable it automatically, so the
+          // Build Output config must declare it — without this the endpoint 404s in prod.
+          // `sizes` MUST list every `w` <Image> requests (w= must match exactly, else 400); keep it
+          // in sync with the widths passed in src/components/ui/image.tsx + lib/vercel-image.ts.
+          images: {
+            sizes: [
+              16, 24, 32, 48, 64, 72, 80, 120, 144, 160, 240, 400, 640, 800, 960, 1200, 1280, 1600,
+              1920, 2048,
+            ],
+            domains: [],
+            remotePatterns: [
+              { protocol: "https", hostname: "*.public.blob.vercel-storage.com", pathname: "/**" },
+            ],
+            formats: ["image/avif", "image/webp"],
+            minimumCacheTTL: 86400,
+          },
         },
       },
       routeRules: {


### PR DESCRIPTION
Promotes accumulated `dev` work to `main`. Highlights from the latest batch:

## Production fix
- **Vercel image optimizer** — `<Image>` rewrites Vercel-Blob URLs to `/_vercel/image` in prod, but Nitro/TanStack Start doesn't provision that endpoint automatically like Next.js, so Blob-backed covers/previews/avatars were **404'ing in production**. Added an `images` block to the Build Output config (`sizes` for every requested width + blob `remotePattern`); verified emitted into `.vercel/output/config.json` via a `NITRO_PRESET=vercel` build.
  - ⚠️ Maintenance note: `sizes` must list every `w` that `<Image>` requests — the optimizer 400s on unlisted widths. New call sites with novel widths must be added.

## Forms / theming
- Auto-contrast theme tokens (input/badge ink + surfaces) so customized forms stay legible on any Input/Button color.
- `<img>` → `<Image>` migration across covers, icons, avatars, card thumbnails.
- Pre-rendered light/dark template preview thumbnails on gallery cards.
- `form-input-error` as an `!important` box-shadow ring (beats `form-input`'s border).
- Inline templates-gallery search + "Thank you" page slash command.

## Dashboard / inbox
- Rename "Recent Forms" heading → "All Forms".
- Notification rows restyled to the Figma single-line layout (title + time + unread dot); day labels recolored to gray-500.

Pre-push typecheck + full test suite (925 tests) passed on the latest push.