### PR TITLE
fix(popup): match Figma cover, radius, and dark overlay

### DIFF
--- a/src/components/form-builder/embed-preview-mockup.tsx
+++ b/src/components/form-builder/embed-preview-mockup.tsx
@@ -316,7 +316,8 @@ export const EmbedPreviewMockup = ({
           {isPopup && darkOverlay && isPopupExpanded && (
             <motion.div
               key="dark-overlay"
-              className="absolute inset-0 z-10 bg-black/30"
+              // Match the real popup dark overlay (Figma 27196-14471): black 24% + backdrop blur.
+              className="absolute inset-0 z-10 bg-black/24 backdrop-blur-[6px]"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}

--- a/src/embed/embed-popup.ts
+++ b/src/embed/embed-popup.ts
@@ -163,6 +163,13 @@ const handleMessage = (event: MessageEvent): void => {
       if (instance.loadingEl) {
         hideLoading(instance.loadingEl);
       }
+      // Match the popup frame radius to the form's cover radius (else the fixed 12px frame corners
+      // clip a larger cover radius, leaving a sliver).
+      if (data.frameRadius) {
+        instance.container.style.borderRadius = data.frameRadius;
+        const iframeContainer = instance.iframe.parentElement;
+        if (iframeContainer) iframeContainer.style.borderRadius = data.frameRadius;
+      }
       break;
 
     case "Reform.Resize":

--- a/src/embed/lib/styles.ts
+++ b/src/embed/lib/styles.ts
@@ -42,7 +42,10 @@ const STYLES = `
   position: fixed;
   inset: 0;
   z-index: 2147483000;
-  background-color: rgba(0, 0, 0, 0.5);
+  /* Dark overlay (Figma 27196-14471): black 24% + 6px backdrop blur. */
+  background-color: rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/embed/lib/types.ts
+++ b/src/embed/lib/types.ts
@@ -61,7 +61,8 @@ export interface PopupInstance {
 
 /** Events sent from iframe to parent */
 export type IframeEvent =
-  | { event: "Reform.FormLoaded"; formId: string }
+  // frameRadius: the form's popup cover radius (--bf-cover-radius) so the host-page frame matches it.
+  | { event: "Reform.FormLoaded"; formId: string; frameRadius?: string }
   | { event: "Reform.Resize"; height: number }
   | {
       event: "Reform.FormSubmitted";

--- a/src/lib/popup-style.ts
+++ b/src/lib/popup-style.ts
@@ -11,6 +11,14 @@ export const POPUP_FORM_STYLE_VARS = {
   "--bf-cover-w": "100%",
   "--bf-cover-mx": "0px",
   "--bf-cover-x": "0%",
+  // Popup cover is a compact, clipped banner (Figma 26889-14091): fixed 134px, no bottom
+  // fade/blur dissolve and no ambient glow (those belong to the full-page/embed cover).
+  "--bf-cover-height": "134px",
+  "--bf-cover-fade": "none",
+  "--bf-cover-glow": "none",
+  // Cover keeps its top radius (--bf-cover-radius, matching the popup frame) but its BOTTOM corners
+  // are flush against the form body — otherwise a full cover radius notches over the fields.
+  "--bf-cover-radius-b": "0px",
   "--bf-title-font-size": "24px",
   "--bf-title-letter-spacing": "-0.72px",
 } as CSSProperties;

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
@@ -432,7 +432,8 @@ const PopupPreviewOverlay = ({
       {darkOverlay && isPopupOpen && (
         <button
           type="button"
-          className="pointer-events-auto absolute inset-0 z-10 size-full cursor-default border-none bg-black/36 backdrop-blur-sm transition-opacity duration-300"
+          // Dark overlay (Figma 27196-14471): black 24% + 6px backdrop blur.
+          className="pointer-events-auto absolute inset-0 z-10 size-full cursor-default border-none bg-black/24 backdrop-blur-[6px] transition-opacity duration-300"
           onClick={handleClosePopup}
           aria-label="Close preview"
         />
@@ -441,8 +442,9 @@ const PopupPreviewOverlay = ({
       {isPopupOpen && (
         <div
           ref={setPopupEl}
-          // Figma 26889:14685 — 20px radius, elevation/light/xl shadow, no border.
-          className="pointer-events-auto absolute z-20 flex flex-col overflow-hidden rounded-[20px] bg-background shadow-[0px_0px_1px_0px_rgba(0,0,0,0.2),0px_0px_10px_2px_rgba(0,0,0,0.04),0px_24px_30px_-8px_rgba(0,0,0,0.1)] transition-[top,left,transform] duration-300 ease-out"
+          // Frame radius follows the Cover-radius customization (--bf-cover-radius) so top + bottom
+          // match the cover; 20px fallback for unthemed forms (Figma 26889:14685).
+          className="pointer-events-auto absolute z-20 flex flex-col overflow-hidden rounded-[var(--bf-cover-radius,20px)] bg-background shadow-[0px_0px_1px_0px_rgba(0,0,0,0.2),0px_0px_10px_2px_rgba(0,0,0,0.04),0px_24px_30px_-8px_rgba(0,0,0,0.1)] transition-[top,left,transform] duration-300 ease-out"
           style={{
             width: popupWidth,
             ...(popupPosition === "center"

--- a/src/routes/forms/-components/public-form-page.tsx
+++ b/src/routes/forms/-components/public-form-page.tsx
@@ -225,7 +225,14 @@ const useIframeResizeNotifier = (
     if ((!isPopup && !dynamicHeight) || typeof window === "undefined" || window.parent === window)
       return;
 
-    sendToParent("Reform.FormLoaded", { formId });
+    // Tell the host-page popup frame (popup.js) to match the form's cover radius so its rounded
+    // corners line up with the cover instead of a fixed default.
+    const frameRadius =
+      isPopup && containerRef.current
+        ? getComputedStyle(containerRef.current).getPropertyValue("--bf-cover-radius").trim() ||
+          undefined
+        : undefined;
+    sendToParent("Reform.FormLoaded", { formId, frameRadius });
 
     let lastHeight = 0;
     let resizeTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -887,8 +887,11 @@
 
 .bf-themed [data-bf-cover] {
   height: var(--bf-cover-height);
-  /* unset = current square cover; overflow clips img once a radius is set */
-  border-radius: var(--bf-cover-radius, 0);
+  /* unset = current square cover; overflow clips img once a radius is set. Bottom corners default
+     to the cover radius, but the popup zeroes them (--bf-cover-radius-b: 0) so the popup cover's
+     bottom stays flush over the fields while its top still follows the cover radius. */
+  border-radius: var(--bf-cover-radius, 0) var(--bf-cover-radius, 0)
+    var(--bf-cover-radius-b, var(--bf-cover-radius, 0)) var(--bf-cover-radius-b, var(--bf-cover-radius, 0));
   /* Fill clips to the rounded box (hidden); Fit goes visible so the ambient glow can bleed past. */
   overflow: var(--bf-cover-overflow, hidden);
   isolation: isolate; /* own stacking context so glow (z0) sits under the image (z1) */


### PR DESCRIPTION
- Popup cover is a compact 134px banner with no bottom fade/blur dissolve and no ambient glow (Figma 26889-14091) — those belong to the full-page cover. Cover vars ride POPUP_FORM_STYLE_VARS so preview + live match.
- Popup frame + cover top corners follow the Cover-radius customization (--bf-cover-radius), while the cover bottom stays flush over the fields (new --bf-cover-radius-b bottom-only override; full-page covers keep the old all-corner radius). Live host frame radius is posted to popup.js via Reform.FormLoaded so the embed frame matches the cover.
- Dark overlay is black 24% + 6px backdrop blur (Figma 27196-14471) across the live overlay, the editor preview, and the Share-panel mockup.