### PR TITLE
fix(forms): footer branding, Back/Submit buttons, borderless embed, popup Figma match

### DIFF
--- a/src/components/form-components/form-preview-rsc.tsx
+++ b/src/components/form-components/form-preview-rsc.tsx
@@ -133,18 +133,23 @@ const StepButton = ({
   grouped?: boolean;
   totalSteps?: number;
 }) => {
+  const { t } = useTranslation();
   const buttonStyle = { fontSize: "13px" } as const;
 
   if (buttonRole === "previous") {
     const button = (
+      // Ghost + dark text (Figma 27112-20305 "Back") — never a filled primary, which would clash
+      // with the themed Submit/Next.
       <Button
         type="button"
+        variant="ghost-flat"
         onClick={onPrevious}
         style={buttonStyle}
-        className="h-8 gap-1.5 rounded-lg px-2.5"
+        className="h-8 gap-1.5 rounded-lg px-2.5 text-gray-900"
         prefix={<ChevronLeftIcon className="size-4" />}
       >
-        {buttonText}
+        {/* Always "Back" (like the one-at-a-time footer) — ignore any authored/legacy "Previous" text. */}
+        {t("back")}
       </Button>
     );
     return grouped ? (
@@ -180,10 +185,12 @@ const StepButton = ({
   // Submit
   const isMultiStep = totalSteps > 1;
   const submitButton = (
+    // Trailing chevron matches the Next button (Figma "→") and keeps the last glyph from clipping.
     <Button
       type="submit"
       style={buttonStyle}
       className="h-8 gap-1.5 rounded-lg px-2.5"
+      suffix={<ChevronRightIcon className="size-4" />}
       disabled={isSubmitting}
     >
       {buttonText}
@@ -383,35 +390,37 @@ const StepFormRSC = ({
           : action?.buttonText || actionDefaultText;
 
       return (
+        // Prev + Next/Submit grouped left (8px gap), branding pushed right (Figma 27112-20305).
         <div
-          className="flex w-full flex-row-reverse items-center justify-between"
+          className="flex w-full items-center justify-between gap-3"
           style={{ maxWidth: "var(--bf-input-width)" }}
         >
-          {action && !(hideSubmit && actionRole === "submit") && (
-            <StepButton
-              buttonText={actionText}
-              buttonRole={actionRole}
-              isSubmitting={isSubmitting}
-              onPrevious={canGoBack ? goToPrevStep : undefined}
-              grouped
-              totalSteps={totalSteps}
-            />
-          )}
-          {prev ? (
-            <StepButton
-              buttonText={prev.buttonText || t("previous")}
-              buttonRole="previous"
-              isSubmitting={isSubmitting}
-              onPrevious={canGoBack ? goToPrevStep : undefined}
-              grouped
-            />
-          ) : (
-            <div />
-          )}
+          <div className="flex items-center gap-2">
+            {prev && (
+              <StepButton
+                buttonText={prev.buttonText || t("previous")}
+                buttonRole="previous"
+                isSubmitting={isSubmitting}
+                onPrevious={canGoBack ? goToPrevStep : undefined}
+                grouped
+              />
+            )}
+            {action && !(hideSubmit && actionRole === "submit") && (
+              <StepButton
+                buttonText={actionText}
+                buttonRole={actionRole}
+                isSubmitting={isSubmitting}
+                onPrevious={canGoBack ? goToPrevStep : undefined}
+                grouped
+                totalSteps={totalSteps}
+              />
+            )}
+          </div>
+          {branding && <FormBrandingBadge />}
         </div>
       );
     },
-    [t, isSubmitting, canGoBack, goToPrevStep, totalSteps, hideSubmit],
+    [t, isSubmitting, canGoBack, goToPrevStep, totalSteps, hideSubmit, branding],
   );
 
   return (

--- a/src/components/form-components/step-form.tsx
+++ b/src/components/form-components/step-form.tsx
@@ -70,8 +70,9 @@ export const StepForm = ({
   });
 
   const groupedItems = useMemo(() => groupSegmentsForRendering(segments), [segments]);
-  // Branding only rides the final Submit row (last step).
-  const showBranding = branding && isLastStep;
+  // Branding rides EVERY step's action row (Next and Submit), not just the final Submit — so
+  // multi-step card forms show "Made with Reform." throughout, matching one-at-a-time (Figma 27112-20324).
+  const showBranding = branding;
 
   const formRef = useRef<HTMLFormElement>(null);
   const [isTextareaFocused, setIsTextareaFocused] = useState(false);
@@ -181,12 +182,21 @@ export const StepForm = ({
             const groupKey = `button-group-${item.buttons.map((b) => b.id).join("-")}`;
 
             return (
+              // Prev + Next/Submit grouped left (8px gap), branding pushed right (Figma 27112-20305).
               <div
                 key={groupKey}
-                className="flex w-full flex-col gap-2"
+                className="flex w-full items-center justify-between gap-3"
                 style={{ maxWidth: "var(--bf-input-width)" }}
               >
-                <div className="flex w-full flex-row-reverse items-center justify-between">
+                <div className="flex items-center gap-2">
+                  {prevButton && (
+                    <RenderStepButton
+                      field={prevButton}
+                      isSubmitting={isSubmitting}
+                      onPrevious={canGoBack ? goToPrevStep : undefined}
+                      grouped
+                    />
+                  )}
                   {actionButton && (
                     <RenderStepButton
                       field={actionButton}
@@ -196,23 +206,8 @@ export const StepForm = ({
                       grouped
                     />
                   )}
-                  {prevButton ? (
-                    <RenderStepButton
-                      field={prevButton}
-                      isSubmitting={isSubmitting}
-                      onPrevious={canGoBack ? goToPrevStep : undefined}
-                      grouped
-                    />
-                  ) : (
-                    <div /> // Spacer for justify-between
-                  )}
                 </div>
-                {/* Multi-step submit row is full (Prev + Submit) — branding sits right-aligned below. */}
-                {showBranding && (
-                  <div className="flex justify-end">
-                    <FormBrandingBadge />
-                  </div>
-                )}
+                {showBranding && <FormBrandingBadge />}
               </div>
             );
           }
@@ -451,14 +446,18 @@ const RenderStepButton = ({
 
   if (buttonRole === "previous") {
     const button = (
+      // Ghost + dark text (Figma 27112-20305 "Back") — never a filled primary, which would clash
+      // with the themed Submit/Next.
       <Button
         type="button"
+        variant="ghost-flat"
         onClick={onPrevious}
         style={buttonStyle}
-        className="h-8 gap-1.5 rounded-lg px-2.5"
+        className="h-8 gap-1.5 rounded-lg px-2.5 text-gray-900"
         prefix={<ChevronLeftIcon className="size-4" />}
       >
-        {buttonText}
+        {/* Always "Back" (like the one-at-a-time footer) — ignore any authored/legacy "Previous" text. */}
+        {t("back")}
       </Button>
     );
     return grouped ? (
@@ -485,32 +484,37 @@ const RenderStepButton = ({
     return grouped ? (
       button
     ) : (
+      // Branding rides the Next row right-aligned (justify-between) — same as the Submit row — so
+      // intermediate steps of a multi-step card form stay branded. Without branding, honor
+      // --bf-button-justify (Buttons → Alignment), fallback right.
       <div
-        className="mb-4 flex"
+        className={`mb-4 flex items-center ${showBranding ? "justify-between gap-3" : ""}`}
         style={{
           maxWidth: "var(--bf-input-width)",
-          // Button alignment (Buttons → Alignment); fallback keeps the prior right-aligned default.
-          justifyContent: "var(--bf-button-justify, flex-end)",
+          ...(showBranding ? {} : { justifyContent: "var(--bf-button-justify, flex-end)" }),
         }}
       >
         {button}
+        {showBranding && <FormBrandingBadge />}
       </div>
     );
   }
 
   const isMultiStep = totalSteps > 1;
   const submitButton = (
+    // Trailing chevron matches the Next button (Figma "→"); it also gives the TextSwap span trailing
+    // room so `.bf-themed` letter-spacing doesn't clip the last glyph ("Submit" → "Submi").
     <Button
       type="submit"
       data-bf-button
       style={buttonStyle}
       className="h-8 gap-1.5 rounded-lg px-2.5"
+      suffix={<ChevronRightIcon className="size-4" />}
       disabled={isSubmitting}
     >
-      {(() => {
-        const label = isSubmitting ? t("submitting") : buttonText;
-        return <TextSwap key={label}>{label}</TextSwap>;
-      })()}
+      {/* Render text directly (not TextSwap) — the inline-block+blur span clipped the last glyph
+          ("Submit" → "Submi"); the Next button and live renderer render text directly too. */}
+      {isSubmitting ? t("submitting") : buttonText}
     </Button>
   );
   return grouped ? (

--- a/src/components/ui/form-button-node.tsx
+++ b/src/components/ui/form-button-node.tsx
@@ -19,7 +19,7 @@ export interface FormButtonElementData {
 }
 
 export const createFormButtonNode = (role: ButtonRole, text?: string): FormButtonElementData => {
-  const defaultText = role === "next" ? "Next" : role === "previous" ? "Previous" : "Submit";
+  const defaultText = role === "next" ? "Next" : role === "previous" ? "Back" : "Submit";
   return {
     type: "formButton",
     buttonRole: role,
@@ -33,7 +33,7 @@ const getPlaceholderForRole = (role: ButtonRole): string => {
     case "next":
       return "Next";
     case "previous":
-      return "Previous";
+      return "Back";
     case "submit":
       return "Submit";
     default:
@@ -59,9 +59,12 @@ export const FormButtonElement = ({ children, ...props }: PlateElementProps) => 
   );
 
   // Get label from element property (fallback to children for backwards compat)
-  const label =
+  const rawLabel =
     (element.label as string) ??
     extractTextFromChildren(element.children as Array<{ text?: string }>);
+  // Back button is a fixed nav affordance — surface "Back" for legacy "Previous"/empty labels so the
+  // editor matches the preview/live (which always render "Back").
+  const label = isPrevious && (!rawLabel || rawLabel === "Previous") ? "Back" : rawLabel;
 
   // Inline-editable label: a native input (Slate ignores it — parent is contentEditable=false)
   // edits element.label directly, the same property the transform reads first. Local state controls
@@ -178,6 +181,10 @@ export const FormButtonElement = ({ children, ...props }: PlateElementProps) => 
             onPointerDown={stopPointer}
             onClick={stopPointer}
             aria-label="Button label"
+            // letterSpacing:normal — the .bf-themed `* { letter-spacing }` makes field-sizing-content
+            // undersize by ~1px, clipping the last glyph ("Submit" → "Submi"). Inline wins over the
+            // unlayered global rule.
+            style={{ letterSpacing: "normal" }}
             className="field-sizing-content min-w-[2ch] cursor-text bg-transparent text-center text-inherit outline-none placeholder:text-current/60"
           />
           {buttonRole === "submit" && <CheckIcon className="size-4" />}

--- a/src/lib/editor/transform-plate-for-preview.ts
+++ b/src/lib/editor/transform-plate-for-preview.ts
@@ -350,8 +350,7 @@ const createSegments = (nodes: Value): PreviewSegment[] => {
       const btnText =
         (node.label as string | undefined) || childText || (node.buttonText as string | undefined);
       const btnRole = (node.buttonRole as "next" | "previous" | "submit") || "submit";
-      const defaultText =
-        btnRole === "next" ? "Next" : btnRole === "previous" ? "Previous" : "Submit";
+      const defaultText = btnRole === "next" ? "Next" : btnRole === "previous" ? "Back" : "Submit";
       const name = `button_${fieldIndex}`;
 
       segments.push({

--- a/src/lib/editor/transform-plate-to-form.ts
+++ b/src/lib/editor/transform-plate-to-form.ts
@@ -747,8 +747,7 @@ export const transformPlateStateToFormElements = (rawValue: Value): TransformedE
       const btnText =
         (node.label as string | undefined) || childText || (node.buttonText as string | undefined);
       const btnRole = (node.buttonRole as "next" | "previous" | "submit") || "submit";
-      const defaultText =
-        btnRole === "next" ? "Next" : btnRole === "previous" ? "Previous" : "Submit";
+      const defaultText = btnRole === "next" ? "Next" : btnRole === "previous" ? "Back" : "Submit";
       const name = `button_${fieldIndex}`;
       elements.push({
         id: name,

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
@@ -267,11 +267,11 @@ const EmbedPreviewSurface = ({
                 <div
                   ref={setEmbedFrame}
                   className={cn(
-                    "w-full overflow-hidden rounded-2xl transition-all duration-200",
+                    // No card frame (border/radius/shadow) — the real embed iframe is frameborder=0,
+                    // so the preview must match live: borderless form on the host page (Figma 25724-11834).
+                    "w-full overflow-hidden transition-all duration-200",
                     dynamicWidth ? "" : "max-w-[460px]",
-                    transparentBackground
-                      ? "bg-transparent"
-                      : "border border-border bg-background shadow-sm",
+                    transparentBackground ? "bg-transparent" : "bg-background",
                   )}
                   style={{
                     height: dynamicHeight ? "auto" : height,


### PR DESCRIPTION
Form-rendering fixes across the **editor, in-app preview, and live/published** surfaces, matching the system-flat Figma. Three commits:

## 1. Borderless standard embed (`preview-mode.tsx`)
The editor's standard-embed preview wrapped the form in a rounded border+shadow card, but the real embed iframe is `frameborder=0` and the live form has no such frame (Figma 25724-11834). Now borderless, matching live.

## 2. Multi-step card footer + buttons (`step-form.tsx`, `form-preview-rsc.tsx`, `form-button-node.tsx`, transforms)
- **Branding on every card step** (not just the final Submit), matching one-at-a-time (Figma 27112-20305/20324).
- **Grouped footer**: Prev + Next/Submit on the left, branding pushed right (one `justify-between` row).
- **Back button**: ghost + dark text, always labelled "Back" (never a filled primary); legacy "Previous" content surfaces as "Back" in the editor too.
- **Submit**: trailing chevron; fixed the editor label input clipping the last glyph (`.bf-themed` letter-spacing undersized `field-sizing-content` → pinned `letter-spacing: normal`).

## 3. Popup Figma match (`popup-style.ts`, `styles.css`, `embed/*`, `public-form-page.tsx`)
- **Cover**: compact 134px banner, no bottom fade/blur dissolve, no ambient glow (Figma 26889-14091) — those belong to the full-page cover.
- **Radius**: popup frame + cover top follow the **Cover-radius** customization (`--bf-cover-radius`); cover bottom stays flush over the fields (new `--bf-cover-radius-b` bottom-only override; full-page covers unchanged). Live host frame radius is posted to `popup.js` via `Reform.FormLoaded`.
- **Dark overlay**: black 24% + 6px backdrop blur (Figma 27196-14471) across the live overlay, editor preview, and the Share-panel mockup.

## Verification
- `tsc --noEmit`, `oxfmt --check`, pre-commit `lint`/`knip`, and pre-push `typecheck`/`test` all pass (pre-existing warnings only).
- Preview + editor surfaces verified live via the in-app browser (measured computed styles + screenshots against Figma).
- **Live caveat**: the embed-bundle changes (`popup.js` frame-radius messaging, `.bf-overlay` blur) can't be verified in the local editor preview — they need the embed script rebuilt and tested on a real host page. Failures degrade gracefully (frame stays at its prior default).