### PR TITLE
Form rendering fixes: footer branding, buttons, borderless embed, popup Figma match

### DIFF
--- a/src/components/form-builder/embed-preview-mockup.tsx
+++ b/src/components/form-builder/embed-preview-mockup.tsx
@@ -316,7 +316,8 @@ export const EmbedPreviewMockup = ({
           {isPopup && darkOverlay && isPopupExpanded && (
             <motion.div
               key="dark-overlay"
-              className="absolute inset-0 z-10 bg-black/30"
+              // Match the real popup dark overlay (Figma 27196-14471): black 24% + backdrop blur.
+              className="absolute inset-0 z-10 bg-black/24 backdrop-blur-[6px]"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}

--- a/src/components/form-components/form-preview-rsc.tsx
+++ b/src/components/form-components/form-preview-rsc.tsx
@@ -133,18 +133,23 @@ const StepButton = ({
   grouped?: boolean;
   totalSteps?: number;
 }) => {
+  const { t } = useTranslation();
   const buttonStyle = { fontSize: "13px" } as const;
 
   if (buttonRole === "previous") {
     const button = (
+      // Ghost + dark text (Figma 27112-20305 "Back") — never a filled primary, which would clash
+      // with the themed Submit/Next.
       <Button
         type="button"
+        variant="ghost-flat"
         onClick={onPrevious}
         style={buttonStyle}
-        className="h-8 gap-1.5 rounded-lg px-2.5"
+        className="h-8 gap-1.5 rounded-lg px-2.5 text-gray-900"
         prefix={<ChevronLeftIcon className="size-4" />}
       >
-        {buttonText}
+        {/* Always "Back" (like the one-at-a-time footer) — ignore any authored/legacy "Previous" text. */}
+        {t("back")}
       </Button>
     );
     return grouped ? (
@@ -180,10 +185,12 @@ const StepButton = ({
   // Submit
   const isMultiStep = totalSteps > 1;
   const submitButton = (
+    // Trailing chevron matches the Next button (Figma "→") and keeps the last glyph from clipping.
     <Button
       type="submit"
       style={buttonStyle}
       className="h-8 gap-1.5 rounded-lg px-2.5"
+      suffix={<ChevronRightIcon className="size-4" />}
       disabled={isSubmitting}
     >
       {buttonText}
@@ -383,35 +390,37 @@ const StepFormRSC = ({
           : action?.buttonText || actionDefaultText;
 
       return (
+        // Prev + Next/Submit grouped left (8px gap), branding pushed right (Figma 27112-20305).
         <div
-          className="flex w-full flex-row-reverse items-center justify-between"
+          className="flex w-full items-center justify-between gap-3"
           style={{ maxWidth: "var(--bf-input-width)" }}
         >
-          {action && !(hideSubmit && actionRole === "submit") && (
-            <StepButton
-              buttonText={actionText}
-              buttonRole={actionRole}
-              isSubmitting={isSubmitting}
-              onPrevious={canGoBack ? goToPrevStep : undefined}
-              grouped
-              totalSteps={totalSteps}
-            />
-          )}
-          {prev ? (
-            <StepButton
-              buttonText={prev.buttonText || t("previous")}
-              buttonRole="previous"
-              isSubmitting={isSubmitting}
-              onPrevious={canGoBack ? goToPrevStep : undefined}
-              grouped
-            />
-          ) : (
-            <div />
-          )}
+          <div className="flex items-center gap-2">
+            {prev && (
+              <StepButton
+                buttonText={prev.buttonText || t("previous")}
+                buttonRole="previous"
+                isSubmitting={isSubmitting}
+                onPrevious={canGoBack ? goToPrevStep : undefined}
+                grouped
+              />
+            )}
+            {action && !(hideSubmit && actionRole === "submit") && (
+              <StepButton
+                buttonText={actionText}
+                buttonRole={actionRole}
+                isSubmitting={isSubmitting}
+                onPrevious={canGoBack ? goToPrevStep : undefined}
+                grouped
+                totalSteps={totalSteps}
+              />
+            )}
+          </div>
+          {branding && <FormBrandingBadge />}
         </div>
       );
     },
-    [t, isSubmitting, canGoBack, goToPrevStep, totalSteps, hideSubmit],
+    [t, isSubmitting, canGoBack, goToPrevStep, totalSteps, hideSubmit, branding],
   );
 
   return (

--- a/src/components/form-components/step-form.tsx
+++ b/src/components/form-components/step-form.tsx
@@ -70,8 +70,9 @@ export const StepForm = ({
   });
 
   const groupedItems = useMemo(() => groupSegmentsForRendering(segments), [segments]);
-  // Branding only rides the final Submit row (last step).
-  const showBranding = branding && isLastStep;
+  // Branding rides EVERY step's action row (Next and Submit), not just the final Submit — so
+  // multi-step card forms show "Made with Reform." throughout, matching one-at-a-time (Figma 27112-20324).
+  const showBranding = branding;
 
   const formRef = useRef<HTMLFormElement>(null);
   const [isTextareaFocused, setIsTextareaFocused] = useState(false);
@@ -181,12 +182,21 @@ export const StepForm = ({
             const groupKey = `button-group-${item.buttons.map((b) => b.id).join("-")}`;
 
             return (
+              // Prev + Next/Submit grouped left (8px gap), branding pushed right (Figma 27112-20305).
               <div
                 key={groupKey}
-                className="flex w-full flex-col gap-2"
+                className="flex w-full items-center justify-between gap-3"
                 style={{ maxWidth: "var(--bf-input-width)" }}
               >
-                <div className="flex w-full flex-row-reverse items-center justify-between">
+                <div className="flex items-center gap-2">
+                  {prevButton && (
+                    <RenderStepButton
+                      field={prevButton}
+                      isSubmitting={isSubmitting}
+                      onPrevious={canGoBack ? goToPrevStep : undefined}
+                      grouped
+                    />
+                  )}
                   {actionButton && (
                     <RenderStepButton
                       field={actionButton}
@@ -196,23 +206,8 @@ export const StepForm = ({
                       grouped
                     />
                   )}
-                  {prevButton ? (
-                    <RenderStepButton
-                      field={prevButton}
-                      isSubmitting={isSubmitting}
-                      onPrevious={canGoBack ? goToPrevStep : undefined}
-                      grouped
-                    />
-                  ) : (
-                    <div /> // Spacer for justify-between
-                  )}
                 </div>
-                {/* Multi-step submit row is full (Prev + Submit) — branding sits right-aligned below. */}
-                {showBranding && (
-                  <div className="flex justify-end">
-                    <FormBrandingBadge />
-                  </div>
-                )}
+                {showBranding && <FormBrandingBadge />}
               </div>
             );
           }
@@ -451,14 +446,18 @@ const RenderStepButton = ({
 
   if (buttonRole === "previous") {
     const button = (
+      // Ghost + dark text (Figma 27112-20305 "Back") — never a filled primary, which would clash
+      // with the themed Submit/Next.
       <Button
         type="button"
+        variant="ghost-flat"
         onClick={onPrevious}
         style={buttonStyle}
-        className="h-8 gap-1.5 rounded-lg px-2.5"
+        className="h-8 gap-1.5 rounded-lg px-2.5 text-gray-900"
         prefix={<ChevronLeftIcon className="size-4" />}
       >
-        {buttonText}
+        {/* Always "Back" (like the one-at-a-time footer) — ignore any authored/legacy "Previous" text. */}
+        {t("back")}
       </Button>
     );
     return grouped ? (
@@ -485,32 +484,37 @@ const RenderStepButton = ({
     return grouped ? (
       button
     ) : (
+      // Branding rides the Next row right-aligned (justify-between) — same as the Submit row — so
+      // intermediate steps of a multi-step card form stay branded. Without branding, honor
+      // --bf-button-justify (Buttons → Alignment), fallback right.
       <div
-        className="mb-4 flex"
+        className={`mb-4 flex items-center ${showBranding ? "justify-between gap-3" : ""}`}
         style={{
           maxWidth: "var(--bf-input-width)",
-          // Button alignment (Buttons → Alignment); fallback keeps the prior right-aligned default.
-          justifyContent: "var(--bf-button-justify, flex-end)",
+          ...(showBranding ? {} : { justifyContent: "var(--bf-button-justify, flex-end)" }),
         }}
       >
         {button}
+        {showBranding && <FormBrandingBadge />}
       </div>
     );
   }
 
   const isMultiStep = totalSteps > 1;
   const submitButton = (
+    // Trailing chevron matches the Next button (Figma "→"); it also gives the TextSwap span trailing
+    // room so `.bf-themed` letter-spacing doesn't clip the last glyph ("Submit" → "Submi").
     <Button
       type="submit"
       data-bf-button
       style={buttonStyle}
       className="h-8 gap-1.5 rounded-lg px-2.5"
+      suffix={<ChevronRightIcon className="size-4" />}
       disabled={isSubmitting}
     >
-      {(() => {
-        const label = isSubmitting ? t("submitting") : buttonText;
-        return <TextSwap key={label}>{label}</TextSwap>;
-      })()}
+      {/* Render text directly (not TextSwap) — the inline-block+blur span clipped the last glyph
+          ("Submit" → "Submi"); the Next button and live renderer render text directly too. */}
+      {isSubmitting ? t("submitting") : buttonText}
     </Button>
   );
   return grouped ? (

--- a/src/components/ui/form-button-node.tsx
+++ b/src/components/ui/form-button-node.tsx
@@ -19,7 +19,7 @@ export interface FormButtonElementData {
 }
 
 export const createFormButtonNode = (role: ButtonRole, text?: string): FormButtonElementData => {
-  const defaultText = role === "next" ? "Next" : role === "previous" ? "Previous" : "Submit";
+  const defaultText = role === "next" ? "Next" : role === "previous" ? "Back" : "Submit";
   return {
     type: "formButton",
     buttonRole: role,
@@ -33,7 +33,7 @@ const getPlaceholderForRole = (role: ButtonRole): string => {
     case "next":
       return "Next";
     case "previous":
-      return "Previous";
+      return "Back";
     case "submit":
       return "Submit";
     default:
@@ -59,9 +59,12 @@ export const FormButtonElement = ({ children, ...props }: PlateElementProps) => 
   );
 
   // Get label from element property (fallback to children for backwards compat)
-  const label =
+  const rawLabel =
     (element.label as string) ??
     extractTextFromChildren(element.children as Array<{ text?: string }>);
+  // Back button is a fixed nav affordance — surface "Back" for legacy "Previous"/empty labels so the
+  // editor matches the preview/live (which always render "Back").
+  const label = isPrevious && (!rawLabel || rawLabel === "Previous") ? "Back" : rawLabel;
 
   // Inline-editable label: a native input (Slate ignores it — parent is contentEditable=false)
   // edits element.label directly, the same property the transform reads first. Local state controls
@@ -178,6 +181,10 @@ export const FormButtonElement = ({ children, ...props }: PlateElementProps) => 
             onPointerDown={stopPointer}
             onClick={stopPointer}
             aria-label="Button label"
+            // letterSpacing:normal — the .bf-themed `* { letter-spacing }` makes field-sizing-content
+            // undersize by ~1px, clipping the last glyph ("Submit" → "Submi"). Inline wins over the
+            // unlayered global rule.
+            style={{ letterSpacing: "normal" }}
             className="field-sizing-content min-w-[2ch] cursor-text bg-transparent text-center text-inherit outline-none placeholder:text-current/60"
           />
           {buttonRole === "submit" && <CheckIcon className="size-4" />}

--- a/src/embed/embed-popup.ts
+++ b/src/embed/embed-popup.ts
@@ -163,6 +163,13 @@ const handleMessage = (event: MessageEvent): void => {
       if (instance.loadingEl) {
         hideLoading(instance.loadingEl);
       }
+      // Match the popup frame radius to the form's cover radius (else the fixed 12px frame corners
+      // clip a larger cover radius, leaving a sliver).
+      if (data.frameRadius) {
+        instance.container.style.borderRadius = data.frameRadius;
+        const iframeContainer = instance.iframe.parentElement;
+        if (iframeContainer) iframeContainer.style.borderRadius = data.frameRadius;
+      }
       break;
 
     case "Reform.Resize":

--- a/src/embed/lib/styles.ts
+++ b/src/embed/lib/styles.ts
@@ -42,7 +42,10 @@ const STYLES = `
   position: fixed;
   inset: 0;
   z-index: 2147483000;
-  background-color: rgba(0, 0, 0, 0.5);
+  /* Dark overlay (Figma 27196-14471): black 24% + 6px backdrop blur. */
+  background-color: rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/embed/lib/types.ts
+++ b/src/embed/lib/types.ts
@@ -61,7 +61,8 @@ export interface PopupInstance {
 
 /** Events sent from iframe to parent */
 export type IframeEvent =
-  | { event: "Reform.FormLoaded"; formId: string }
+  // frameRadius: the form's popup cover radius (--bf-cover-radius) so the host-page frame matches it.
+  | { event: "Reform.FormLoaded"; formId: string; frameRadius?: string }
   | { event: "Reform.Resize"; height: number }
   | {
       event: "Reform.FormSubmitted";

--- a/src/lib/editor/transform-plate-for-preview.ts
+++ b/src/lib/editor/transform-plate-for-preview.ts
@@ -350,8 +350,7 @@ const createSegments = (nodes: Value): PreviewSegment[] => {
       const btnText =
         (node.label as string | undefined) || childText || (node.buttonText as string | undefined);
       const btnRole = (node.buttonRole as "next" | "previous" | "submit") || "submit";
-      const defaultText =
-        btnRole === "next" ? "Next" : btnRole === "previous" ? "Previous" : "Submit";
+      const defaultText = btnRole === "next" ? "Next" : btnRole === "previous" ? "Back" : "Submit";
       const name = `button_${fieldIndex}`;
 
       segments.push({

--- a/src/lib/editor/transform-plate-to-form.ts
+++ b/src/lib/editor/transform-plate-to-form.ts
@@ -747,8 +747,7 @@ export const transformPlateStateToFormElements = (rawValue: Value): TransformedE
       const btnText =
         (node.label as string | undefined) || childText || (node.buttonText as string | undefined);
       const btnRole = (node.buttonRole as "next" | "previous" | "submit") || "submit";
-      const defaultText =
-        btnRole === "next" ? "Next" : btnRole === "previous" ? "Previous" : "Submit";
+      const defaultText = btnRole === "next" ? "Next" : btnRole === "previous" ? "Back" : "Submit";
       const name = `button_${fieldIndex}`;
       elements.push({
         id: name,

--- a/src/lib/popup-style.ts
+++ b/src/lib/popup-style.ts
@@ -11,6 +11,14 @@ export const POPUP_FORM_STYLE_VARS = {
   "--bf-cover-w": "100%",
   "--bf-cover-mx": "0px",
   "--bf-cover-x": "0%",
+  // Popup cover is a compact, clipped banner (Figma 26889-14091): fixed 134px, no bottom
+  // fade/blur dissolve and no ambient glow (those belong to the full-page/embed cover).
+  "--bf-cover-height": "134px",
+  "--bf-cover-fade": "none",
+  "--bf-cover-glow": "none",
+  // Cover keeps its top radius (--bf-cover-radius, matching the popup frame) but its BOTTOM corners
+  // are flush against the form body — otherwise a full cover radius notches over the fields.
+  "--bf-cover-radius-b": "0px",
   "--bf-title-font-size": "24px",
   "--bf-title-letter-spacing": "-0.72px",
 } as CSSProperties;

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
@@ -432,7 +432,8 @@ const PopupPreviewOverlay = ({
       {darkOverlay && isPopupOpen && (
         <button
           type="button"
-          className="pointer-events-auto absolute inset-0 z-10 size-full cursor-default border-none bg-black/36 backdrop-blur-sm transition-opacity duration-300"
+          // Dark overlay (Figma 27196-14471): black 24% + 6px backdrop blur.
+          className="pointer-events-auto absolute inset-0 z-10 size-full cursor-default border-none bg-black/24 backdrop-blur-[6px] transition-opacity duration-300"
           onClick={handleClosePopup}
           aria-label="Close preview"
         />
@@ -441,8 +442,9 @@ const PopupPreviewOverlay = ({
       {isPopupOpen && (
         <div
           ref={setPopupEl}
-          // Figma 26889:14685 — 20px radius, elevation/light/xl shadow, no border.
-          className="pointer-events-auto absolute z-20 flex flex-col overflow-hidden rounded-[20px] bg-background shadow-[0px_0px_1px_0px_rgba(0,0,0,0.2),0px_0px_10px_2px_rgba(0,0,0,0.04),0px_24px_30px_-8px_rgba(0,0,0,0.1)] transition-[top,left,transform] duration-300 ease-out"
+          // Frame radius follows the Cover-radius customization (--bf-cover-radius) so top + bottom
+          // match the cover; 20px fallback for unthemed forms (Figma 26889:14685).
+          className="pointer-events-auto absolute z-20 flex flex-col overflow-hidden rounded-[var(--bf-cover-radius,20px)] bg-background shadow-[0px_0px_1px_0px_rgba(0,0,0,0.2),0px_0px_10px_2px_rgba(0,0,0,0.04),0px_24px_30px_-8px_rgba(0,0,0,0.1)] transition-[top,left,transform] duration-300 ease-out"
           style={{
             width: popupWidth,
             ...(popupPosition === "center"

--- a/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
+++ b/src/routes/_authenticated/workspace/$workspaceId/form-builder/-components/preview-mode.tsx
@@ -267,11 +267,11 @@ const EmbedPreviewSurface = ({
                 <div
                   ref={setEmbedFrame}
                   className={cn(
-                    "w-full overflow-hidden rounded-2xl transition-all duration-200",
+                    // No card frame (border/radius/shadow) — the real embed iframe is frameborder=0,
+                    // so the preview must match live: borderless form on the host page (Figma 25724-11834).
+                    "w-full overflow-hidden transition-all duration-200",
                     dynamicWidth ? "" : "max-w-[460px]",
-                    transparentBackground
-                      ? "bg-transparent"
-                      : "border border-border bg-background shadow-sm",
+                    transparentBackground ? "bg-transparent" : "bg-background",
                   )}
                   style={{
                     height: dynamicHeight ? "auto" : height,

--- a/src/routes/forms/-components/public-form-page.tsx
+++ b/src/routes/forms/-components/public-form-page.tsx
@@ -225,7 +225,14 @@ const useIframeResizeNotifier = (
     if ((!isPopup && !dynamicHeight) || typeof window === "undefined" || window.parent === window)
       return;
 
-    sendToParent("Reform.FormLoaded", { formId });
+    // Tell the host-page popup frame (popup.js) to match the form's cover radius so its rounded
+    // corners line up with the cover instead of a fixed default.
+    const frameRadius =
+      isPopup && containerRef.current
+        ? getComputedStyle(containerRef.current).getPropertyValue("--bf-cover-radius").trim() ||
+          undefined
+        : undefined;
+    sendToParent("Reform.FormLoaded", { formId, frameRadius });
 
     let lastHeight = 0;
     let resizeTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -887,8 +887,11 @@
 
 .bf-themed [data-bf-cover] {
   height: var(--bf-cover-height);
-  /* unset = current square cover; overflow clips img once a radius is set */
-  border-radius: var(--bf-cover-radius, 0);
+  /* unset = current square cover; overflow clips img once a radius is set. Bottom corners default
+     to the cover radius, but the popup zeroes them (--bf-cover-radius-b: 0) so the popup cover's
+     bottom stays flush over the fields while its top still follows the cover radius. */
+  border-radius: var(--bf-cover-radius, 0) var(--bf-cover-radius, 0)
+    var(--bf-cover-radius-b, var(--bf-cover-radius, 0)) var(--bf-cover-radius-b, var(--bf-cover-radius, 0));
   /* Fill clips to the rounded box (hidden); Fit goes visible so the ambient glow can bleed past. */
   overflow: var(--bf-cover-overflow, hidden);
   isolation: isolate; /* own stacking context so glow (z0) sits under the image (z1) */


### PR DESCRIPTION
Promotes `dev` → `main`. Form-rendering fixes across the **editor, in-app preview, and live/published** surfaces, matching the system-flat Figma.

## Borderless standard embed
The editor's standard-embed preview wrapped the form in a rounded border+shadow card, but the real embed iframe is `frameborder=0` and the live form has no such frame (Figma 25724-11834). Now borderless, matching live.

## Multi-step card footer + buttons
- **Branding on every card step** (not just the final Submit), matching one-at-a-time (Figma 27112-20305/20324).
- **Grouped footer**: Prev + Next/Submit on the left, branding pushed right.
- **Back button**: ghost + dark text, always labelled "Back"; legacy "Previous" surfaces as "Back" in the editor.
- **Submit**: trailing chevron; fixed the editor label input clipping the last glyph (`letter-spacing: normal` on the field-sizing input).

## Popup Figma match
- **Cover**: compact 134px banner, no bottom fade/blur, no ambient glow (Figma 26889-14091).
- **Radius**: popup frame + cover top follow the Cover-radius customization (`--bf-cover-radius`); cover bottom flush over the fields (`--bf-cover-radius-b`; full-page covers unchanged). Live host frame radius posted to `popup.js` via `Reform.FormLoaded`.
- **Dark overlay**: black 24% + 6px backdrop blur (Figma 27196-14471) across live overlay, editor preview, and the Share-panel mockup.

## Verification
- `tsc`, `oxfmt`, `lint`, `knip`, `test` all pass.
- Preview + editor surfaces verified live (computed styles + screenshots vs Figma).
- **Live caveat**: embed-bundle changes (`popup.js` frame-radius messaging, `.bf-overlay` blur) need the embed script rebuilt + tested on a real host page; failures degrade gracefully.

Squashes PRs #124 + #125 (both already merged into `dev`).